### PR TITLE
Add note to PostgreSQL HA section that the max_connections need to be adjusted based on the number of region controllers.

### DIFF
--- a/en/manage-ha.md
+++ b/en/manage-ha.md
@@ -76,13 +76,20 @@ here for convenience only. Its purpose is to give an idea of what's involved at
 the command line level when implementing one particular form of HA with
 PostgreSQL.
 
+!!! Note:
+    Each region controller uses up to 40 connections to PostgreSQL in high load
+    situations. Running 2 region controllers requires no modifications to the
+    `max_connections` in `postgresql.conf`. More than 2 region controllers
+    requires that `max_connections` be adjusted to add 40 more connections per
+    extra region controller added to the HA configuration.
+
 ### Secondary API server
 
 This section assumes that PostgreSQL HA has been set up.
 
-!!! Note: 
+!!! Note:
     Any number of API servers can be present as long as each connects to
-    the same PostgreSQL database.
+    the same PostgreSQL database and allows the required number of connections.
 
 On the primary database host, edit file `/etc/postgresql/9.5/main/pg_hba.conf`
 to allow the eventual secondary API server to contact the primary PostgreSQL
@@ -93,7 +100,7 @@ IP address of the host that will contain the secondary API server:
 host    maasdb          maas	$SECONDARY_API_SERVER_IP/32         md5
 ```
 
-!!! Note: 
+!!! Note:
     It is very common for the primary database server and the primary API
     server to reside on the same host.
 
@@ -193,7 +200,7 @@ load upon reboot and pass a kernel option:
 sudo apt install keepalived
 sudo modprobe ip_vs
 echo 'ip_vs' | sudo tee -a /etc/modules
-echo 'net.ipv4.ip_nonlocal_bind=1' | sudo tee /etc/sysctl.d/60-keepalived-nonlocal.conf 
+echo 'net.ipv4.ip_nonlocal_bind=1' | sudo tee /etc/sysctl.d/60-keepalived-nonlocal.conf
 sudo systemctl restart procps
 ```
 
@@ -264,7 +271,7 @@ Restart the daemon to have these changes take effect:
 sudo systemctl restart keepalived
 ```
 
-!!! Note: 
+!!! Note:
     If this is being done inside a container, its host needs the ip\_vs
     module loaded and the sysctl change. A restart of the container will then be
     required.
@@ -272,7 +279,7 @@ sudo systemctl restart keepalived
 Finally, for all API servers, replace the original IP address in the MAAS URL
 with that of the VIP. Then inform all rack controllers of that change.
 
-To adjust an API server: 
+To adjust an API server:
 
 ```bash
 sudo maas-region local_config_set --maas-url http://$VIP/MAAS


### PR DESCRIPTION
This came about after doing some testing of MAAS in HA configurations. When more then 2 region controllers are present in the HA then `max_connections` must be adjusted or MAAS will fall over.

I targeted this to master branch, but it also applies to 2.2.