### PR TITLE
Add `site_title` and `logo_url` to context

### DIFF
--- a/context.yaml
+++ b/context.yaml
@@ -1,3 +1,6 @@
+site_title: MAAS documentation
+logo_path: /static/media/maas-logo.svg
+
 navigation:
   - title: Introduction
 


### PR DESCRIPTION
So that these variables can be used in a generic template, to satisfy: https://github.com/ubuntudesign/docs.ubuntu.com/issues/3