### PR TITLE
Make links to media consistent

### DIFF
--- a/src/en/configure.md
+++ b/src/en/configure.md
@@ -84,7 +84,7 @@ manually, or on the node page when the node has been automatically
 discovered but before it is accepted, there is a drop down menu to
 select the version of Ubuntu you wish to install.
 
-![](../images/series.png)
+![](./media/series.png)
 
 The menu will always list all the currently available series according
 to which boot images are available.
@@ -202,7 +202,7 @@ standard install of the MAAS region controller includes a cluster
 controller, but it is possible to add additional cluster controllers to
 the configuration, as shown in the diagram below:
 
-![](../images/orientation_architecture-diagram.png)
+![](./media/orientation_architecture-diagram.png)
 
 Each cluster controller will need to run on a separate Ubuntu server.
 Installing and configuring the software is straightforward though:
@@ -229,7 +229,7 @@ configure the software:
 dpkg-reconfigure maas-cluster-controller
 ```
 
-![](../images/cluster-config.png)
+![](./media/cluster-config.png)
 
 The configuration script should then bring up a screen where you can
 enter the IP address of the region controller. Additionally, you will

--- a/src/en/configure.md
+++ b/src/en/configure.md
@@ -84,7 +84,7 @@ manually, or on the node page when the node has been automatically
 discovered but before it is accepted, there is a drop down menu to
 select the version of Ubuntu you wish to install.
 
-![](./media/series.png)
+![Selecting the release series](./media/series.png)
 
 The menu will always list all the currently available series according
 to which boot images are available.
@@ -202,12 +202,12 @@ standard install of the MAAS region controller includes a cluster
 controller, but it is possible to add additional cluster controllers to
 the configuration, as shown in the diagram below:
 
-![](./media/orientation_architecture-diagram.png)
+![Additional cluster controllers diagram](./media/orientation_architecture-diagram.png)
 
 Each cluster controller will need to run on a separate Ubuntu server.
 Installing and configuring the software is straightforward though:
 
-```bash 
+```bash
 sudo apt-get install maas-cluster-controller
 ```
 
@@ -229,7 +229,7 @@ configure the software:
 dpkg-reconfigure maas-cluster-controller
 ```
 
-![](./media/cluster-config.png)
+![maas-cluster-controller configuration prompt](./media/cluster-config.png)
 
 The configuration script should then bring up a screen where you can
 enter the IP address of the region controller. Additionally, you will
@@ -267,5 +267,3 @@ host running the MAAS DNS server.
 
 However, for hosts using the `resolvconf` package,
 please read its documentation for more information.
-
-

--- a/src/en/installing-ubuntu.md
+++ b/src/en/installing-ubuntu.md
@@ -34,7 +34,7 @@ that’s been configured to use the fast installer, visit the node’s page
 as an administrator and click the `Use the Debian installer`{.docutils
 .literal} button.
 
-![](../media/node-page-use-default-installer.png)
+![A node with the default installer option](./media/node-page-use-default-installer.png)
 
 To set multiple nodes to use the Debian installer, select the
 `Mark nodes as using the Debian installer` option
@@ -53,7 +53,7 @@ installer](#debian-installer).
 
 The fast installer is enabled by default for newly enlisted nodes.
 
-![](../media/node-page-use-fast-installer.png)
+![A node with the fast installer option](./media/node-page-use-fast-installer.png)
 
 To set multiple nodes to use the fast installer, select the
 `Mark nodes as using the fast installer` option from


### PR DESCRIPTION
- Point to media using the same `./media` standard used throughout the rest of the documentation
- Add alt tags to images