### PR TITLE
Remove top level link to 1.9 docs

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -189,9 +189,6 @@ navigation:
   - title: API documentation
     location: api.md
 
-  - title: MAAS 1.9 docs
-    location: /maas/1.9/en/
-
   - title: Help improve these docs
     location: contributing-writing.md
 


### PR DESCRIPTION
- 1.9 docs are now properly versioned and accessible form the version number link.