### PR TITLE
Update the 2.1 branch with a link to legacy docs

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -160,6 +160,9 @@ navigation:
   - title: API documentation
     location: http://docs.maas.io/2.0/api.html
 
+  - title: MAAS 1.9 docs
+    location: /maas/1.9/en/
+
   - title: Help improve these docs
     location: contributing.md
 


### PR DESCRIPTION
Add a link to the navigation to link to MAAS 1.9 documentation.