### PR TITLE
remove rack controller ncurses dialog

### DIFF
--- a/src/en/installconfig-package-install.md
+++ b/src/en/installconfig-package-install.md
@@ -56,11 +56,3 @@ As described above, to put everything on one machine:
 ```bash
 sudo apt install maas
 ```
-
-The below dialog will appear:
-
-![image](./media/install_cluster-config.png)
-
-Enter the IP address of the region controller. In some cases, the machine
-running the region controller (i.e. the web and API interface) may have several
-network interfaces. Choose the address according to your design.


### PR DESCRIPTION
This ncurses dialog is for adding a rack/cluster controller in 1.9. It certainly is not for seen when installing MAAS via the 'maas' metapackage. For completeness, when a rack controller *is* added in 2.0 the dialog is not ncurses-based.