### PR TITLE
Moved release notes link in menu

### DIFF
--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -201,7 +201,7 @@ navigation:
       - title: Getting help
         location: troubleshoot-getting-help.md
 
- - title: API documentation
+  - title: API documentation
     location: api.md
 
     children:

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -201,10 +201,7 @@ navigation:
       - title: Getting help
         location: troubleshoot-getting-help.md
 
-  - title: Release notes
-    location: release-notes.md
-
-  - title: API documentation
+ - title: API documentation
     location: api.md
 
     children:
@@ -215,6 +212,9 @@ navigation:
       - title: API authentication
         location: api-authentication.md
 
+  - title: Release notes
+    location: release-notes.md
+ 
   - title: Help improve these docs
     location: contributing-writing.md
 


### PR DESCRIPTION
fixes #738 

- small fix to move *Release notes* one notch down in the main main, for formatting and consistency. 