### PR TITLE
Fix common cli task snippet to determine system ID

### DIFF
--- a/en/manage-cli-common.md
+++ b/en/manage-cli-common.md
@@ -31,7 +31,7 @@ To determine the system ID based on a node's hostname:
 
 ```bash
 SYSTEM_ID=$(maas $PROFILE nodes read hostname=$HOSTNAME \
-	| grep system_id | cut -d '"' -f 4)
+	| grep system_id -m 1 | cut -d '"' -f 4)
 ```
 
 


### PR DESCRIPTION
Fixes #248 

Adds max count flag to grep part of the cli snippet to make sure we only return 1 system ID if found.