### PR TITLE
API doc update

### DIFF
--- a/en/api.md
+++ b/en/api.md
@@ -24,14 +24,14 @@ error message and the api version are returned as plaintext.
 ## HTTP methods and parameter-passing
 
 The following HTTP methods are available for accessing the API:
-    -   GET (for information retrieval and queries),
-    -   POST (for asking the system to do things),
-    -   PUT (for updating objects), and
-    -   DELETE (for deleting objects).
+   -   GET (for information retrieval and queries),
+   -   POST (for asking the system to do things),
+   -   PUT (for updating objects), and
+   -   DELETE (for deleting objects).
 
 All methods except DELETE may take parameters, but they are not all passed in
-the same way. GET parameters are passed in the URL, as is normal with a
-GET: "/item/?foo=bar" passes parameter "foo" with value "bar".
+the same way. GET parameters are passed in the URL, as is normal with a GET:
+"/item/?foo=bar" passes parameter "foo" with value "bar".
 
 POST and PUT are different. Your request should have MIME type
 "multipart/form-data"; each part represents one parameter (for POST) or
@@ -58,56 +58,56 @@ Manage the current logged-in user.
 
 List authorisation tokens available to the currently logged-in user.
 
-:return`
+- `return`
    list of dictionaries representing each key's name and token.
 
 ##### `POST /api/2.0/account/ op=create_authorisation_token`
 
 Create an authorisation OAuth token and OAuth consumer.
 
-:param name`
+- `param name`
    Optional name of the token that will be generated.
 
-:type name`
+- `type name`
    unicode
 
-:return`
+- `return`
    a json dict with four keys: 'token_key',
-       'token_secret', 'consumer_key' and 'name'(e.g. {token_key:
-        's65244576fgqs', token_secret:
+   'token_secret', 'consumer_key' and 'name'(e.g. {token_key:
+   's65244576fgqs', token_secret:
 
-    'qsdfdhv34',
-       consumer_key: '68543fhj854fg', name`
+   'qsdfdhv34',
+   consumer_key: '68543fhj854fg', name:
 
-    'MAAS consumer'}).
+   'MAAS consumer'}).
 
-:rtype`
+- `rtype`
    string (json)
 
 ##### `POST /api/2.0/account/ op=delete_authorisation_token`
 
 Delete an authorisation OAuth token and the related OAuth consumer.
 
-:param token_key`
+- `param token_key`
    The key of the token to be deleted.
 
-:type token_key`
+- `type token_key`
    unicode
 
 ##### `POST /api/2.0/account/ op=update_token_name`
 
 Modify the consumer name of an authorisation OAuth token.
 
-:param token`
+- `param token`
    Can be the whole token or only the token key.
 
-:type token`
+- `type token`
    unicode
 
-:param name`
+- `param name`
    New name of the token.
 
-:type name`
+- `type name`
    unicode
 
 ### Bcache Cache Set
@@ -131,10 +131,10 @@ Returns 404 if the machine or cache set is not found.
 
 Delete bcache on a machine.
 
-:param cache_device`
+- `param cache_device`
    Cache block device to replace current one.
 
-:param cache_partition`
+- `param cache_partition`
    Cache partition to replace current one.
 
 Specifying both a cache_device and a cache_partition is not allowed.
@@ -156,10 +156,10 @@ Returns 404 if the machine is not found.
 
 Creates a Bcache Cache Set.
 
-:param cache_device`
+- `param cache_device`
    Cache block device.
 
-:param cache_partition`
+- `param cache_partition`
    Cache partition.
 
 Specifying both a cache_device and a cache_partition is not allowed.
@@ -188,22 +188,22 @@ Returns 404 if the machine or bcache is not found.
 
 Delete bcache on a machine.
 
-:param name`
+- `param name`
    Name of the Bcache.
 
-:param uuid`
+- `param uuid`
    UUID of the Bcache.
 
-:param cache_set`
+- `param cache_set`
    Cache set to replace current one.
 
-:param backing_device`
+- `param backing_device`
    Backing block device to replace current one.
 
-:param backing_partition`
+- `param backing_partition`
    Backing partition to replace current one.
 
-:param cache_mode`
+- `param cache_mode`
    Cache mode (writeback, writethrough, writearound).
 
 Specifying both a device and a partition for a given role (cache or backing)
@@ -226,22 +226,22 @@ Returns 404 if the machine is not found.
 
 Creates a Bcache.
 
-:param name`
+- `param name`
    Name of the Bcache.
 
-:param uuid`
+- `param uuid`
    UUID of the Bcache.
 
-:param cache_set`
+- `param cache_set`
    Cache set.
 
-:param backing_device`
+- `param backing_device`
    Backing block device.
 
-:param backing_partition`
+- `param backing_partition`
    Backing partition.
 
-:param cache_mode`
+- `param cache_mode`
    Cache mode (WRITEBACK, WRITETHROUGH, WRITEAROUND).
 
 Specifying both a device and a partition for a given role (cache or backing)
@@ -272,7 +272,7 @@ Returns 404 if the machine or block device is not found.
 
 Add a tag to block device on a machine.
 
-:param tag`
+- `param tag`
    The tag being added.
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -283,10 +283,10 @@ not Ready.
 
 Format block device with filesystem.
 
-:param fstype`
+- `param fstype`
    Type of filesystem.
 
-:param uuid`
+- `param uuid`
    UUID of the filesystem.
 
 Returns 403 when the user doesn't have the ability to format the block device.
@@ -297,10 +297,10 @@ machine is not Ready or Allocated.
 
 Mount the filesystem on block device.
 
-:param mount_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-:param mount_options`
+- `param mount_options`
    Options to pass to mount(8).
 
 Returns 403 when the user doesn't have the ability to mount the block device.
@@ -311,7 +311,7 @@ machine is not Ready or Allocated.
 
 Remove a tag from block device on a machine.
 
-:param tag`
+- `param tag`
    The tag being removed.
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -356,35 +356,35 @@ replaced while the machine remains deployed.
 
 Fields for physical block device:
 
-:param name`
+- `param name`
    Name of the block device.
 
-:param model`
+- `param model`
    Model of the block device.
 
-:param serial`
+- `param serial`
    Serial number of the block device.
 
-:param id_path`
+- `param id_path`
    (optional) Only used if model and serial cannot be provided. This should
-    be a path that is fixed and doesn't change depending on the boot order or
-    kernel version.
+   be a path that is fixed and doesn't change depending on the boot order or
+   kernel version.
 
-:param size`
+- `param size`
    Size of the block device.
 
-:param block_size`
+- `param block_size`
    Block size of the block device.
 
 Fields for virtual block device:
 
-:param name`
+- `param name`
    Name of the block device.
 
-:param uuid`
+- `param uuid`
    UUID of the block device.
 
-:param size`
+- `param size`
    Size of the block device. (Only allowed for logical volumes.)
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -405,24 +405,24 @@ Returns 404 if the machine is not found.
 
 Create a physical block device.
 
-:param name`
+- `param name`
    Name of the block device.
 
-:param model`
+- `param model`
    Model of the block device.
 
-:param serial`
+- `param serial`
    Serial number of the block device.
 
-:param id_path`
+- `param id_path`
    (optional) Only used if model and serial cannot be
-       provided. This should be a path that is fixed and doesn't change
-        depending on the boot order or kernel version.
+   provided. This should be a path that is fixed and doesn't change
+   depending on the boot order or kernel version.
 
-:param size`
+- `param size`
    Size of the block device.
 
-:param block_size`
+- `param block_size`
    Block size of the block device.
 
 Returns 404 if the node is not found.
@@ -447,7 +447,7 @@ Manage the boot resources.
 
 List all boot resources.
 
-:param type`
+- `param type`
    Type of boot resources to list. Default: all
 
 ##### `GET /api/2.0/boot-resources/ op=is_importing`
@@ -458,23 +458,22 @@ Return import status.
 
 Uploads a new boot resource.
 
-:param name`
+- `param name`
    Name of the boot resource.
 
-:param title`
+- `param title`
    Title for the boot resource.
 
-:param architecture`
+- `param architecture`
    Architecture the boot resource supports.
 
-:param filetype`
+- `param filetype`
    Filetype for uploaded content. (Default: tgz,
-       Supported: tgz, ddtgz, ddtbz, ddtxz, ddtar, ddbz2, ddgz, ddxz,
-        ddraw
+   Supported: tgz, ddtgz, ddtbz, ddtxz, ddtar, ddbz2, ddgz, ddxz, ddraw
 
-:param content`
+- `param content`
    Image content. Note: this is not a normal parameter,
-       but a file upload.
+   but a file upload.
 
 ##### `POST /api/2.0/boot-resources/ op=import`
 
@@ -500,16 +499,16 @@ Read a boot source.
 
 Update a specific boot source.
 
-:param url`
+- `param url`
    The URL of the BootSource.
 
-:param keyring_filename`
+- `param keyring_filename`
    The path to the keyring file for this
-       BootSource.
+   BootSource.
 
-:param keyring_data`
+- `param keyring_data`
    The GPG keyring for this BootSource,
-       base64-encoded data.
+   base64-encoded data.
 
 ### Boot source selection
 
@@ -527,20 +526,20 @@ Read a boot source selection.
 
 Update a specific boot source selection.
 
-:param os`
+- `param os`
    The OS (e.g. ubuntu, centos) for which to import resources.
 
-:param release`
+- `param release`
    The release for which to import resources.
 
-:param arches`
+- `param arches`
    The list of architectures for which to import resources.
 
-:param subarches`
+- `param subarches`
    The list of subarchitectures for which to import
-       resources.
+   resources.
 
-:param labels`
+- `param labels`
    The list of labels for which to import resources.
 
 ### Boot source selections
@@ -557,20 +556,20 @@ Get a listing of a boot source's selections.
 
 Create a new boot source selection.
 
-:param os`
+- `param os`
    The OS (e.g. ubuntu, centos) for which to import resources.
 
-:param release`
+- `param release`
    The release for which to import resources.
 
-:param arches`
+- `param arches`
    The architecture list for which to import resources.
 
-:param subarches`
+- `param subarches`
    The subarchitecture list for which to import
-       resources.
+   resources.
 
-:param labels`
+- `param labels`
    The label lists for which to import resources.
 
 ### Boot sources
@@ -587,16 +586,16 @@ Get a listing of boot sources.
 
 Create a new boot source.
 
-:param url`
+- `param url`
    The URL of the BootSource.
 
-:param keyring_filename`
+- `param keyring_filename`
    The path to the keyring file for
-       this BootSource.
+   this BootSource.
 
-:param keyring_data`
+- `param keyring_data`
    The GPG keyring for this BootSource,
-       base64-encoded.
+   base64-encoded.
 
 ### Commissioning script
 
@@ -656,15 +655,15 @@ commissioning script might consist of a binary tool provided by a hardware
 vendor. Either way, the script gets passed to the commissioning machine in the
 exact form in which it was uploaded.
 
-:param name`
+- `param name`
    Unique identifying name for the script. Names should
-       follow the pattern of "25-burn-in-hard-disk" (all ASCII, and with
-        numbers greater than zero, and generally no "weird" characters).
+   follow the pattern of "25-burn-in-hard-disk" (all ASCII, and with
+   numbers greater than zero, and generally no "weird" characters).
 
-:param content`
+- `param content`
    A script file, to be uploaded in binary form. Note:
-       this is not a normal parameter, but a file upload. Its filename is
-        ignored; MAAS will know it by the name you pass to the request.
+   this is not a normal parameter, but a file upload. Its filename is
+   ignored; MAAS will know it by the name you pass to the request.
 
 ### DHCP Snippet
 
@@ -688,12 +687,12 @@ Returns 404 if the snippet is not found.
 
 Revert the value of a DHCP snippet to an earlier revision.
 
-:param to`
+- `param to`
    What revision in the DHCP snippet's history to revert to.
-       This can either be an ID or a negative number representing how far
-        back to go.
+   This can either be an ID or a negative number representing how far
+   back to go.
 
-:type to`
+- `type to`
    integer
 
 Returns 404 if the DHCP snippet is not found.
@@ -702,50 +701,50 @@ Returns 404 if the DHCP snippet is not found.
 
 Update a DHCP snippet.
 
-:param name`
+- `param name`
    The name of the DHCP snippet.
 
-:type name`
+- `type name`
    unicode
 
-:param value`
+- `param value`
    The new value of the DHCP snippet to be used in
-       dhcpd.conf. Previous values are stored and can be reverted.
+   dhcpd.conf. Previous values are stored and can be reverted.
 
-:type value`
+- `type value`
    unicode
 
-:param description`
+- `param description`
    A description of what the DHCP snippet does.
 
-:type description`
+- `type description`
    unicode
 
-:param enabled`
+- `param enabled`
    Whether or not the DHCP snippet is currently enabled.
 
-:type enabled`
+- `type enabled`
    boolean
 
-:param node`
+- `param node`
    The node the DHCP snippet is to be used for. Can not be
-       set if subnet is set.
+   set if subnet is set.
 
-:type node`
+- `type node`
    unicode
 
-:param subnet`
+- `param subnet`
    The subnet the DHCP snippet is to be used for. Can not
-       be set if node is set.
+   be set if node is set.
 
-:type subnet`
+- `type subnet`
    unicode
 
-:param global_snippet`
+- `param global_snippet`
    Set the DHCP snippet to be a global option. This
-       removes any node or subnet links.
+   removes any node or subnet links.
 
-:type global_snippet`
+- `type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -762,51 +761,51 @@ List all DHCP snippets.
 
 Create a DHCP snippet.
 
-:param name`
+- `param name`
    The name of the DHCP snippet. This is required to create
-       a new DHCP snippet.
+   a new DHCP snippet.
 
-:type name`
+- `type name`
    unicode
 
-:param value`
+- `param value`
    The snippet of config inserted into dhcpd.conf. This is
-       required to create a new DHCP snippet.
+   required to create a new DHCP snippet.
 
-:type value`
+- `type value`
    unicode
 
-:param description`
+- `param description`
    A description of what the snippet does.
 
-:type description`
+- `type description`
    unicode
 
-:param enabled`
+- `param enabled`
    Whether or not the snippet is currently enabled.
 
-:type enabled`
+- `type enabled`
    boolean
 
-:param node`
+- `param node`
    The node this snippet applies to. Cannot be used with
-       subnet or global_snippet.
+   subnet or global_snippet.
 
-:type node`
+- `type node`
    unicode
 
-:param subnet`
+- `param subnet`
    The subnet this snippet applies to. Cannot be used with
-       node or global_snippet.
+   node or global_snippet.
 
-:type subnet`
+- `type subnet`
    unicode
 
-:param global_snippet`
+- `param global_snippet`
    Whether or not this snippet is to be applied
-       globally. Cannot be used with node or subnet.
+   globally. Cannot be used with node or subnet.
 
-:type global_snippet`
+- `type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -832,10 +831,10 @@ Returns 404 if the dnsresource is not found.
 
 Update dnsresource.
 
-:param fqdn`
+- `param fqdn`
    Hostname (with domain) for the dnsresource.
 
-:param ip_address`
+- `param ip_address`
    Address to assign to the dnsresource.
 
 Returns 403 if the user does not have permission to update the dnsresource.
@@ -862,10 +861,10 @@ Returns 404 if the dnsresourcerecord is not found.
 
 Update dnsresourcerecord.
 
-:param rrtype`
+- `param rrtype`
    Resource Type
 
-:param rrdata`
+- `param rrdata`
    Resource Data (everything to the right of Type.)
 
 Returns 403 if the user does not have permission to update the
@@ -879,40 +878,40 @@ Manage DNS resource records (e.g. CNAME, MX, NS, SRV, TXT)
 
 List all dnsresourcerecords.
 
-:param domain`
+- `param domain`
    restrict the listing to entries for the domain.
 
-:param name`
+- `param name`
    restrict the listing to entries of the given name.
 
-:param rrtype`
+- `param rrtype`
    restrict the listing to entries which have
-       records of the given rrtype.
+   records of the given rrtype.
 
 ##### `POST /api/2.0/dnsresourcerecords/`
 
 Create a DNS resource record.
 
-:param fqdn`
+- `param fqdn`
    Hostname (with domain) for the dnsresource. Either fqdn
-       or (name, domain) must be specified. Fqdn is ignored if either name or
-        domain is given (e.g. www.your-maas.maas).
+   or (name, domain) must be specified. Fqdn is ignored if either name or
+   domain is given (e.g. www.your-maas.maas).
 
-:param name`
+- `param name`
    The name (or hostname without a domain) of the DNS
-       resource record (e.g. www.your-maas)
+   resource record (e.g. www.your-maas)
 
-:param domain`
+- `param domain`
    The domain (name or id) where to create the DNS
-       resource record (Domain (e.g. 'maas')
+   resource record (Domain (e.g. 'maas')
 
-:param rrtype`
+- `param rrtype`
    The resource record type (e.g 'cname', 'mx', 'ns',
-       'srv', 'sshfp', 'txt')
+   'srv', 'sshfp', 'txt')
 
-:param rrdata`
+- `param rrdata`
    The resource record data (e.g. 'your-maas',
-       '10 mail.your-maas.maas')
+   '10 mail.your-maas.maas')
 
 ### DNSResources
 
@@ -922,37 +921,37 @@ Manage dnsresources.
 
 List all resources for the specified criteria.
 
-:param domain`
+- `param domain`
    restrict the listing to entries for the domain.
 
-:param name`
+- `param name`
    restrict the listing to entries of the given name.
 
-:param rrtype`
+- `param rrtype`
    restrict the listing to entries which have
-       records of the given rrtype.
+   records of the given rrtype.
 
 ##### `POST /api/2.0/dnsresources/`
 
 Create a dnsresource.
 
-:param fqdn`
+- `param fqdn`
    Hostname (with domain) for the dnsresource. Either fqdn
-       or (name, domain) must be specified. Fqdn is ignored if either name or
-        domain is given.
+   or (name, domain) must be specified. Fqdn is ignored if either name or
+   domain is given.
 
-:param name`
+- `param name`
    Hostname (without domain)
 
-:param domain`
+- `param domain`
    Domain (name or id)
 
-:param address_ttl`
+- `param address_ttl`
    Default ttl for entries in this zone.
 
-:param ip_addresses`
+- `param ip_addresses`
    (optional) Address (ip or id) to assign to the
-       dnsresource.
+   dnsresource.
 
 ### Device
 
@@ -980,8 +979,8 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
-like "lldp" or "lshw".
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something like
+"lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
 mainly because JSON can't do binary content without applying additional
@@ -1034,31 +1033,31 @@ permission.
 
 Update a specific device.
 
-:param hostname`
+- `param hostname`
    The new hostname for this device.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param domain`
+- `param domain`
    The domain for this device.
 
-:type domain`
+- `type domain`
    unicode
 
-:param parent`
+- `param parent`
    Optional system_id to indicate this device's parent.
-       If the parent is already set and this parameter is omitted, the parent
-        will be unchanged.
+   If the parent is already set and this parameter is omitted, the parent
+   will be unchanged.
 
-:type parent`
+- `type parent`
    unicode
 
-:param zone`
+- `param zone`
    Name of a valid physical zone in which to place this
-       node.
+   node.
 
-:type zone`
+- `type zone`
    unicode
 
 Returns 404 if the device is not found. Returns 403 if the user does not have
@@ -1074,48 +1073,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only nodes relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to see multiple nodes.
+   with the matching hostname will be returned. This can be specified
+   multiple times to see multiple nodes.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param mac_address`
+- `param mac_address`
    An optional MAC address. Only nodes relating to the
-       node owning the specified MAC address will be returned. This can be
-        specified multiple times to see multiple nodes.
+   node owning the specified MAC address will be returned. This can be
+   specified multiple times to see multiple nodes.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes relating to the
-       nodes with matching system ids will be returned.
+   nodes with matching system ids will be returned.
 
-:type id`
+- `type id`
    unicode
 
-:param domain`
+- `param domain`
    An optional name for a dns domain. Only nodes relating
-       to the nodes in the domain will be returned.
+   to the nodes in the domain will be returned.
 
-:type domain`
+- `type domain`
    unicode
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes relating
-       to the nodes in the zone will be returned.
+   to the nodes in the zone will be returned.
 
-:type zone`
+- `type zone`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes relating to the
-       nodes with matching agent names will be returned.
+   nodes with matching agent names will be returned.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
 ##### `GET /api/2.0/devices/ op=is_registered`
@@ -1123,16 +1122,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-:param mac_address`
+- `param mac_address`
    The mac address to be checked.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:return`
+- `return`
    'true' or 'false'.
 
-:rtype`
+- `rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -1141,42 +1140,42 @@ Returns 400 if any mandatory parameters are missing.
 
 Create a new device.
 
-:param hostname`
+- `param hostname`
    A hostname. If not given, one will be generated.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param domain`
+- `param domain`
    The domain of the device. If not given the default
-       domain is used.
+   domain is used.
 
-:type domain`
+- `type domain`
    unicode
 
-:param mac_addresses`
+- `param mac_addresses`
    One or more MAC addresses for the device.
 
-:type mac_addresses`
+- `type mac_addresses`
    unicode
 
-:param parent`
+- `param parent`
    The system id of the parent. Optional.
 
-:type parent`
+- `type parent`
    unicode
 
 ##### `POST /api/2.0/devices/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
-:param zone`
+- `param zone`
    Zone name. If omitted, the zone is "none" and the nodes
-       will be taken out of their physical zones.
+   will be taken out of their physical zones.
 
-:param nodes`
+- `param nodes`
    system_ids of the nodes whose zones are to be set.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -1227,13 +1226,13 @@ Discoveries are listed in the order they were last observed on the network
 
 Deletes all discovered neighbours and/or mDNS entries.
 
-:param mdns`
+- `param mdns`
    if True, deletes all mDNS entries.
 
-:param neighbours`
+- `param neighbours`
    if True, deletes all neighbour entries.
 
-:param all`
+- `param all`
    if True, deletes all discovery data.
 
 ##### `POST /api/2.0/discovery/ op=scan`
@@ -1253,10 +1252,9 @@ networks.
 If the call is a success, this method will return a dictionary of results as
 follows:
 
-result: A human-readable string summarizing the results.
-scan_attempted_on: A list of rack 'system_id' values where a scan was
-attempted. (That is, an RPC connection was successful and a subsequent call
-was intended.)
+result: A human-readable string summarizing the results. scan_attempted_on:
+A list of rack 'system_id' values where a scan was attempted. (That is, an
+RPC connection was successful and a subsequent call was intended.)
 
 failed_to_connect_to: A list of rack 'system_id' values where the RPC
 connection failed.
@@ -1267,33 +1265,33 @@ successfully started.
 scan_failed_on: A list of rack 'system_id' values where a scan was
 attempted, but failed because a scan was already in progress.
 
-rpc_call_timed_out_on: A list of rack 'system_id' values where the
-RPC connection was made, but the call timed out before a ten second timeout
+rpc_call_timed_out_on: A list of rack 'system_id' values where the RPC
+connection was made, but the call timed out before a ten second timeout
 elapsed.
 
-:param cidr`
+- `param cidr`
    The subnet CIDR(s) to scan (can be specified multiple
-       times). If not specified, defaults to all networks.
+   times). If not specified, defaults to all networks.
 
-:param force`
+- `param force`
    If True, will force the scan, even if all networks are
-       specified. (This may not be the best idea, depending on acceptable use
-        agreements, and the politics of the organization that owns the
-        network.) Default: False.
+   specified. (This may not be the best idea, depending on acceptable use
+   agreements, and the politics of the organization that owns the
+   network.) Default: False.
 
-:param always_use_ping`
+- `param always_use_ping`
    If True, will force the scan to use 'ping' even
-       if 'nmap' is installed. Default: False.
+   if 'nmap' is installed. Default: False.
 
-:param slow`
+- `param slow`
    If True, and 'nmap' is being used, will limit the scan
-       to nine packets per second. If the scanner is 'ping', this option has
-        no effect. Default: False.
+   to nine packets per second. If the scanner is 'ping', this option has
+   no effect. Default: False.
 
-:param threads`
+- `param threads`
    The number of threads to use during scanning. If 'nmap'
-       is the scanner, the default is one thread per 'nmap' process. If
-        'ping' is the scanner, the default is four threads per CPU.
+   is the scanner, the default is one thread per 'nmap' process. If
+   'ping' is the scanner, the default is four threads per CPU.
 
 ### Discovery
 
@@ -1322,13 +1320,13 @@ Returns 404 if the domain is not found.
 
 Update domain.
 
-:param name`
+- `param name`
    Name of the domain.
 
-:param authoritative`
+- `param authoritative`
    True if we are authoritative for this domain.
 
-:param ttl`
+- `param ttl`
    The default TTL for this domain.
 
 Returns 403 if the user does not have permission to update the dnsresource.
@@ -1346,17 +1344,17 @@ List all domains.
 
 Create a domain.
 
-:param name`
+- `param name`
    Name of the domain.
 
-:param authoritative`
+- `param authoritative`
    Class type of the domain.
 
 ##### `POST /api/2.0/domains/ op=set_serial`
 
 Set the SOA serial number (for all DNS zones.)
 
-:param serial`
+- `param serial`
    serial number to use next.
 
 ### Events
@@ -1371,47 +1369,47 @@ Retrieve filtered node events.
 List Node events, optionally filtered by various criteria via URL query
 parameters.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only events relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to get events relating to more than one node.
+   with the matching hostname will be returned. This can be specified
+   multiple times to get events relating to more than one node.
 
-:param mac_address`
+- `param mac_address`
    An optional list of MAC addresses. Only
-       nodes with matching MAC addresses will be returned.
+   nodes with matching MAC addresses will be returned.
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes with
-       matching system ids will be returned.
+   matching system ids will be returned.
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes in the
-       zone will be returned.
+   zone will be returned.
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes with
-       matching agent names will be returned.
+   matching agent names will be returned.
 
-:param level`
+- `param level`
    Desired minimum log level of returned events. Returns
-       this level of events and greater. Choose from: AUDIT, CRITICAL,
-        DEBUG, ERROR, INFO, WARNING. The default is INFO.
+   this level of events and greater. Choose from: AUDIT, CRITICAL, DEBUG,
+   ERROR, INFO, WARNING. The default is INFO.
 
-:param limit`
+- `param limit`
    Optional number of events to return. Default 100.
-       Maximum: 1000.
+   Maximum: 1000.
 
-:param before`
+- `param before`
    Optional event id. Defines where to start returning
-       older events.
+   older events.
 
-:param after`
+- `param after`
    Optional event id. Defines where to start returning
-       newer events.
+   newer events.
 
-:param owner`
+- `param owner`
    If specified, filters the list to show only events
-       owned by the specified username.
+   owned by the specified username.
 
 ### Fabric
 
@@ -1433,13 +1431,13 @@ Returns 404 if the fabric is not found.
 
 Update fabric.
 
-:param name`
+- `param name`
    Name of the fabric.
 
-:param description`
+- `param description`
    Description of the fabric.
 
-:param class_type`
+- `param class_type`
    Class type of the fabric.
 
 Returns 404 if the fabric is not found.
@@ -1456,13 +1454,13 @@ List all fabrics.
 
 Create a fabric.
 
-:param name`
+- `param name`
    Name of the fabric.
 
-:param description`
+- `param description`
    Description of the fabric.
 
-:param class_type`
+- `param class_type`
    Class type of the fabric.
 
 ### Fan Network
@@ -1485,25 +1483,25 @@ Returns 404 if the fannetwork is not found.
 
 Update fannetwork.
 
-:param name`
+- `param name`
    Name of the fannetwork.
 
-:param overlay`
+- `param overlay`
    Overlay network
 
-:param underlay`
+- `param underlay`
    Underlay network
 
-:param dhcp`
+- `param dhcp`
    confiugre dhcp server for overlay net
 
-:param host_reserve`
+- `param host_reserve`
    number of IP addresses to reserve for host
 
-:param bridge`
+- `param bridge`
    override bridge name
 
-:param off`
+- `param off`
    put this int he config, but disable it.
 
 Returns 404 if the fannetwork is not found.
@@ -1520,25 +1518,25 @@ List all fannetworks.
 
 Create a fannetwork.
 
-:param name`
+- `param name`
    Name of the fannetwork.
 
-:param overlay`
+- `param overlay`
    Overlay network
 
-:param underlay`
+- `param underlay`
    Underlay network
 
-:param dhcp`
+- `param dhcp`
    confiugre dhcp server for overlay net
 
-:param host_reserve`
+- `param host_reserve`
    number of IP addresses to reserve for host
 
-:param bridge`
+- `param bridge`
    override bridge name
 
-:param off`
+- `param off`
    put this int he config, but disable it.
 
 ### File
@@ -1565,10 +1563,10 @@ Manage the collection of all the files in this MAAS.
 
 Delete a FileStorage object.
 
-:param filename`
+- `param filename`
    The filename of the object to be deleted.
 
-:type filename`
+- `type filename`
    unicode
 
 ##### `GET /api/2.0/files/`
@@ -1577,56 +1575,56 @@ List the files from the file storage.
 
 The returned files are ordered by file name and the content is excluded.
 
-:param prefix`
+- `param prefix`
    Optional prefix used to filter out the returned files.
 
-:type prefix`
+- `type prefix`
    string
 
 ##### `GET /api/2.0/files/ op=get`
 
 Get a named file from the file storage.
 
-:param filename`
+- `param filename`
    The exact name of the file you want to get.
 
-:type filename`
+- `type filename`
    string
 
-:return`
+- `return`
    The file is returned in the response content.
 
 ##### `GET /api/2.0/files/ op=get_by_key`
 
 Get a file from the file storage using its key.
 
-:param key`
+- `param key`
    The exact key of the file you want to get.
 
-:type key`
+- `type key`
    string
 
-:return`
+- `return`
    The file is returned in the response content.
 
 ##### `POST /api/2.0/files/`
 
 Add a new file to the file storage.
 
-:param filename`
+- `param filename`
    The file name to use in the storage.
 
-:type filename`
+- `type filename`
    string
 
-:param file`
+- `param file`
    Actual file data with content type
-       application/octet-stream
+   application/octet-stream
 
 Returns 400 if any of these conditions apply:
    -   The filename is missing from the parameters
-    -   The file data is missing
-    -   More than one file is supplied
+   -   The file data is missing
+   -   More than one file is supplied
 
 ### IP Addresses
 
@@ -1639,54 +1637,54 @@ List IP addresses known to MAAS.
 By default, gets a listing of all IP addresses allocated to the requesting
 user.
 
-:param ip`
+- `param ip`
    If specified, will only display information for the
-       specified IP address.
+   specified IP address.
 
-:type ip`
+- `type ip`
    unicode (must be an IPv4 or IPv6 address)
 
 If the requesting user is a MAAS administrator, the following options may also
 be supplied:
 
-:param all`
+- `param all`
    If True, all reserved IP addresses will be shown. (By
-       default, only addresses of type 'User reserved' that are assigned to
-        the requesting user are shown.)
+   default, only addresses of type 'User reserved' that are assigned to
+   the requesting user are shown.)
 
-:type all`
+- `type all`
    bool
 
-:param owner`
+- `param owner`
    If specified, filters the list to show only IP addresses
-       owned by the specified username.
+   owned by the specified username.
 
-:type user`
+- `type user`
    unicode
 
 ##### `POST /api/2.0/ipaddresses/ op=release`
 
 Release an IP address that was previously reserved by the user.
 
-:param ip`
+- `param ip`
    The IP address to release.
 
-:type ip`
+- `type ip`
    unicode
 
-:param force`
+- `param force`
    If True, allows a MAAS administrator to force an IP
-       address to be released, even if it is not a user-reserved IP address
-        or does not belong to the requesting user. Use with caution.
+   address to be released, even if it is not a user-reserved IP address
+   or does not belong to the requesting user. Use with caution.
 
-:type force`
+- `type force`
    bool
 
-:param discovered`
+- `param discovered`
    If True, allows a MAAS administrator to release
-       a discovered address. Only valid if 'force' is specified. If not
-        specified, MAAS will attempt to release any type of address except for
-        discovered addresses.
+   a discovered address. Only valid if 'force' is specified. If not
+   specified, MAAS will attempt to release any type of address except for
+   discovered addresses.
 
 Returns 404 if the provided IP address is not found.
 
@@ -1699,23 +1697,23 @@ use; it is free for use by the requesting user until released by the user.
 
 The user may supply either a subnet or a specific IP address within a subnet.
 
-:param subnet`
+- `param subnet`
    CIDR representation of the subnet on which the IP
-       reservation is required. e.g. 10.1.2.0/24
+   reservation is required. e.g. 10.1.2.0/24
 
-:param ip`
+- `param ip`
    The IP address, which must be within
-       a known subnet.
+   a known subnet.
 
-:param ip_address`
+- `param ip_address`
    (Deprecated.) Alias for 'ip' parameter. Provided
-       for backward compatibility.
+   for backward compatibility.
 
-:param hostname`
+- `param hostname`
    The hostname to use for the specified IP address. If
-       no domain component is given, the default domain will be used.
+   no domain component is given, the default domain will be used.
 
-:param mac`
+- `param mac`
    The MAC address that should be linked to this reservation.
 
 Returns 400 if there is no subnet in MAAS matching the provided one, or a
@@ -1743,13 +1741,13 @@ Returns 404 if the IP range is not found.
 
 Update IP range.
 
-:param start_ip`
+- `param start_ip`
    Start IP address of this range (inclusive).
 
-:param end_ip`
+- `param end_ip`
    End IP address of this range (inclusive).
 
-:param comment`
+- `param comment`
    A description of this range. (optional)
 
 Returns 403 if not owner of IP range. Returns 404 if the IP Range is not
@@ -1767,19 +1765,19 @@ List all IP ranges.
 
 Create an IP range.
 
-:param type`
+- `param type`
    Type of this range. (dynamic or reserved)
 
-:param start_ip`
+- `param start_ip`
    Start IP address of this range (inclusive).
 
-:param end_ip`
+- `param end_ip`
    End IP address of this range (inclusive).
 
-:param subnet`
+- `param subnet`
    Subnet this range is associated with. (optional)
 
-:param comment`
+- `param comment`
    A description of this range. (optional)
 
 Returns 403 if standard users tries to create a dynamic IP range.
@@ -1804,7 +1802,7 @@ Returns 404 if the node or interface is not found.
 
 Add a tag to interface on a node.
 
-:param tag`
+- `param tag`
    The tag being added.
 
 Returns 404 if the node or interface is not found. Returns 403 if the user is
@@ -1823,32 +1821,32 @@ Returns 404 if the node or interface is not found.
 
 Link interface to a subnet.
 
-:param mode`
+- `param mode`
    AUTO, DHCP, STATIC or LINK_UP connection to subnet.
 
-:param subnet`
+- `param subnet`
    Subnet linked to interface.
 
-:param ip_address`
+- `param ip_address`
    IP address for the interface in subnet. Only used
-       when mode is STATIC. If not provided an IP address from subnet will be
-        auto selected.
+   when mode is STATIC. If not provided an IP address from subnet will be
+   auto selected.
 
-:param force`
+- `param force`
    If True, allows LINK_UP to be set on the interface
-       even if other links already exist. Also allows the selection of any
-        VLAN, even a VLAN MAAS does not believe the interface to currently be
-        on. Using this option will cause all other links on the interface to
-        be deleted. (Defaults to False.)
+   even if other links already exist. Also allows the selection of any
+   VLAN, even a VLAN MAAS does not believe the interface to currently be
+   on. Using this option will cause all other links on the interface to
+   be deleted. (Defaults to False.)
 
-:param default_gateway`
+- `param default_gateway`
    True sets the gateway IP address for the subnet
-       as the default gateway for the node this interface belongs to. Option
-        can only be used with the AUTO and STATIC modes.
+   as the default gateway for the node this interface belongs to. Option
+   can only be used with the AUTO and STATIC modes.
 
-Mode definitions: AUTO - Assign this interface a static IP address from
-the provided subnet. The subnet must be a managed subnet. The IP address will
-not be assigned until the node goes to be deployed.
+Mode definitions: AUTO - Assign this interface a static IP address from the
+provided subnet. The subnet must be a managed subnet. The IP address will not
+be assigned until the node goes to be deployed.
 
 DHCP - Bring this interface up with DHCP on the given subnet. Only one subnet
 can be set to DHCP. If the subnet is managed this interface will pull from the
@@ -1867,7 +1865,7 @@ Returns 404 if the node or interface is not found.
 
 Remove a tag from interface on a node.
 
-:param tag`
+- `param tag`
    The tag being removed.
 
 Returns 404 if the node or interface is not found. Returns 403 if the user is
@@ -1881,9 +1879,9 @@ If this interface has more than one subnet with a gateway IP in the same IP
 address family then specifying the ID of the link on this interface is
 required.
 
-:param link_id`
+- `param link_id`
    ID of the link on this interface to select the
-       default gateway IP address from.
+   default gateway IP address from.
 
 Returns 400 if the interface has not AUTO or STATIC links. Returns 404 if the
 node or interface is not found.
@@ -1892,7 +1890,7 @@ node or interface is not found.
 
 Unlink interface to a subnet.
 
-:param id`
+- `param id`
    ID of the link on the interface to remove.
 
 Returns 404 if the node or interface is not found.
@@ -1908,102 +1906,102 @@ replaced while the machine remains deployed.
 
 Fields for physical interface:
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    Untagged VLAN the interface is connected to. If not set
-       then the interface is considered disconnected.
+   then the interface is considered disconnected.
 
 Fields for bond interface:
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    Untagged VLAN the interface is connected to. If not set
-       then the interface is considered disconnected.
+   then the interface is considered disconnected.
 
-:param parents`
+- `param parents`
    Parent interfaces that make this bond.
 
 Fields for VLAN interface:
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    Tagged VLAN the interface is connected to.
 
-:param parent`
+- `param parent`
    Parent interface for this VLAN interface.
 
 Fields for bridge interface:
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    VLAN the interface is connected to.
 
-:param parent`
+- `param parent`
    Parent interface for this bridge interface.
 
 Following are extra parameters that can be set on all interface types:
 
-:param mtu`
+- `param mtu`
    Maximum transmission unit.
 
-:param accept_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-:param autoconf`
+- `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Following are parameters specific to bonds:
 
-:param bond_mode`
+- `param bond_mode`
    The operating mode of the bond.
-       (Default: active-backup).
+   (Default: active-backup).
 
-:param bond_miimon`
+- `param bond_miimon`
    The link monitoring freqeuncy in milliseconds.
-       (Default: 100).
+   (Default: 100).
 
-:param bond_downdelay`
+- `param bond_downdelay`
    Specifies the time, in milliseconds, to wait
-       before disabling a slave after a link failure has been detected.
+   before disabling a slave after a link failure has been detected.
 
-:param bond_updelay`
+- `param bond_updelay`
    Specifies the time, in milliseconds, to wait
-       before enabling a slave after a link recovery has been detected.
+   before enabling a slave after a link recovery has been detected.
 
-:param bond_lacp_rate`
+- `param bond_lacp_rate`
    Option specifying the rate in which we'll ask
-       our link partner to transmit LACPDU packets in 802.3ad mode. Available
-        options are fast or slow. (Default: slow).
+   our link partner to transmit LACPDU packets in 802.3ad mode. Available
+   options are fast or slow. (Default: slow).
 
-:param bond_xmit_hash_policy`
+- `param bond_xmit_hash_policy`
    The transmit hash policy to use for
-       slave selection in balance-xor, 802.3ad, and tlb modes.
+   slave selection in balance-xor, 802.3ad, and tlb modes.
 
 Supported bonding modes (bond-mode):
 
@@ -2026,22 +2024,22 @@ fault tolerance.
 that share the same speed and duplex settings. Utilizes all slaves in the
 active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing: channel bonding that does
-not require any special switch support.
+balance-tlb - Adaptive transmit load balancing: channel bonding that does not
+require any special switch support.
 
-balance-alb - Adaptive load balancing: includes balance-tlb plus receive
-load balancing (rlb) for IPV4 traffic, and does not require any special switch
+balance-alb - Adaptive load balancing: includes balance-tlb plus receive load
+balancing (rlb) for IPV4 traffic, and does not require any special switch
 support. The receive load balancing is achieved by ARP negotiation.
 
 Following are parameters specific to bridges:
 
-:param bridge_stp`
+- `param bridge_stp`
    Turn spanning tree protocol on or off.
-       (Default: False).
+   (Default: False).
 
-:param bridge_fd`
+- `param bridge_fd`
    Set bridge forward delay to time seconds.
-       (Default: 15).
+   (Default: 15).
 
 Returns 404 if the node or interface is not found.
 
@@ -2059,54 +2057,54 @@ Returns 404 if the node is not found.
 
 Create a bond interface on a machine.
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    VLAN the interface is connected to. If not
-       provided then the interface is considered disconnected.
+   provided then the interface is considered disconnected.
 
-:param parents`
+- `param parents`
    Parent interfaces that make this bond.
 
 Following are parameters specific to bonds:
 
-:param bond_mode`
+- `param bond_mode`
    The operating mode of the bond.
-       (Default: active-backup).
+   (Default: active-backup).
 
-:param bond_miimon`
+- `param bond_miimon`
    The link monitoring freqeuncy in milliseconds.
-       (Default: 100).
+   (Default: 100).
 
-:param bond_downdelay`
+- `param bond_downdelay`
    Specifies the time, in milliseconds, to wait
-       before disabling a slave after a link failure has been detected.
+   before disabling a slave after a link failure has been detected.
 
-:param bond_updelay`
+- `param bond_updelay`
    Specifies the time, in milliseconds, to wait
-       before enabling a slave after a link recovery has been detected.
+   before enabling a slave after a link recovery has been detected.
 
-:param bond_lacp_rate`
+- `param bond_lacp_rate`
    Option specifying the rate in which we'll ask
-       our link partner to transmit LACPDU packets in 802.3ad mode. Available
-        options are fast or slow. (Default: slow).
+   our link partner to transmit LACPDU packets in 802.3ad mode. Available
+   options are fast or slow. (Default: slow).
 
-:param bond_xmit_hash_policy`
+- `param bond_xmit_hash_policy`
    The transmit hash policy to use for
-       slave selection in balance-xor, 802.3ad, and tlb modes. (Default:
-        layer2)
+   slave selection in balance-xor, 802.3ad, and tlb modes. (Default:
+   layer2)
 
-:param bond_num_grat_arp`
+- `param bond_num_grat_arp`
    The number of peer notifications (IPv4 ARP
-       or IPv6 Neighbour Advertisements) to be issued after a failover.
-        (Default: 1)
+   or IPv6 Neighbour Advertisements) to be issued after a failover.
+   (Default: 1)
 
 Supported bonding modes (bond-mode): balance-rr - Transmit packets in
 sequential order from the first available slave through the last. This mode
@@ -2128,22 +2126,22 @@ fault tolerance.
 that share the same speed and duplex settings. Utilizes all slaves in the
 active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing: channel bonding that does
-not require any special switch support.
+balance-tlb - Adaptive transmit load balancing: channel bonding that does not
+require any special switch support.
 
-balance-alb - Adaptive load balancing: includes balance-tlb plus receive
-load balancing (rlb) for IPV4 traffic, and does not require any special switch
+balance-alb - Adaptive load balancing: includes balance-tlb plus receive load
+balancing (rlb) for IPV4 traffic, and does not require any special switch
 support. The receive load balancing is achieved by ARP negotiation.
 
 Following are extra parameters that can be set on the interface:
 
-:param mtu`
+- `param mtu`
    Maximum transmission unit.
 
-:param accept_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-:param autoconf`
+- `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2152,40 +2150,40 @@ Returns 404 if the node is not found.
 
 Create a bridge interface on a machine.
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    VLAN the interface is connected to.
 
-:param parent`
+- `param parent`
    Parent interface for this bridge interface.
 
 Following are parameters specific to bridges:
 
-:param bridge_stp`
+- `param bridge_stp`
    Turn spanning tree protocol on or off.
-       (Default: False).
+   (Default: False).
 
-:param bridge_fd`
+- `param bridge_fd`
    Set bridge forward delay to time seconds.
-       (Default: 15).
+   (Default: 15).
 
 Following are extra parameters that can be set on the interface:
 
-:param mtu`
+- `param mtu`
    Maximum transmission unit.
 
-:param accept_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-:param autoconf`
+- `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2194,28 +2192,28 @@ Returns 404 if the node is not found.
 
 Create a physical interface on a machine and device.
 
-:param name`
+- `param name`
    Name of the interface.
 
-:param mac_address`
+- `param mac_address`
    MAC address of the interface.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    Untagged VLAN the interface is connected to. If not
-       provided then the interface is considered disconnected.
+   provided then the interface is considered disconnected.
 
 Following are extra parameters that can be set on the interface:
 
-:param mtu`
+- `param mtu`
    Maximum transmission unit.
 
-:param accept_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-:param autoconf`
+- `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2224,24 +2222,24 @@ Returns 404 if the node is not found.
 
 Create a VLAN interface on a machine.
 
-:param tags`
+- `param tags`
    Tags for the interface.
 
-:param vlan`
+- `param vlan`
    Tagged VLAN the interface is connected to.
 
-:param parent`
+- `param parent`
    Parent interface for this VLAN interface.
 
 Following are extra parameters that can be set on the interface:
 
-:param mtu`
+- `param mtu`
    Maximum transmission unit.
 
-:param accept_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-:param autoconf`
+- `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2262,13 +2260,13 @@ Read license key.
 
 Update license key.
 
-:param osystem`
+- `param osystem`
    Operating system that the key belongs to.
 
-:param distro_series`
+- `param distro_series`
    OS release that the key belongs to.
 
-:param license_key`
+- `param license_key`
    License key for osystem/distro_series combo.
 
 ### License Keys
@@ -2283,13 +2281,13 @@ List license keys.
 
 Define a license key.
 
-:param osystem`
+- `param osystem`
    Operating system that the key belongs to.
 
-:param distro_series`
+- `param distro_series`
    OS release that the key belongs to.
 
-:param license_key`
+- `param license_key`
    License key for osystem/distro_series combo.
 
 ### MAAS server
@@ -2300,290 +2298,290 @@ Manage the MAAS server.
 
 Get a config value.
 
-:param name`
+- `param name`
    The name of the config item to be retrieved.
 
 Available configuration items:
 
-:active_discovery_interval`
+- `active_discovery_interval`
    Active subnet mapping interval. When enabled, each rack will scan subnets
-    enabled for active mapping. This helps ensure discovery information is
-    accurate and complete.
+   enabled for active mapping. This helps ensure discovery information is
+   accurate and complete.
 
-:boot_images_auto_import`
+- `boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-:commissioning_distro_series`
+- `commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-:completed_intro`
+- `completed_intro`
    Marks if the initial intro has been completed.
 
-:curtin_verbose`
+- `curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
-    detail in the installation logs.
+   detail in the installation logs.
 
-:default_distro_series`
+- `default_distro_series`
    Default OS release used for deployment.
 
-:default_dns_ttl`
+- `default_dns_ttl`
    Default Time-To-Live for the DNS. If no TTL value is specified at a more
-    specific point this is how long DNS responses are valid, in seconds.
+   specific point this is how long DNS responses are valid, in seconds.
 
-:default_min_hwe_kernel`
+- `default_min_hwe_kernel`
    Default Minimum Kernel Version. The default minimum kernel version used on
-    all new and commissioned nodes.
+   all new and commissioned nodes.
 
-:default_osystem`
+- `default_osystem`
    Default operating system used for deployment.
 
-:default_storage_layout`
+- `default_storage_layout`
    Default storage layout. Storage layout that is applied to a node when it
-    is commissioned. Available choices are: 'bcache' (Bcache layout),
-    'flat' (Flat layout), 'lvm' (LVM layout).
+   is commissioned. Available choices are: 'bcache' (Bcache layout), 'flat'
+   (Flat layout), 'lvm' (LVM layout).
 
-:disk_erase_with_quick_erase`
+- `disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
-    erase; it wipes only the beginning and end of each disk.
+   erase; it wipes only the beginning and end of each disk.
 
-:disk_erase_with_secure_erase`
+- `disk_erase_with_secure_erase`
    Use secure erase by default when erasing disks. Will only be used on
-    devices that support secure erase. Other devices will fall back to full
-    wipe or quick erase depending on the selected options.
+   devices that support secure erase. Other devices will fall back to full
+   wipe or quick erase depending on the selected options.
 
-:dnssec_validation`
+- `dnssec_validation`
    Enable DNSSEC validation of upstream zones. Only used when MAAS is running
-    its own DNS server. This value is used as the value of
-    'dnssec_validation' in the DNS server config.
+   its own DNS server. This value is used as the value of
+   'dnssec_validation' in the DNS server config.
 
-:enable_analytics`
+- `enable_analytics`
    Enable Google Analytics in MAAS UI to shape improvements in user
-    experience.
+   experience.
 
-:enable_disk_erasing_on_release`
+- `enable_disk_erasing_on_release`
    Erase nodes' disks prior to releasing. Forces users to always erase disks
-    when releasing.
+   when releasing.
 
-:enable_http_proxy`
+- `enable_http_proxy`
    Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
-    built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
-    proxy for downloading boot images.
+   built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
+   proxy for downloading boot images.
 
-:enable_third_party_drivers`
+- `enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-:http_proxy`
+- `http_proxy`
    Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
-    to use as a proxy for APT traffic. MAAS also uses the proxy for
-    downloading boot images. If no URL is provided, the built-in MAAS proxy
-    will be used.
+   to use as a proxy for APT traffic. MAAS also uses the proxy for
+   downloading boot images. If no URL is provided, the built-in MAAS proxy
+   will be used.
 
-:kernel_opts`
+- `kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-:maas_name`
+- `maas_name`
    MAAS name.
 
-:max_node_commissioning_results`
+- `max_node_commissioning_results`
    The maximum number of commissioning results runs which are stored.
 
-:max_node_installation_results`
+- `max_node_installation_results`
    The maximum number of installation result runs which are stored.
 
-:max_node_testing_results`
+- `max_node_testing_results`
    The maximum number of testing results runs which are stored.
 
-:network_discovery`
+- `network_discovery`
    . When enabled, MAAS will use passive techniques (such as listening to ARP
-    requests and mDNS advertisements) to observe networks attached to rack
-    controllers. Active subnet mapping will also be available to be enabled on
-    the configured subnets.
+   requests and mDNS advertisements) to observe networks attached to rack
+   controllers. Active subnet mapping will also be available to be enabled on
+   the configured subnets.
 
-:ntp_external_only`
+- `ntp_external_only`
    Use external NTP servers only. Configure all region controller hosts, rack
-    controller hosts, and subsequently deployed machines to refer directly to
-    the configured external NTP servers. Otherwise only region controller
-    hosts will be configured to use those external NTP servers, rack contoller
-    hosts will in turn refer to the regions' NTP servers, and deployed
-    machines will refer to the racks' NTP servers.
+   controller hosts, and subsequently deployed machines to refer directly to
+   the configured external NTP servers. Otherwise only region controller
+   hosts will be configured to use those external NTP servers, rack contoller
+   hosts will in turn refer to the regions' NTP servers, and deployed
+   machines will refer to the racks' NTP servers.
 
-:ntp_servers`
+- `ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
-    hostnames delimited by commas and/or spaces, to be used as time references
-    for MAAS itself, the machines MAAS deploys, and devices that make use of
-    MAAS's DHCP services.
+   hostnames delimited by commas and/or spaces, to be used as time references
+   for MAAS itself, the machines MAAS deploys, and devices that make use of
+   MAAS's DHCP services.
 
-:prefer_v4_proxy`
+- `prefer_v4_proxy`
    Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
-    proxy will be set to prefer IPv4 DNS resolution before it attempts to
-    perform IPv6 DNS resolution.
+   proxy will be set to prefer IPv4 DNS resolution before it attempts to
+   perform IPv6 DNS resolution.
 
-:subnet_ip_exhaustion_threshold_count`
+- `subnet_ip_exhaustion_threshold_count`
    If the number of free IP addresses on a subnet becomes less than or equal
-    to this threshold, an IP exhaustion warning will appear for that subnet.
+   to this threshold, an IP exhaustion warning will appear for that subnet.
 
-:upstream_dns`
+- `upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
-    (space-separated IP addresses). Only used when MAAS is running its own DNS
-    server. This value is used as the value of 'forwarders' in the DNS server
-    config.
+   (space-separated IP addresses). Only used when MAAS is running its own DNS
+   server. This value is used as the value of 'forwarders' in the DNS server
+   config.
 
-:use_peer_proxy`
+- `use_peer_proxy`
    Use the built-in proxy with an external proxy as a peer. If
-    enable_http_proxy is set, the built-in proxy will be configured to use
-    http_proxy as a peer proxy. The deployed machines will be configured to
-    use the built-in proxy.
+   enable_http_proxy is set, the built-in proxy will be configured to use
+   http_proxy as a peer proxy. The deployed machines will be configured to
+   use the built-in proxy.
 
-:windows_kms_host`
+- `windows_kms_host`
    Windows KMS activation host. FQDN or IP address of the host that provides
-    the KMS Windows activation service. (Only needed for Windows deployments
-    using KMS activation.)
+   the KMS Windows activation service. (Only needed for Windows deployments
+   using KMS activation.)
 
 ##### `POST /api/2.0/maas/ op=set_config`
 
 Set a config value.
 
-:param name`
+- `param name`
    The name of the config item to be set.
 
-:param value`
+- `param value`
    The value of the config item to be set.
 
 Available configuration items:
 
-:active_discovery_interval`
+- `active_discovery_interval`
    Active subnet mapping interval. When enabled, each rack will scan subnets
-    enabled for active mapping. This helps ensure discovery information is
-    accurate and complete.
+   enabled for active mapping. This helps ensure discovery information is
+   accurate and complete.
 
-:boot_images_auto_import`
+- `boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-:commissioning_distro_series`
+- `commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-:completed_intro`
+- `completed_intro`
    Marks if the initial intro has been completed.
 
-:curtin_verbose`
+- `curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
-    detail in the installation logs.
+   detail in the installation logs.
 
-:default_distro_series`
+- `default_distro_series`
    Default OS release used for deployment.
 
-:default_dns_ttl`
+- `default_dns_ttl`
    Default Time-To-Live for the DNS. If no TTL value is specified at a more
-    specific point this is how long DNS responses are valid, in seconds.
+   specific point this is how long DNS responses are valid, in seconds.
 
-:default_min_hwe_kernel`
+- `default_min_hwe_kernel`
    Default Minimum Kernel Version. The default minimum kernel version used on
-    all new and commissioned nodes.
+   all new and commissioned nodes.
 
-:default_osystem`
+- `default_osystem`
    Default operating system used for deployment.
 
-:default_storage_layout`
+- `default_storage_layout`
    Default storage layout. Storage layout that is applied to a node when it
-    is commissioned. Available choices are: 'bcache' (Bcache layout),
-    'flat' (Flat layout), 'lvm' (LVM layout).
+   is commissioned. Available choices are: 'bcache' (Bcache layout), 'flat'
+   (Flat layout), 'lvm' (LVM layout).
 
-:disk_erase_with_quick_erase`
+- `disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
-    erase; it wipes only the beginning and end of each disk.
+   erase; it wipes only the beginning and end of each disk.
 
-:disk_erase_with_secure_erase`
+- `disk_erase_with_secure_erase`
    Use secure erase by default when erasing disks. Will only be used on
-    devices that support secure erase. Other devices will fall back to full
-    wipe or quick erase depending on the selected options.
+   devices that support secure erase. Other devices will fall back to full
+   wipe or quick erase depending on the selected options.
 
-:dnssec_validation`
+- `dnssec_validation`
    Enable DNSSEC validation of upstream zones. Only used when MAAS is running
-    its own DNS server. This value is used as the value of
-    'dnssec_validation' in the DNS server config.
+   its own DNS server. This value is used as the value of
+   'dnssec_validation' in the DNS server config.
 
-:enable_analytics`
+- `enable_analytics`
    Enable Google Analytics in MAAS UI to shape improvements in user
-    experience.
+   experience.
 
-:enable_disk_erasing_on_release`
+- `enable_disk_erasing_on_release`
    Erase nodes' disks prior to releasing. Forces users to always erase disks
-    when releasing.
+   when releasing.
 
-:enable_http_proxy`
+- `enable_http_proxy`
    Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
-    built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
-    proxy for downloading boot images.
+   built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
+   proxy for downloading boot images.
 
-:enable_third_party_drivers`
+- `enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-:http_proxy`
+- `http_proxy`
    Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
-    to use as a proxy for APT traffic. MAAS also uses the proxy for
-    downloading boot images. If no URL is provided, the built-in MAAS proxy
-    will be used.
+   to use as a proxy for APT traffic. MAAS also uses the proxy for
+   downloading boot images. If no URL is provided, the built-in MAAS proxy
+   will be used.
 
-:kernel_opts`
+- `kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-:maas_name`
+- `maas_name`
    MAAS name.
 
-:max_node_commissioning_results`
+- `max_node_commissioning_results`
    The maximum number of commissioning results runs which are stored.
 
-:max_node_installation_results`
+- `max_node_installation_results`
    The maximum number of installation result runs which are stored.
 
-:max_node_testing_results`
+- `max_node_testing_results`
    The maximum number of testing results runs which are stored.
 
-:network_discovery`
+- `network_discovery`
    . When enabled, MAAS will use passive techniques (such as listening to ARP
-    requests and mDNS advertisements) to observe networks attached to rack
-    controllers. Active subnet mapping will also be available to be enabled on
-    the configured subnets.
+   requests and mDNS advertisements) to observe networks attached to rack
+   controllers. Active subnet mapping will also be available to be enabled on
+   the configured subnets.
 
-:ntp_external_only`
+- `ntp_external_only`
    Use external NTP servers only. Configure all region controller hosts, rack
-    controller hosts, and subsequently deployed machines to refer directly to
-    the configured external NTP servers. Otherwise only region controller
-    hosts will be configured to use those external NTP servers, rack contoller
-    hosts will in turn refer to the regions' NTP servers, and deployed
-    machines will refer to the racks' NTP servers.
+   controller hosts, and subsequently deployed machines to refer directly to
+   the configured external NTP servers. Otherwise only region controller
+   hosts will be configured to use those external NTP servers, rack contoller
+   hosts will in turn refer to the regions' NTP servers, and deployed
+   machines will refer to the racks' NTP servers.
 
-:ntp_servers`
+- `ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
-    hostnames delimited by commas and/or spaces, to be used as time references
-    for MAAS itself, the machines MAAS deploys, and devices that make use of
-    MAAS's DHCP services.
+   hostnames delimited by commas and/or spaces, to be used as time references
+   for MAAS itself, the machines MAAS deploys, and devices that make use of
+   MAAS's DHCP services.
 
-:prefer_v4_proxy`
+- `prefer_v4_proxy`
    Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
-    proxy will be set to prefer IPv4 DNS resolution before it attempts to
-    perform IPv6 DNS resolution.
+   proxy will be set to prefer IPv4 DNS resolution before it attempts to
+   perform IPv6 DNS resolution.
 
-:subnet_ip_exhaustion_threshold_count`
+- `subnet_ip_exhaustion_threshold_count`
    If the number of free IP addresses on a subnet becomes less than or equal
-    to this threshold, an IP exhaustion warning will appear for that subnet.
+   to this threshold, an IP exhaustion warning will appear for that subnet.
 
-:upstream_dns`
+- `upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
-    (space-separated IP addresses). Only used when MAAS is running its own DNS
-    server. This value is used as the value of 'forwarders' in the DNS server
-    config.
+   (space-separated IP addresses). Only used when MAAS is running its own DNS
+   server. This value is used as the value of 'forwarders' in the DNS server
+   config.
 
-:use_peer_proxy`
+- `use_peer_proxy`
    Use the built-in proxy with an external proxy as a peer. If
-    enable_http_proxy is set, the built-in proxy will be configured to use
-    http_proxy as a peer proxy. The deployed machines will be configured to
-    use the built-in proxy.
+   enable_http_proxy is set, the built-in proxy will be configured to use
+   http_proxy as a peer proxy. The deployed machines will be configured to
+   use the built-in proxy.
 
-:windows_kms_host`
+- `windows_kms_host`
    Windows KMS activation host. FQDN or IP address of the host that provides
-    the KMS Windows activation service. (Only needed for Windows deployments
-    using KMS activation.)
+   the KMS Windows activation service. (Only needed for Windows deployments
+   using KMS activation.)
 
 ### Machine
 
@@ -2611,8 +2609,8 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
-like "lldp" or "lshw".
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something like
+"lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
 mainly because JSON can't do binary content without applying additional
@@ -2649,12 +2647,12 @@ state. The reply to this could be delayed by up to 30 seconds while waiting
 for the power controller to respond. Use this method sparingly as it ties up
 an appserver thread while waiting.
 
-:param system_id`
+- `param system_id`
    The node to query.
 
-:return`
+- `return`
    a dict whose key is "state" with a value of one of
-       'on' or 'off'.
+   'on' or 'off'.
 
 Returns 404 if the node is not found. Returns node's power state.
 
@@ -2662,10 +2660,10 @@ Returns 404 if the node is not found. Returns node's power state.
 
 Abort a node's current operation.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the node could not be found. Returns 403 if the user does not
@@ -2697,43 +2695,43 @@ not have permission to clear the default gateways.
 
 Begin commissioning process for a machine.
 
-:param enable_ssh`
+- `param enable_ssh`
    Whether to enable SSH for the commissioning
-       environment using the user's SSH key(s).
+   environment using the user's SSH key(s).
 
-:type enable_ssh`
+- `type enable_ssh`
    bool ('0' for False, '1' for True)
 
-:param skip_networking`
+- `param skip_networking`
    Whether to skip re-configuring the networking
-       on the machine after the commissioning has completed.
+   on the machine after the commissioning has completed.
 
-:type skip_networking`
+- `type skip_networking`
    bool ('0' for False, '1' for True)
 
-:param skip_storage`
+- `param skip_storage`
    Whether to skip re-configuring the storage
-       on the machine after the commissioning has completed.
+   on the machine after the commissioning has completed.
 
-:type skip_storage`
+- `type skip_storage`
    bool ('0' for False, '1' for True)
 
-:param commissioning_scripts`
+- `param commissioning_scripts`
    A comma seperated list of commissioning
-       script names and tags to be run. By default all custom commissioning
-        scripts are run. Builtin commissioning scripts always run. Selecting
-        'update_firmware' or 'configure_hba' will run firmware updates or
-        configure HBA's on matching machines.
+   script names and tags to be run. By default all custom commissioning
+   scripts are run. Builtin commissioning scripts always run. Selecting
+   'update_firmware' or 'configure_hba' will run firmware updates or
+   configure HBA's on matching machines.
 
-:type commissioning_scripts`
+- `type commissioning_scripts`
    string
 
-:param testing_scripts`
+- `param testing_scripts`
    A comma seperated list of testing script names
-       and tags to be run. By default all tests tagged 'commissioning' will
-        be run. Set to 'none' to disable running tests.
+   and tags to be run. By default all tests tagged 'commissioning' will
+   be run. Set to 'none' to disable running tests.
 
-:type testing_scripts`
+- `type testing_scripts`
    string
 
 A machine in the 'ready', 'declared' or 'failed test' state may initiate a
@@ -2748,68 +2746,67 @@ Returns 404 if the machine is not found.
 
 Deploy an operating system to a machine.
 
-:param user_data`
+- `param user_data`
    If present, this blob of user-data to be made
-       available to the machines through the metadata service.
+   available to the machines through the metadata service.
 
-:type user_data`
+- `type user_data`
    base64-encoded unicode
 
-:param distro_series`
+- `param distro_series`
    If present, this parameter specifies the
-       OS release the machine will use.
+   OS release the machine will use.
 
-:type distro_series`
+- `type distro_series`
    unicode
 
-:param hwe_kernel`
+- `param hwe_kernel`
    If present, this parameter specified the kernel to
-       be used on the machine
+   be used on the machine
 
-:type hwe_kernel`
+- `type hwe_kernel`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name to attach to the
-       acquired machine.
+   acquired machine.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
-:param bridge_all`
+- `param bridge_all`
    Optionally create a bridge interface for every
-       configured interface on the machine. The created bridges will be
-        removed once the machine is released. (Default: False)
+   configured interface on the machine. The created bridges will be
+   removed once the machine is released. (Default: False)
 
-:type bridge_all`
+- `type bridge_all`
    boolean
 
-:param bridge_stp`
+- `param bridge_stp`
    Optionally turn spanning tree protocol on or off
-       for the bridges created on every configured interface. (Default:
-        off)
+   for the bridges created on every configured interface. (Default: off)
 
-:type bridge_stp`
+- `type bridge_stp`
    boolean
 
-:param bridge_fd`
+- `param bridge_fd`
    Optionally adjust the forward delay to time seconds.
-       (Default: 15)
+   (Default: 15)
 
-:type bridge_fd`
+- `type bridge_fd`
    integer
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
-:param install_rackd`
+- `param install_rackd`
    If True, the Rack Controller will be installed on
-       this machine.
+   this machine.
 
-:type install_rackd`
+- `type install_rackd`
    boolean
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -2836,10 +2833,10 @@ Mark a deployed machine as locked, to prevent changes.
 
 A locked machine cannot be released or modified.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2851,11 +2848,11 @@ Mark a node as 'broken'.
 
 If the node is allocated, release it first.
 
-:param comment`
+- `param comment`
    Optional comment for the event log. Will be
-       displayed on the node as an error description until marked fixed.
+   displayed on the node as an error description until marked fixed.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -2865,10 +2862,10 @@ permission to mark the node broken.
 
 Mark a broken node as fixed and set its status as 'ready'.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2878,14 +2875,14 @@ permission to mark the machine fixed.
 
 Mount a special-purpose filesystem, like tmpfs.
 
-:param fstype`
+- `param fstype`
    The filesystem type. This must be a filesystem that
-       does not require a block special device.
+   does not require a block special device.
 
-:param mount_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-:param mount_option`
+- `param mount_option`
    Options to pass to mount(8).
 
 Returns 403 when the user is not permitted to mount the partition.
@@ -2894,10 +2891,10 @@ Returns 403 when the user is not permitted to mount the partition.
 
 Ignore failed tests and put node back into a usable state.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2907,22 +2904,22 @@ permission to ignore tests for the node.
 
 Power off a node.
 
-:param stop_mode`
+- `param stop_mode`
    An optional power off mode. If 'soft',
-       perform a soft power down if the node's power type supports it,
-        otherwise perform a hard power off. For all values other than 'soft',
-        and by default, perform a hard power off. A soft power off generally
-        asks the OS to shutdown the system gracefully before powering off,
-        while a hard power off occurs immediately without any warning to the
-        OS.
+   perform a soft power down if the node's power type supports it,
+   otherwise perform a hard power off. For all values other than 'soft',
+   and by default, perform a hard power off. A soft power off generally
+   asks the OS to shutdown the system gracefully before powering off,
+   while a hard power off occurs immediately without any warning to the
+   OS.
 
-:type stop_mode`
+- `type stop_mode`
    unicode
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -2932,17 +2929,17 @@ permission to stop the node.
 
 Turn on a node.
 
-:param user_data`
+- `param user_data`
    If present, this blob of user-data to be made
-       available to the nodes through the metadata service.
+   available to the nodes through the metadata service.
 
-:type user_data`
+- `type user_data`
    base64-encoded unicode
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -2958,33 +2955,33 @@ relevant cluster interface.
 
 Release a machine. Opposite of Machines.allocate.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
-:param erase`
+- `param erase`
    Erase the disk when releasing.
 
-:type erase`
+- `type erase`
    boolean
 
-:param secure_erase`
+- `param secure_erase`
    Use the drive's secure erase feature if available.
-       In some cases this can be much faster than overwriting the drive. Some
-        drives implement secure erasure by overwriting themselves so this
-        could still be slow.
+   In some cases this can be much faster than overwriting the drive. Some
+   drives implement secure erasure by overwriting themselves so this
+   could still be slow.
 
-:type secure_erase`
+- `type secure_erase`
    boolean
 
-:param quick_erase`
+- `param quick_erase`
    Wipe 2MiB at the start and at the end of the drive
-       to make data recovery inconvenient and unlikely to happen by accident.
-        This is not secure.
+   to make data recovery inconvenient and unlikely to happen by accident.
+   This is not secure.
 
-:type quick_erase`
+- `type quick_erase`
    boolean
 
 If neither secure_erase nor quick_erase are specified, MAAS will overwrite
@@ -3054,51 +3051,51 @@ Changes the storage layout on the machine.
 
 This operation can only be performed on a machine with a status of 'Ready'.
 
-Note: This will clear the current storage layout and any extra
-configuration and replace it will the new layout.
+Note: This will clear the current storage layout and any extra configuration
+and replace it will the new layout.
 
-:param storage_layout`
+- `param storage_layout`
    Storage layout for the machine. (flat, lvm,
-       and bcache)
+   and bcache)
 
 The following are optional for all layouts:
 
-:param boot_size`
+- `param boot_size`
    Size of the boot partition.
 
-:param root_size`
+- `param root_size`
    Size of the root partition.
 
-:param root_device`
+- `param root_device`
    Physical block device to place the root partition.
 
 The following are optional for LVM:
 
-:param vg_name`
+- `param vg_name`
    Name of created volume group.
 
-:param lv_name`
+- `param lv_name`
    Name of created logical volume.
 
-:param lv_size`
+- `param lv_size`
    Size of created logical volume.
 
 The following are optional for Bcache:
 
-:param cache_device`
+- `param cache_device`
    Physical block device to use as the cache device.
 
-:param cache_mode`
+- `param cache_mode`
    Cache mode for bcache device. (writeback,
-       writethrough, writearound)
+   writethrough, writearound)
 
-:param cache_size`
+- `param cache_size`
    Size of the cache partition to create on the cache
-       device.
+   device.
 
-:param cache_no_part`
+- `param cache_no_part`
    Don't create a partition on the cache device.
-       Use the entire disk as the cache device.
+   Use the entire disk as the cache device.
 
 Returns 400 if the machine is currently not allocated. Returns 404 if the
 machine could not be found. Returns 403 if the user does not have permission
@@ -3108,19 +3105,19 @@ to set the storage layout.
 
 Begin testing process for a node.
 
-:param enable_ssh`
+- `param enable_ssh`
    Whether to enable SSH for the testing environment
-       using the user's SSH key(s).
+   using the user's SSH key(s).
 
-:type enable_ssh`
+- `type enable_ssh`
    bool ('0' for False, '1' for True)
 
-:param testing_scripts`
+- `param testing_scripts`
    A comma seperated list of testing script names
-       and tags to be run. By default all tests tagged 'commissioning' will
-        be run.
+   and tags to be run. By default all tests tagged 'commissioning' will
+   be run.
 
-:type testing_scripts`
+- `type testing_scripts`
    string
 
 A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
@@ -3135,10 +3132,10 @@ Returns 404 if the node is not found.
 
 Mark a machine as unlocked, allowing changes.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -3148,7 +3145,7 @@ permission unlock the machine.
 
 Unmount a special-purpose filesystem, like tmpfs.
 
-:param mount_point`
+- `param mount_point`
    Path on the filesystem to unmount.
 
 Returns 403 when the user is not permitted to unmount the partition.
@@ -3157,91 +3154,91 @@ Returns 403 when the user is not permitted to unmount the partition.
 
 Update a specific Machine.
 
-:param hostname`
+- `param hostname`
    The new hostname for this machine.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param domain`
+- `param domain`
    The domain for this machine. If not given the default
-       domain is used.
+   domain is used.
 
-:type domain`
+- `type domain`
    unicode
 
-:param architecture`
+- `param architecture`
    The new architecture for this machine.
 
-:type architecture`
+- `type architecture`
    unicode
 
-:param min_hwe_kernel`
+- `param min_hwe_kernel`
    A string containing the minimum kernel version
-       allowed to be ran on this machine.
+   allowed to be ran on this machine.
 
-:type min_hwe_kernel`
+- `type min_hwe_kernel`
    unicode
 
-:param power_type`
+- `param power_type`
    The new power type for this machine. If you use the
-       default value, power_parameters will be set to the empty string.
-        Available to admin users. See the [Power types]() section for a list
-        of the available power types.
+   default value, power_parameters will be set to the empty string.
+   Available to admin users. See the [Power types]() section for a list
+   of the available power types.
 
-:type power_type`
+- `type power_type`
    unicode
 
-:param [power_parameters](){param1}`
+- `param power_parameters_{param1}`
    The new value for the 'param1'
-       power parameter. Note that this is dynamic as the available parameters
-        depend on the selected value of the Machine's power_type. Available
-        to admin users. See the [Power types]() section for a list of the
-        available power parameters for each power type.
+   power parameter. Note that this is dynamic as the available parameters
+   depend on the selected value of the Machine's power_type. Available
+   to admin users. See the [Power types]() section for a list of the
+   available power parameters for each power type.
 
-:type [power_parameters](){param1}`
+- `type power_parameters_{param1}`
    unicode
 
-:param power_parameters_skip_check`
+- `param power_parameters_skip_check`
    Whether or not the new power
-       parameters for this machine should be checked against the expected
-        power parameters for the machine's power type ('true' or 'false'). The
-        default is 'false'.
+   parameters for this machine should be checked against the expected
+   power parameters for the machine's power type ('true' or 'false'). The
+   default is 'false'.
 
-:type power_parameters_skip_check`
+- `type power_parameters_skip_check`
    unicode
 
-:param zone`
+- `param zone`
    Name of a valid physical zone in which to place this
-       machine.
+   machine.
 
-:type zone`
+- `type zone`
    unicode
 
-:param swap_size`
+- `param swap_size`
    Specifies the size of the swap file, in bytes. Field
-       accept K, M, G and T suffixes for values expressed respectively in
-        kilobytes, megabytes, gigabytes and terabytes.
+   accept K, M, G and T suffixes for values expressed respectively in
+   kilobytes, megabytes, gigabytes and terabytes.
 
-:type swap_size`
+- `type swap_size`
    unicode
 
-:param disable_ipv4`
+- `param disable_ipv4`
    Deprecated. If specified, must be False.
 
-:type disable_ipv4`
+- `type disable_ipv4`
    boolean
 
-:param cpu_count`
+- `param cpu_count`
    The amount of CPU cores the machine has.
 
-:type cpu_count`
+- `type cpu_count`
    integer
 
-:param memory`
+- `param memory`
    How much memory the machine has.
 
-:type memory`
+- `type memory`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -3257,48 +3254,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only nodes relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to see multiple nodes.
+   with the matching hostname will be returned. This can be specified
+   multiple times to see multiple nodes.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param mac_address`
+- `param mac_address`
    An optional MAC address. Only nodes relating to the
-       node owning the specified MAC address will be returned. This can be
-        specified multiple times to see multiple nodes.
+   node owning the specified MAC address will be returned. This can be
+   specified multiple times to see multiple nodes.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes relating to the
-       nodes with matching system ids will be returned.
+   nodes with matching system ids will be returned.
 
-:type id`
+- `type id`
    unicode
 
-:param domain`
+- `param domain`
    An optional name for a dns domain. Only nodes relating
-       to the nodes in the domain will be returned.
+   to the nodes in the domain will be returned.
 
-:type domain`
+- `type domain`
    unicode
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes relating
-       to the nodes in the zone will be returned.
+   to the nodes in the zone will be returned.
 
-:type zone`
+- `type zone`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes relating to the
-       nodes with matching agent names will be returned.
+   nodes with matching agent names will be returned.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
 ##### `GET /api/2.0/machines/ op=is_registered`
@@ -3306,16 +3303,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-:param mac_address`
+- `param mac_address`
    The mac address to be checked.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:return`
+- `return`
    'true' or 'false'.
 
-:rtype`
+- `rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -3328,14 +3325,14 @@ Fetch Machines that were allocated to the User/oauth token.
 
 Retrieve power parameters for multiple machines.
 
-:param id`
+- `param id`
    An optional list of system ids. Only machines with
-       matching system ids will be returned.
+   matching system ids will be returned.
 
-:type id`
+- `type id`
    iterable
 
-:return`
+- `return`
    A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
@@ -3350,63 +3347,62 @@ enlistment (and when the enlistment is done by a non-admin), the machine is
 held in the "New" state for approval by a MAAS admin.
 
 The minimum data required is: architecture=&lt;arch string&gt; (e.g.
-"i386/generic") mac_addresses=&lt;value&gt; (e.g. "aa:bb`
-cc:dd`ee`ff")
+"i386/generic") mac_addresses=&lt;value&gt; (e.g. "aa:bb: cc:dd:ee:ff")
 
-:param architecture`
+- `param architecture`
    A string containing the architecture type of
-       the machine. (For example, "i386", or "amd64".) To determine the
-        supported architectures, use the boot-resources endpoint.
+   the machine. (For example, "i386", or "amd64".) To determine the
+   supported architectures, use the boot-resources endpoint.
 
-:type architecture`
+- `type architecture`
    unicode
 
-:param min_hwe_kernel`
+- `param min_hwe_kernel`
    A string containing the minimum kernel version
-       allowed to be ran on this machine.
+   allowed to be ran on this machine.
 
-:type min_hwe_kernel`
+- `type min_hwe_kernel`
    unicode
 
-:param subarchitecture`
+- `param subarchitecture`
    A string containing the subarchitecture type
-       of the machine. (For example, "generic" or "hwe-t".) To determine the
-        supported subarchitectures, use the boot-resources endpoint.
+   of the machine. (For example, "generic" or "hwe-t".) To determine the
+   supported subarchitectures, use the boot-resources endpoint.
 
-:type subarchitecture`
+- `type subarchitecture`
    unicode
 
-:param mac_addresses`
+- `param mac_addresses`
    One or more MAC addresses for the machine. To
-       specify more than one MAC address, the parameter must be specified
-        twice. (such as "machines new mac_addresses=01:02`
+   specify more than one MAC address, the parameter must be specified
+   twice. (such as "machines new mac_addresses=01:02:
 
-03:04`05`06
-   mac_addresses=02:03`
+03:04:05:06
+   mac_addresses=02:03:
 
-> 04:05`06`07")
+> 04:05:06:07")
 
-:type mac_addresses`
+- `type mac_addresses`
    unicode
 
-:param hostname`
+- `param hostname`
    A hostname. If not given, one will be generated.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param domain`
+- `param domain`
    The domain of the machine. If not given the default
-       domain is used.
+   domain is used.
 
-:type domain`
+- `type domain`
    unicode
 
-:param power_type`
+- `param power_type`
    A power management type, if applicable (e.g.
-       "virsh", "ipmi").
+   "virsh", "ipmi").
 
-:type power_type`
+- `type power_type`
    unicode
 
 ##### `POST /api/2.0/machines/ op=accept`
@@ -3421,14 +3417,14 @@ Enlistments can be accepted en masse, by passing multiple machines to this
 call. Accepting an already accepted machine is not an error, but accepting one
 that is already allocated, broken, etc. is.
 
-:param machines`
+- `param machines`
    system_ids of the machines whose enlistment is to be
-       accepted. (An empty list is acceptable).
+   accepted. (An empty list is acceptable).
 
-:return`
+- `return`
    The system_ids of any machines that have their status changed
-       by this call. Thus, machines that were already accepted are excluded
-        from the result.
+   by this call. Thus, machines that were already accepted are excluded
+   from the result.
 
 Returns 400 if any of the machines do not exist. Returns 403 if the user is
 not an admin.
@@ -3441,111 +3437,111 @@ Machines can be enlisted in the MAAS anonymously or by non-admin users, as
 opposed to by an admin. These machines are held in the New state; a MAAS admin
 must first verify the authenticity of these enlistments, and accept them.
 
-:return`
+- `return`
    Representations of any machines that have their status changed
-       by this call. Thus, machines that were already accepted are excluded
-        from the result.
+   by this call. Thus, machines that were already accepted are excluded
+   from the result.
 
 ##### `POST /api/2.0/machines/ op=add_chassis`
 
 Add special hardware types.
 
-:param chassis_type`
+- `param chassis_type`
    The type of hardware.
-       mscm is the type for the Moonshot Chassis Manager. msftocs is the type
-        for the Microsoft OCS Chassis Manager. powerkvm is the type for
-        Virtual Machines on Power KVM, managed by Virsh. recs_box is the type
-        for the christmann RECS|Box servers. seamicro15k is the type for the
-        Seamicro 1500 Chassis. ucsm is the type for the Cisco UCS Manager.
-        virsh is the type for virtual machines managed by Virsh. vmware is the
-        type for virtual machines managed by VMware.
+   mscm is the type for the Moonshot Chassis Manager. msftocs is the type
+   for the Microsoft OCS Chassis Manager. powerkvm is the type for
+   Virtual Machines on Power KVM, managed by Virsh. recs_box is the type
+   for the christmann RECS|Box servers. seamicro15k is the type for the
+   Seamicro 1500 Chassis. ucsm is the type for the Cisco UCS Manager.
+   virsh is the type for virtual machines managed by Virsh. vmware is the
+   type for virtual machines managed by VMware.
 
-:type chassis_type`
+- `type chassis_type`
    unicode
 
-:param hostname`
+- `param hostname`
    The URL, hostname, or IP address to access the
-       chassis.
+   chassis.
 
-:type url`
+- `type url`
    unicode
 
-:param username`
+- `param username`
    The username used to access the chassis. This field
-       is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
-        ucsm chassis types.
+   is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
+   ucsm chassis types.
 
-:type username`
+- `type username`
    unicode
 
-:param password`
+- `param password`
    The password used to access the chassis. This field
-       is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
-        ucsm chassis types.
+   is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
+   ucsm chassis types.
 
-:type password`
+- `type password`
    unicode
 
-:param accept_all`
+- `param accept_all`
    If true, all enlisted machines will be
-       commissioned.
+   commissioned.
 
-:type accept_all`
+- `type accept_all`
    unicode
 
-:param rack_controller`
+- `param rack_controller`
    The system_id of the rack controller to send
-       the add chassis command through. If none is specifed MAAS will
-        automatically determine the rack controller to use.
+   the add chassis command through. If none is specifed MAAS will
+   automatically determine the rack controller to use.
 
-:type rack_controller`
+- `type rack_controller`
    unicode
 
-:param domain`
+- `param domain`
    The domain that each new machine added should use.
 
-:type domain`
+- `type domain`
    unicode
 
 The following are optional if you are adding a virsh, vmware, or powerkvm
 chassis:
 
-:param prefix_filter`
+- `param prefix_filter`
    Filter machines with supplied prefix.
 
-:type prefix_filter`
+- `type prefix_filter`
    unicode
 
 The following are optional if you are adding a seamicro15k chassis:
 
-:param power_control`
+- `param power_control`
    The power_control to use, either ipmi (default),
-       restapi, or restapi2.
+   restapi, or restapi2.
 
-:type power_control`
+- `type power_control`
    unicode
 
 The following are optional if you are adding a recs_box, vmware or msftocs
 chassis.
 
-:param port`
+- `param port`
    The port to use when accessing the chassis.
 
-:type port`
+- `type port`
    integer
 
 The following are optioanl if you are adding a vmware chassis:
 
-:param protocol`
+- `param protocol`
    The protocol to use when accessing the VMware
-       chassis (default: https).
+   chassis (default: https).
 
-:type protocol`
+- `type protocol`
    unicode
 
-:return`
+- `return`
    A string containing the chassis powered on by which rack
-       controller.
+   controller.
 
 Returns 404 if no rack controller can be found which has access to the given
 URL. Returns 403 if the user does not have access to the rack controller.
@@ -3559,321 +3555,318 @@ Constraints parameters can be used to allocate a machine that possesses
 certain characteristics. All the constraints are optional and when multiple
 constraints are provided, they are combined using 'AND' semantics.
 
-:param name`
+- `param name`
    Hostname or FQDN of the desired machine. If a FQDN is
-       specified, both the domain and the hostname portions must match.
+   specified, both the domain and the hostname portions must match.
 
-:type name`
+- `type name`
    unicode
 
-:param system_id`
+- `param system_id`
    system_id of the desired machine.
 
-:type system_id`
+- `type system_id`
    unicode
 
-:param arch`
+- `param arch`
    Architecture of the returned machine (e.g. 'i386/generic',
-       'amd64', 'armhf/highbank', etc.).
+   'amd64', 'armhf/highbank', etc.).
 
-        If multiple architectures are specified, the machine to acquire may
-        match any of the given architectures. To request multiple
-        architectures, this parameter must be repeated in the request with
-        each value.
+   If multiple architectures are specified, the machine to acquire may
+   match any of the given architectures. To request multiple
+   architectures, this parameter must be repeated in the request with
+   each value.
 
-:type arch`
+- `type arch`
    unicode (accepts multiple)
 
-:param cpu_count`
+- `param cpu_count`
    Minimum number of CPUs a returned machine must have.
 
-    > A machine with additional CPUs may be allocated if there is no exact
-    > match, or if the 'mem' constraint is not also specified.
+   > A machine with additional CPUs may be allocated if there is no exact
+   > match, or if the 'mem' constraint is not also specified.
 
-:type cpu_count`
+- `type cpu_count`
    positive integer
 
-:param mem`
+- `param mem`
    The minimum amount of memory (expressed in MB) the
-       returned machine must have. A machine with additional memory may be
-        allocated if there is no exact match, or the 'cpu_count' constraint
-        is not also specified.
+   returned machine must have. A machine with additional memory may be
+   allocated if there is no exact match, or the 'cpu_count' constraint
+   is not also specified.
 
-:type mem`
+- `type mem`
    positive integer
 
-:param tags`
+- `param tags`
    Tags the machine must match in order to be acquired.
 
-    > If multiple tag names are specified, the machine must be tagged with all
-    > of them. To request multiple tags, this parameter must be repeated in
-    > the request with each value.
+   > If multiple tag names are specified, the machine must be tagged with all
+   > of them. To request multiple tags, this parameter must be repeated in
+   > the request with each value.
 
-:type tags`
+- `type tags`
    unicode (accepts multiple)
 
-:param not_tags`
+- `param not_tags`
    Tags the machine must NOT match.
 
-    > If multiple tag names are specified, the machine must NOT be tagged with
-    > ANY of them. To request exclusion of multiple tags, this parameter must
-    > be repeated in the request with each value.
+   > If multiple tag names are specified, the machine must NOT be tagged with
+   > ANY of them. To request exclusion of multiple tags, this parameter must
+   > be repeated in the request with each value.
 
-:type tags`
+- `type tags`
    unicode (accepts multiple)
 
-:param zone`
+- `param zone`
    Physical zone name the machine must be located in.
 
-:type zone`
+- `type zone`
    unicode
 
-:param not_in_zone`
+- `param not_in_zone`
    List of physical zones from which the machine must
-       not be acquired.
+   not be acquired.
 
-        If multiple zones are specified, the machine must NOT be associated
-        with ANY of them. To request multiple zones to exclude, this parameter
-        must be repeated in the request with each value.
+   If multiple zones are specified, the machine must NOT be associated
+   with ANY of them. To request multiple zones to exclude, this parameter
+   must be repeated in the request with each value.
 
-:type not_in_zone`
+- `type not_in_zone`
    unicode (accepts multiple)
 
-:param pod`
+- `param pod`
    Pod the machine must be located in.
 
-:type pod`
+- `type pod`
    unicode
 
-:param not_pod`
+- `param not_pod`
    Pod the machine must not be located in.
 
-:type not_pod`
+- `type not_pod`
    unicode
 
-:param pod_type`
+- `param pod_type`
    Pod type the machine must be located in.
 
-:type pod_type`
+- `type pod_type`
    unicode
 
-:param not_pod_type`
+- `param not_pod_type`
    Pod type the machine must not be located in.
 
-:type not_pod_type`
+- `type not_pod_type`
    unicode
 
-:param subnets`
+- `param subnets`
    Subnets that must be linked to the machine.
 
-    > "Linked to" means the node must be configured to acquire an address in
-    > the specified subnet, have a static IP address in the specified subnet,
-    > or have been observed to DHCP from the specified subnet during
-    > commissioning time (which implies that it *could* have an address on the
-    > specified subnet).
-    >
-    > Subnets can be specified by one of the following criteria:
-    >
-    > -   &lt;id&gt;: match the subnet by its 'id' field
-    > -   fabric:&lt;fabric-spec&gt;`
+   > "Linked to" means the node must be configured to acquire an address in
+   > the specified subnet, have a static IP address in the specified subnet,
+   > or have been observed to DHCP from the specified subnet during
+   > commissioning time (which implies that it *could* have an address on the
+   > specified subnet).
+   >
+   > Subnets can be specified by one of the following criteria:
+   >
+   > -   &lt;id&gt;: match the subnet by its 'id' field
+   > -   fabric:&lt;fabric-spec&gt;:
 
-    match all subnets in a given fabric.
-       -   ip:&lt;ip-address&gt;`
+   match all subnets in a given fabric.
+   -   ip:&lt;ip-address&gt;:
 
-    Match the subnet containing &lt;ip-address&gt; with
-       the with the longest-prefix match.
+   Match the subnet containing &lt;ip-address&gt; with
+   the with the longest-prefix match.
 
-    > -   name:&lt;subnet-name&gt;`
+   > -   name:&lt;subnet-name&gt;:
 
-    Match a subnet with the given name.
-       -   space:&lt;space-spec&gt;`
+   Match a subnet with the given name.
+   -   space:&lt;space-spec&gt;:
 
-    Match all subnets in a given space.
-       -   vid:&lt;vid-integer&gt;`
+   Match all subnets in a given space.
+   -   vid:&lt;vid-integer&gt;:
 
-    Match a subnet on a VLAN with the specified
-       VID. Valid values range from 0 through 4094 (inclusive). An untagged
-        VLAN can be specified by using the value "0".
+   Match a subnet on a VLAN with the specified
+   VID. Valid values range from 0 through 4094 (inclusive). An untagged
+   VLAN can be specified by using the value "0".
 
-    > -   vlan:&lt;vlan-spec&gt;`
+   > -   vlan:&lt;vlan-spec&gt;:
 
-    Match all subnets on the given VLAN.
+   Match all subnets on the given VLAN.
 
-    > Note that (as of this writing), the 'fabric', 'space', 'vid', and 'vlan'
-    > specifiers are only useful for the 'not_spaces' version of this
-    > constraint, because they will most likely force the query to match ALL
-    > the subnets in each fabric, space, or VLAN, and thus not return any
-    > nodes. (This is not a particularly useful behavior, so may be changed in
-    > the future.)
-    >
-    > If multiple subnets are specified, the machine must be associated with
-    > all of them. To request multiple subnets, this parameter must be
-    > repeated in the request with each value.
-    >
-    > Note that this replaces the leagcy 'networks' constraint in MAAS 1.x.
+   > Note that (as of this writing), the 'fabric', 'space', 'vid', and 'vlan'
+   > specifiers are only useful for the 'not_spaces' version of this
+   > constraint, because they will most likely force the query to match ALL
+   > the subnets in each fabric, space, or VLAN, and thus not return any
+   > nodes. (This is not a particularly useful behavior, so may be changed in
+   > the future.)
+   >
+   > If multiple subnets are specified, the machine must be associated with
+   > all of them. To request multiple subnets, this parameter must be
+   > repeated in the request with each value.
+   >
+   > Note that this replaces the leagcy 'networks' constraint in MAAS 1.x.
 
-:type subnets`
+- `type subnets`
    unicode (accepts multiple)
 
-:param not_subnets`
+- `param not_subnets`
    Subnets that must NOT be linked to the machine.
 
-    > See the 'subnets' constraint documentation above for more information
-    > about how each subnet can be specified.
-    >
-    > If multiple subnets are specified, the machine must NOT be associated
-    > with ANY of them. To request multiple subnets to exclude, this parameter
-    > must be repeated in the request with each value. (Or a fabric, space, or
-    > VLAN specifier may be used to match multiple subnets).
-    >
-    > Note that this replaces the leagcy 'not_networks' constraint in MAAS
-    > 1.x.
+   > See the 'subnets' constraint documentation above for more information
+   > about how each subnet can be specified.
+   >
+   > If multiple subnets are specified, the machine must NOT be associated
+   > with ANY of them. To request multiple subnets to exclude, this parameter
+   > must be repeated in the request with each value. (Or a fabric, space, or
+   > VLAN specifier may be used to match multiple subnets).
+   >
+   > Note that this replaces the leagcy 'not_networks' constraint in MAAS
+   > 1.x.
 
-:type not_subnets`
+- `type not_subnets`
    unicode (accepts multiple)
 
-:param storage`
+- `param storage`
    A list of storage constraint identifiers, in the form:
-       &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+   &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;:
 
 > ...\]
 
-:type storage`
+- `type storage`
    unicode
 
-:param interfaces`
+- `param interfaces`
    A labeled constraint map associating constraint
-       labels with interface properties that should be matched. Returned
-        nodes must have one or more interface matching the specified
-        constraints. The labeled constraint map must be in the format:
-        `<label>:<key>=<value>[,<key2>=<value2>[,...]]`
+   labels with interface properties that should be matched. Returned
+   nodes must have one or more interface matching the specified
+   constraints. The labeled constraint map must be in the format:
+   `<label>:<key>=<value>[,<key2>=<value2>[,...]]`
 
-        Each key can be one of the following:
+   Each key can be one of the following:
 
-        -   id: Matches an interface with the specific id
-        -   fabric: Matches an interface attached to the specified
-            fabric.
-        -   fabric_class: Matches an interface attached to a fabric with
-            the specified class.
-        -   ip: Matches an interface with the specified IP address
-            assigned to it.
-        -   mode: Matches an interface with the specified mode.
-            (Currently, the only supported mode is "unconfigured".)
-        -   name: Matches an interface with the specified name. (For
-            example, "eth0".)
-        -   hostname: Matches an interface attached to the node with the
-            specified hostname.
-        -   subnet: Matches an interface attached to the specified
-            subnet.
-        -   space: Matches an interface attached to the specified space.
-        -   subnet_cidr: Matches an interface attached to the specified
-            subnet CIDR. (For example, "192.168.0.0/24".)
-        -   type: Matches an interface of the specified type. (Valid
-            types: "physical", "vlan", "bond", "bridge", or "unknown".)
-        -   vlan: Matches an interface on the specified VLAN.
-        -   vid: Matches an interface on a VLAN with the specified VID.
-        -   tag: Matches an interface tagged with the specified tag.
+   -   id: Matches an interface with the specific id
+   -   fabric: Matches an interface attached to the specified fabric.
+   -   fabric_class: Matches an interface attached to a fabric with the
+       specified class.
+   -   ip: Matches an interface with the specified IP address assigned to
+       it.
+   -   mode: Matches an interface with the specified mode. (Currently,
+       the only supported mode is "unconfigured".)
+   -   name: Matches an interface with the specified name. (For example,
+       "eth0".)
+   -   hostname: Matches an interface attached to the node with the
+       specified hostname.
+   -   subnet: Matches an interface attached to the specified subnet.
+   -   space: Matches an interface attached to the specified space.
+   -   subnet_cidr: Matches an interface attached to the specified
+       subnet CIDR. (For example, "192.168.0.0/24".)
+   -   type: Matches an interface of the specified type. (Valid types:
+       "physical", "vlan", "bond", "bridge", or "unknown".)
+   -   vlan: Matches an interface on the specified VLAN.
+   -   vid: Matches an interface on a VLAN with the specified VID.
+   -   tag: Matches an interface tagged with the specified tag.
 
-:type interfaces`
+- `type interfaces`
    unicode
 
-:param fabrics`
+- `param fabrics`
    Set of fabrics that the machine must be associated with
-       in order to be acquired.
+   in order to be acquired.
 
-        If multiple fabrics names are specified, the machine can be in any of
-        the specified fabrics. To request multiple possible fabrics to match,
-        this parameter must be repeated in the request with each value.
+   If multiple fabrics names are specified, the machine can be in any of
+   the specified fabrics. To request multiple possible fabrics to match,
+   this parameter must be repeated in the request with each value.
 
-:type fabrics`
+- `type fabrics`
    unicode (accepts multiple)
 
-:param not_fabrics`
+- `param not_fabrics`
    Fabrics the machine must NOT be associated with in
-       order to be acquired.
+   order to be acquired.
 
-        If multiple fabrics names are specified, the machine must NOT be in
-        ANY of them. To request exclusion of multiple fabrics, this parameter
-        must be repeated in the request with each value.
+   If multiple fabrics names are specified, the machine must NOT be in
+   ANY of them. To request exclusion of multiple fabrics, this parameter
+   must be repeated in the request with each value.
 
-:type not_fabrics`
+- `type not_fabrics`
    unicode (accepts multiple)
 
-:param fabric_classes`
+- `param fabric_classes`
    Set of fabric class types whose fabrics the
-       machine must be associated with in order to be acquired.
+   machine must be associated with in order to be acquired.
 
-        If multiple fabrics class types are specified, the machine can be in
-        any matching fabric. To request multiple possible fabrics class types
-        to match, this parameter must be repeated in the request with each
-        value.
+   If multiple fabrics class types are specified, the machine can be in
+   any matching fabric. To request multiple possible fabrics class types
+   to match, this parameter must be repeated in the request with each
+   value.
 
-:type fabric_classes`
+- `type fabric_classes`
    unicode (accepts multiple)
 
-:param not_fabric_classes`
+- `param not_fabric_classes`
    Fabric class types whose fabrics the machine
-       must NOT be associated with in order to be acquired.
+   must NOT be associated with in order to be acquired.
 
-        If multiple fabrics names are specified, the machine must NOT be in
-        ANY of them. To request exclusion of multiple fabrics, this parameter
-        must be repeated in the request with each value.
+   If multiple fabrics names are specified, the machine must NOT be in
+   ANY of them. To request exclusion of multiple fabrics, this parameter
+   must be repeated in the request with each value.
 
-:type not_fabric_classes`
+- `type not_fabric_classes`
    unicode (accepts multiple)
 
-:param agent_name`
+- `param agent_name`
    An optional agent name to attach to the
-       acquired machine.
+   acquired machine.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
-:param bridge_all`
+- `param bridge_all`
    Optionally create a bridge interface for every
-       configured interface on the machine. The created bridges will be
-        removed once the machine is released. (Default: False)
+   configured interface on the machine. The created bridges will be
+   removed once the machine is released. (Default: False)
 
-:type bridge_all`
+- `type bridge_all`
    boolean
 
-:param bridge_stp`
+- `param bridge_stp`
    Optionally turn spanning tree protocol on or off
-       for the bridges created on every configured interface. (Default:
-        off)
+   for the bridges created on every configured interface. (Default: off)
 
-:type bridge_stp`
+- `type bridge_stp`
    boolean
 
-:param bridge_fd`
+- `param bridge_fd`
    Optionally adjust the forward delay to time seconds.
-       (Default: 15)
+   (Default: 15)
 
-:type bridge_fd`
+- `type bridge_fd`
    integer
 
-:param dry_run`
+- `param dry_run`
    Optional boolean to indicate that the machine should
-       not actually be acquired (this is for support/troubleshooting, or
-        users who want to see which machine would match a constraint, without
-        acquiring a machine). Defaults to False.
+   not actually be acquired (this is for support/troubleshooting, or
+   users who want to see which machine would match a constraint, without
+   acquiring a machine). Defaults to False.
 
-:type dry_run`
+- `type dry_run`
    bool
 
-:param verbose`
+- `param verbose`
    Optional boolean to indicate that the user would like
-       additional verbosity in the constraints_by_type field (each
-        constraint will be prefixed by verbose_, and contain the full data
-        structure that indicates which machine(s) matched).
+   additional verbosity in the constraints_by_type field (each
+   constraint will be prefixed by verbose_, and contain the full data
+   structure that indicates which machine(s) matched).
 
-:type verbose`
+- `type verbose`
    bool
 
 Returns 409 if a suitable machine matching the constraints could not be found.
@@ -3884,20 +3877,20 @@ Release multiple machines.
 
 This places the machines back into the pool, ready to be reallocated.
 
-:param machines`
+- `param machines`
    system_ids of the machines which are to be released.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
-:return`
+- `return`
    The system_ids of any machines that have their status
-       changed by this call. Thus, machines that were already released are
-        excluded from the result.
+   changed by this call. Thus, machines that were already released are
+   excluded from the result.
 
 Returns 400 if any of the machines cannot be found. Returns 403 if the user
 does not have permission to release any of the machines. Returns a 409 if any
@@ -3907,13 +3900,13 @@ of the machines could not be released due to their current state.
 
 Assign multiple nodes to a physical zone at once.
 
-:param zone`
+- `param zone`
    Zone name. If omitted, the zone is "none" and the nodes
-       will be taken out of their physical zones.
+   will be taken out of their physical zones.
 
-:param nodes`
+- `param nodes`
    system_ids of the nodes whose zones are to be set.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -3957,26 +3950,26 @@ Update network definition.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-:param name`
+- `param name`
    A simple name for the network, to make it easier to
-       refer to. Must consist only of letters, digits, dashes, and
-        underscores.
+   refer to. Must consist only of letters, digits, dashes, and
+   underscores.
 
-:param ip`
+- `param ip`
    Base IP address for the network, e.g. 10.1.0.0. The host
-       bits will be zeroed.
+   bits will be zeroed.
 
-:param netmask`
+- `param netmask`
    Subnet mask to indicate which parts of an IP address
-       are part of the network address. For example, 255.255.255.0.
+   are part of the network address. For example, 255.255.255.0.
 
-:param vlan_tag`
+- `param vlan_tag`
    Optional VLAN tag: a number between 1 and 0xffe (4094)
-       inclusive, or zero for an untagged network.
+   inclusive, or zero for an untagged network.
 
-:param description`
+- `param description`
    Detailed description of the network for the benefit
-       of users and administrators.
+   of users and administrators.
 
 ### Networks
 
@@ -3988,10 +3981,10 @@ Manage the networks.
 
 List networks.
 
-:param node`
+- `param node`
    Optionally, nodes which must be attached to any returned
-       networks. If more than one node is given, the result will be
-        restricted to networks that these nodes have in common.
+   networks. If more than one node is given, the result will be
+   restricted to networks that these nodes have in common.
 
 ##### `POST /api/2.0/networks/`
 
@@ -4025,8 +4018,8 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
-like "lldp" or "lshw".
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something like
+"lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
 mainly because JSON can't do binary content without applying additional
@@ -4055,25 +4048,25 @@ Read the collection of NodeResult in the MAAS.
 
 List NodeResult visible to the user, optionally filtered.
 
-:param system_id`
+- `param system_id`
    An optional list of system ids. Only the
-       results related to the nodes with these system ids will be returned.
+   results related to the nodes with these system ids will be returned.
 
-:type system_id`
+- `type system_id`
    iterable
 
-:param name`
+- `param name`
    An optional list of names. Only the results
-       with the specified names will be returned.
+   with the specified names will be returned.
 
-:type name`
+- `type name`
    iterable
 
-:param result_type`
+- `param result_type`
    An optional result_type. Only the results
-       with the specified result_type will be returned.
+   with the specified result_type will be returned.
 
-:type name`
+- `type name`
    iterable
 
 ### Node Script
@@ -4088,31 +4081,31 @@ Delete a script.
 
 Return a script's metadata.
 
-:param include_script`
+- `param include_script`
    Include the base64 encoded script content.
 
-:type include_script`
+- `type include_script`
    bool
 
 ##### `GET /api/2.0/scripts/{name} op=download`
 
 Download a script.
 
-:param revision`
+- `param revision`
    What revision to download, latest by default. Can use
-       rev as a shortcut.
+   rev as a shortcut.
 
-:type revision`
+- `type revision`
    integer
 
 ##### `POST /api/2.0/scripts/{name} op=add_tag`
 
 Add a single tag to a script.
 
-:param tag`
+- `param tag`
    The tag being added.
 
-:type tag`
+- `type tag`
    unicode
 
 Returns 404 if the script is not found.
@@ -4121,10 +4114,10 @@ Returns 404 if the script is not found.
 
 Remove a single tag to a script.
 
-:param tag`
+- `param tag`
    The tag being removed.
 
-:type tag`
+- `type tag`
    unicode
 
 Returns 404 if the script is not found.
@@ -4133,11 +4126,11 @@ Returns 404 if the script is not found.
 
 Revert a script to an earlier version.
 
-:param to`
+- `param to`
    What revision in the script's history to revert to. This can
-       either be an ID or a negative number representing how far back to go.
+   either be an ID or a negative number representing how far back to go.
 
-:type to`
+- `type to`
    integer
 
 Returns 404 if the script is not found.
@@ -4146,110 +4139,109 @@ Returns 404 if the script is not found.
 
 Update a commissioning script.
 
-:param name`
+- `param name`
    The name of the script.
 
-:type name`
+- `type name`
    unicode
 
-:param title`
+- `param title`
    The title of the script.
 
-:type title`
+- `type title`
    unicode
 
-:param description`
+- `param description`
    A description of what the script does.
 
-:type description`
+- `type description`
    unicode
 
-:param tags`
+- `param tags`
    A comma seperated list of tags for this script.
 
-:type tags`
+- `type tags`
    unicode
 
-:param type`
+- `param type`
    The type defines when the script should be used. Can be
-       testing or commissioning, defaults to testing.
+   testing or commissioning, defaults to testing.
 
-:type script_type`
+- `type script_type`
    unicode
 
-:param hardware_type`
+- `param hardware_type`
    The hardware_type defines what type of hardware
-       the script is assoicated with. May be CPU, memory, storage, or node.
+   the script is assoicated with. May be CPU, memory, storage, or node.
 
-:type hardware_type`
+- `type hardware_type`
    unicode
 
-:param parallel`
+- `param parallel`
    Whether the script may be run in parallel with other
-       scripts. May be disabled to run by itself, instance to run along
-        scripts with the same name, or any to run along any script.
+   scripts. May be disabled to run by itself, instance to run along
+   scripts with the same name, or any to run along any script.
 
-:type parallel`
+- `type parallel`
    unicode
 
-:param timeout`
+- `param timeout`
    How long the script is allowed to run before failing.
-       0 gives unlimited time, defaults to 0.
+   0 gives unlimited time, defaults to 0.
 
-:type timeout`
+- `type timeout`
    unicode
 
-:param timeout`
+- `param timeout`
    How long the script is allowed to run before failing.
-       0 gives unlimited time, defaults to 0.
+   0 gives unlimited time, defaults to 0.
 
-:type timeout`
+- `type timeout`
    unicode
 
-:param destructive`
+- `param destructive`
    Whether or not the script overwrites data on any
-       drive on the running system. Destructive scripts can not be run on
-        deployed systems. Defaults to false.
+   drive on the running system. Destructive scripts can not be run on
+   deployed systems. Defaults to false.
 
-:type destructive`
+- `type destructive`
    boolean
 
-:param script`
+- `param script`
    The content of the script to be uploaded in binary form.
-       note: this is not a normal parameter, but a file upload. Its
-        filename is ignored; MAAS will know it by the name you pass to the
-        request. Optionally you can ignore the name and script parameter in
-        favor of uploading a single file as part of the request.
+   note: this is not a normal parameter, but a file upload. Its filename
+   is ignored; MAAS will know it by the name you pass to the request.
+   Optionally you can ignore the name and script parameter in favor of
+   uploading a single file as part of the request.
 
-:param comment`
+- `param comment`
    A comment about what this change does.
 
-:type comment`
+- `type comment`
    unicode
 
-:param for_hardware`
+- `param for_hardware`
    A list of modalias, PCI IDs, and/or USB IDs the
-       script will automatically run on. Must start with modalias:,
-        pci:
+   script will automatically run on. Must start with modalias:, pci:
 
 ,
    or usb:.
 
-:type for_hardware`
+- `type for_hardware`
    unicode
 
-:param may_reboot`
+- `param may_reboot`
    Whether or not the script may reboot the system
-       while running.
+   while running.
 
-:type may_reboot`
+- `type may_reboot`
    boolean
 
-:param recommission`
+- `param recommission`
    Whether builtin commissioning scripts should be
-       rerun after successfully running this scripts.
+   rerun after successfully running this scripts.
 
-:type recommission`
+- `type recommission`
    boolean
 
 ### Node Script Result
@@ -4270,24 +4262,24 @@ View a specific set of results.
 id can either by the script set id, current-commissioning, current-testing, or
 current-installation.
 
-:param hardware_type`
+- `param hardware_type`
    Only return scripts for the given hardware type.
-       Can be node, cpu, memory, or storage. Defaults to all.
+   Can be node, cpu, memory, or storage. Defaults to all.
 
-:type script_type`
+- `type script_type`
    unicode
 
-:param include_output`
+- `param include_output`
    Include base64 encoded output from the script.
 
-:type include_output`
+- `type include_output`
    bool
 
-:param filters`
+- `param filters`
    A comma seperated list to show only results that ran
-       with a script name, tag, or id.
+   with a script name, tag, or id.
 
-:type filters`
+- `type filters`
    unicode
 
 ##### `GET /api/2.0/nodes/{system_id}/results/{id}/ op=download`
@@ -4297,31 +4289,31 @@ Download a compressed tar containing all results.
 id can either by the script set id, current-commissioning, current-testing, or
 current-installation.
 
-:param hardware_type`
+- `param hardware_type`
    Only return scripts for the given hardware type.
-       Can be node, cpu, memory, or storage. Defaults to all.
+   Can be node, cpu, memory, or storage. Defaults to all.
 
-:type script_type`
+- `type script_type`
    unicode
 
-:param filters`
+- `param filters`
    A comma seperated list to show only results that ran
-       with a script name or tag.
+   with a script name or tag.
 
-:type filters`
+- `type filters`
    unicode
 
-:param output`
+- `param output`
    Can be either combined, stdout, stderr, or all. By
-       default only the combined output is returned.
+   default only the combined output is returned.
 
-:type output`
+- `type output`
    unicode
 
-:param filetype`
+- `param filetype`
    Filetype to output, can be txt or tar.xz
 
-:type format`
+- `type format`
    unicode
 
 ### Node Script Result
@@ -4332,31 +4324,31 @@ Manage node script results.
 
 Return a list of script results grouped by run.
 
-:param type`
+- `param type`
    Only return scripts with the given type. This can be
-       commissioning, testing, or installion. Defaults to showing all.
+   commissioning, testing, or installion. Defaults to showing all.
 
-:type type`
+- `type type`
    unicode
 
-:param hardware_type`
+- `param hardware_type`
    Only return scripts for the given hardware type.
-       Can be node, cpu, memory, or storage. Defaults to all.
+   Can be node, cpu, memory, or storage. Defaults to all.
 
-:type script_type`
+- `type script_type`
    unicode
 
-:param include_output`
+- `param include_output`
    Include base64 encoded output from the script.
 
-:type include_output`
+- `type include_output`
    bool
 
-:param filters`
+- `param filters`
    A comma seperated list to show only results
-       with a script name or tag.
+   with a script name or tag.
 
-:type filters`
+- `type filters`
    unicode
 
 ### Node Scripts
@@ -4369,137 +4361,136 @@ Manage custom scripts.
 
 Return a list of stored scripts.
 
-:param type`
+- `param type`
    Only return scripts with the given type. This can be
-       testing or commissioning. Defaults to showing both.
+   testing or commissioning. Defaults to showing both.
 
-:type type`
+- `type type`
    unicode
 
-:param hardware_type`
+- `param hardware_type`
    Only return scripts for the given hardware type.
-       Can be node, cpu, memory, or storage. Defaults to all.
+   Can be node, cpu, memory, or storage. Defaults to all.
 
-:type hardware_type`
+- `type hardware_type`
    unicode
 
-:param include_script`
+- `param include_script`
    Include the base64 encoded script content.
 
-:type include_script`
+- `type include_script`
    bool
 
-:param filters`
+- `param filters`
    A comma seperated list to show only results
-       with a script name or tag.
+   with a script name or tag.
 
-:type filters`
+- `type filters`
    unicode
 
 ##### `POST /api/2.0/scripts/`
 
 Create a new script.
 
-:param name`
+- `param name`
    The name of the script.
 
-:type name`
+- `type name`
    unicode
 
-:param title`
+- `param title`
    The title of the script.
 
-:type title`
+- `type title`
    unicode
 
-:param description`
+- `param description`
    A description of what the script does.
 
-:type description`
+- `type description`
    unicode
 
-:param tags`
+- `param tags`
    A comma seperated list of tags for this script.
 
-:type tags`
+- `type tags`
    unicode
 
-:param type`
+- `param type`
    The script_type defines when the script should be used.
-       Can be testing or commissioning, defaults to testing.
+   Can be testing or commissioning, defaults to testing.
 
-:type script_type`
+- `type script_type`
    unicode
 
-:param hardware_type`
+- `param hardware_type`
    The hardware_type defines what type of hardware
-       the script is assoicated with. May be CPU, memory, storage, or node.
+   the script is assoicated with. May be CPU, memory, storage, or node.
 
-:type hardware_type`
+- `type hardware_type`
    unicode
 
-:param parallel`
+- `param parallel`
    Whether the script may be run in parallel with other
-       scripts. May be disabled to run by itself, instance to run along
-        scripts with the same name, or any to run along any script.
+   scripts. May be disabled to run by itself, instance to run along
+   scripts with the same name, or any to run along any script.
 
-:type parallel`
+- `type parallel`
    unicode
 
-:param timeout`
+- `param timeout`
    How long the script is allowed to run before failing.
-       0 gives unlimited time, defaults to 0.
+   0 gives unlimited time, defaults to 0.
 
-:type timeout`
+- `type timeout`
    unicode
 
-:param destructive`
+- `param destructive`
    Whether or not the script overwrites data on any
-       drive on the running system. Destructive scripts can not be run on
-        deployed systems. Defaults to false.
+   drive on the running system. Destructive scripts can not be run on
+   deployed systems. Defaults to false.
 
-:type destructive`
+- `type destructive`
    boolean
 
-:param script`
+- `param script`
    The content of the script to be uploaded in binary form.
-       note: this is not a normal parameter, but a file upload. Its
-        filename is ignored; MAAS will know it by the name you pass to the
-        request. Optionally you can ignore the name and script parameter in
-        favor of uploading a single file as part of the request.
+   note: this is not a normal parameter, but a file upload. Its filename
+   is ignored; MAAS will know it by the name you pass to the request.
+   Optionally you can ignore the name and script parameter in favor of
+   uploading a single file as part of the request.
 
-:type script`
+- `type script`
    unicode
 
-:param comment`
+- `param comment`
    A comment about what this change does.
 
-:type comment`
+- `type comment`
    unicode
 
-:param for_hardware`
+- `param for_hardware`
    A list of modalias, PCI IDs, and/or USB IDs the
-       script will automatically run on. Must start with modalias:,
-        pci:
+   script will automatically run on. Must start with modalias:, pci:
 
 ,
    or usb:.
 
-:type for_hardware`
+- `type for_hardware`
    unicode
 
-:param may_reboot`
+- `param may_reboot`
    Whether or not the script may reboot the system
-       while running.
+   while running.
 
-:type may_reboot`
+- `type may_reboot`
    boolean
 
-:param recommission`
+- `param recommission`
    Whether builtin commissioning scripts should be
-       rerun after successfully running this scripts.
+   rerun after successfully running this scripts.
 
-:type recommission`
+- `type recommission`
    boolean
 
 ### Nodes
@@ -4512,48 +4503,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only nodes relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to see multiple nodes.
+   with the matching hostname will be returned. This can be specified
+   multiple times to see multiple nodes.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param mac_address`
+- `param mac_address`
    An optional MAC address. Only nodes relating to the
-       node owning the specified MAC address will be returned. This can be
-        specified multiple times to see multiple nodes.
+   node owning the specified MAC address will be returned. This can be
+   specified multiple times to see multiple nodes.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes relating to the
-       nodes with matching system ids will be returned.
+   nodes with matching system ids will be returned.
 
-:type id`
+- `type id`
    unicode
 
-:param domain`
+- `param domain`
    An optional name for a dns domain. Only nodes relating
-       to the nodes in the domain will be returned.
+   to the nodes in the domain will be returned.
 
-:type domain`
+- `type domain`
    unicode
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes relating
-       to the nodes in the zone will be returned.
+   to the nodes in the zone will be returned.
 
-:type zone`
+- `type zone`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes relating to the
-       nodes with matching agent names will be returned.
+   nodes with matching agent names will be returned.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
 ##### `GET /api/2.0/nodes/ op=is_registered`
@@ -4561,16 +4552,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-:param mac_address`
+- `param mac_address`
    The mac address to be checked.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:return`
+- `return`
    'true' or 'false'.
 
-:rtype`
+- `rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -4579,13 +4570,13 @@ Returns 400 if any mandatory parameters are missing.
 
 Assign multiple nodes to a physical zone at once.
 
-:param zone`
+- `param zone`
    Zone name. If omitted, the zone is "none" and the nodes
-       will be taken out of their physical zones.
+   will be taken out of their physical zones.
 
-:param nodes`
+- `param nodes`
    system_ids of the nodes whose zones are to be set.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -4632,36 +4623,36 @@ Create a notification.
 
 This is available to admins *only*.
 
-:param message`
+- `param message`
    The message for this notification. May contain basic
-       HTML; this will be sanitised before display.
+   HTML; this will be sanitised before display.
 
-:param context`
+- `param context`
    Optional JSON context. The root object *must* be an
-       object (i.e. a mapping). The values herein can be referenced by
-        message with Python's "format" (not %) codes.
+   object (i.e. a mapping). The values herein can be referenced by
+   message with Python's "format" (not %) codes.
 
-:param category`
+- `param category`
    Optional category. Choose from: error, warning,
-       success, or info. Defaults to info.
+   success, or info. Defaults to info.
 
-:param ident`
+- `param ident`
    Optional unique identifier for this notification.
 
-:param user`
+- `param user`
    Optional user ID this notification is intended for. By
-       default it will not be targeted to any individual user.
+   default it will not be targeted to any individual user.
 
-:param users`
+- `param users`
    Optional boolean, true to notify all users, defaults to
-       false, i.e. not targeted to all users.
+   false, i.e. not targeted to all users.
 
-:param admins`
+- `param admins`
    Optional boolean, true to notify all admins, defaults to
-       false, i.e. not targeted to all admins.
+   false, i.e. not targeted to all admins.
 
-Note: if neither user nor users nor admins is set, the notification will
-not be seen by anyone.
+Note: if neither user nor users nor admins is set, the notification will not
+be seen by anyone.
 
 ### Package Repositories
 
@@ -4675,48 +4666,48 @@ List all Package Repositories.
 
 Create a Package Repository.
 
-:param name`
+- `param name`
    The name of the Package Repository.
 
-:type name`
+- `type name`
    unicode
 
-:param url`
+- `param url`
    The url of the Package Repository.
 
-:type url`
+- `type url`
    unicode
 
-:param distributions`
+- `param distributions`
    Which package distributions to include.
 
-:type distributions`
+- `type distributions`
    unicode
 
-:param disabled_pockets`
+- `param disabled_pockets`
    The list of pockets to disable.
 
-:param disabled_components`
+- `param disabled_components`
    The list of components to disable. Only
-       applicable to the default Ubuntu repositories.
+   applicable to the default Ubuntu repositories.
 
-:param components`
+- `param components`
    The list of components to enable. Only applicable
-       to custom repositories.
+   to custom repositories.
 
-:param arches`
+- `param arches`
    The list of supported architectures.
 
-:param key`
+- `param key`
    The authentication key to use with the repository.
 
-:type key`
+- `type key`
    unicode
 
-:param enabled`
+- `param enabled`
    Whether or not the repository is enabled.
 
-:type enabled`
+- `type enabled`
    boolean
 
 ### Package Repository
@@ -4741,48 +4732,48 @@ Returns 404 if the repository is not found.
 
 Update a Package Repository.
 
-:param name`
+- `param name`
    The name of the Package Repository.
 
-:type name`
+- `type name`
    unicode
 
-:param url`
+- `param url`
    The url of the Package Repository.
 
-:type url`
+- `type url`
    unicode
 
-:param distributions`
+- `param distributions`
    Which package distributions to include.
 
-:type distributions`
+- `type distributions`
    unicode
 
-:param disabled_pockets`
+- `param disabled_pockets`
    The list of pockets to disable.
 
-:param disabled_components`
+- `param disabled_components`
    The list of components to disable. Only
-       applicable to the default Ubuntu repositories.
+   applicable to the default Ubuntu repositories.
 
-:param components`
+- `param components`
    The list of components to enable. Only applicable
-       to custom repositories.
+   to custom repositories.
 
-:param arches`
+- `param arches`
    The list of supported architectures.
 
-:param key`
+- `param key`
    The authentication key to use with the repository.
 
-:type key`
+- `type key`
    unicode
 
-:param enabled`
+- `param enabled`
    Whether or not the repository is enabled.
 
-:type enabled`
+- `type enabled`
    boolean
 
 Returns 404 if the Package Repository is not found.
@@ -4807,13 +4798,13 @@ Returns 404 if the node, block device, or partition are not found.
 
 Format a partition.
 
-:param fstype`
+- `param fstype`
    Type of filesystem.
 
-:param uuid`
+- `param uuid`
    The UUID for the filesystem.
 
-:param label`
+- `param label`
    The label for the filesystem.
 
 Returns 403 when the user doesn't have the ability to format the partition.
@@ -4823,10 +4814,10 @@ Returns 404 if the node, block device, or partition is not found.
 
 Mount the filesystem on partition.
 
-:param mount_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-:param mount_options`
+- `param mount_options`
    Options to pass to mount(8).
 
 Returns 403 when the user doesn't have the ability to mount the partition.
@@ -4858,15 +4849,15 @@ Returns 404 if the node or the block device are not found.
 
 Create a partition on the block device.
 
-:param size`
+- `param size`
    The size of the partition. If not specified, all
-       available space will be used.
+   available space will be used.
 
-:param uuid`
+- `param uuid`
    UUID for the partition. Only used if the partition table
-       type for the block device is GPT.
+   type for the block device is GPT.
 
-:param bootable`
+- `param bootable`
    If the partition should be marked bootable.
 
 Returns 404 if the node or the block device are not found.
@@ -4903,7 +4894,7 @@ Returns 404 if the pod is not found.
 
 Add a tag to Pod.
 
-:param tag`
+- `param tag`
    The tag being added.
 
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
@@ -4915,38 +4906,38 @@ Compose a machine from Pod.
 
 All fields below are optional:
 
-:param cores`
+- `param cores`
    Minimum number of CPU cores.
 
-:param memory`
+- `param memory`
    Minimum amount of memory (MiB).
 
-:param cpu_speed`
+- `param cpu_speed`
    Minimum amount of CPU speed (MHz).
 
-:param architecture`
+- `param architecture`
    Architecture for the machine. Must be an
-       architecture that the pod supports.
+   architecture that the pod supports.
 
-:param storage`
+- `param storage`
    A list of storage constraint identifiers, in the form:
-       &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+   &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;:
 
 > ...\]
 
-:type storage`
+- `type storage`
    unicode
 
-:param hostname`
+- `param hostname`
    Hostname for the newly composed machine.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param domain`
+- `param domain`
    ID of domain to place the newly composed machine in.
 
-:param zone`
+- `param zone`
    ID of zone place the newly composed machine in.
 
 Returns 404 if the pod is not found. Returns 403 if the user does not have
@@ -4966,7 +4957,7 @@ permission to refresh the pod.
 
 Remove a tag from Pod.
 
-:param tag`
+- `param tag`
    The tag being removed.
 
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
@@ -4976,11 +4967,11 @@ update the Pod.
 
 Update a specific Pod.
 
-:param name`
+- `param name`
    Name for the pod (optional).
 
-Note: 'type' cannot be updated on a Pod. The Pod must be deleted and
-re-added to change the type.
+Note: 'type' cannot be updated on a Pod. The Pod must be deleted and re-added
+to change the type.
 
 Returns 404 if the pod is not found. Returns 403 if the user does not have
 permission to update the pod.
@@ -4999,16 +4990,16 @@ Get a listing of all the pods.
 
 Create a Pod.
 
-:param type`
+- `param type`
    Type of pod to create (rsd, virsh).
 
-:param name`
+- `param name`
    Name for the pod (optional).
 
-:param zone`
+- `param zone`
    Name of the zone for the pod (optional).
 
-:param tags`
+- `param tags`
    A tag or tags (separated by comma) for the pod.
 
 Returns 503 if the pod could not be discovered. Returns 404 if the pod is not
@@ -5040,8 +5031,8 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
-like "lldp" or "lshw".
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something like
+"lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
 mainly because JSON can't do binary content without applying additional
@@ -5080,12 +5071,12 @@ state. The reply to this could be delayed by up to 30 seconds while waiting
 for the power controller to respond. Use this method sparingly as it ties up
 an appserver thread while waiting.
 
-:param system_id`
+- `param system_id`
    The node to query.
 
-:return`
+- `return`
    a dict whose key is "state" with a value of one of
-       'on' or 'off'.
+   'on' or 'off'.
 
 Returns 404 if the node is not found. Returns node's power state.
 
@@ -5093,10 +5084,10 @@ Returns 404 if the node is not found. Returns node's power state.
 
 Abort a node's current operation.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the node could not be found. Returns 403 if the user does not
@@ -5112,10 +5103,10 @@ Returns 404 if the rack controller is not found.
 
 Ignore failed tests and put node back into a usable state.
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -5125,22 +5116,22 @@ permission to ignore tests for the node.
 
 Power off a node.
 
-:param stop_mode`
+- `param stop_mode`
    An optional power off mode. If 'soft',
-       perform a soft power down if the node's power type supports it,
-        otherwise perform a hard power off. For all values other than 'soft',
-        and by default, perform a hard power off. A soft power off generally
-        asks the OS to shutdown the system gracefully before powering off,
-        while a hard power off occurs immediately without any warning to the
-        OS.
+   perform a soft power down if the node's power type supports it,
+   otherwise perform a hard power off. For all values other than 'soft',
+   and by default, perform a hard power off. A soft power off generally
+   asks the OS to shutdown the system gracefully before powering off,
+   while a hard power off occurs immediately without any warning to the
+   OS.
 
-:type stop_mode`
+- `type stop_mode`
    unicode
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -5150,17 +5141,17 @@ permission to stop the node.
 
 Turn on a node.
 
-:param user_data`
+- `param user_data`
    If present, this blob of user-data to be made
-       available to the nodes through the metadata service.
+   available to the nodes through the metadata service.
 
-:type user_data`
+- `type user_data`
    base64-encoded unicode
 
-:param comment`
+- `param comment`
    Optional comment for the event log.
 
-:type comment`
+- `type comment`
    unicode
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -5176,19 +5167,19 @@ relevant cluster interface.
 
 Begin testing process for a node.
 
-:param enable_ssh`
+- `param enable_ssh`
    Whether to enable SSH for the testing environment
-       using the user's SSH key(s).
+   using the user's SSH key(s).
 
-:type enable_ssh`
+- `type enable_ssh`
    bool ('0' for False, '1' for True)
 
-:param testing_scripts`
+- `param testing_scripts`
    A comma seperated list of testing script names
-       and tags to be run. By default all tests tagged 'commissioning' will
-        be run.
+   and tags to be run. By default all tests tagged 'commissioning' will
+   be run.
 
-:type testing_scripts`
+- `type testing_scripts`
    string
 
 A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
@@ -5203,39 +5194,39 @@ Returns 404 if the node is not found.
 
 Update a specific Rack controller.
 
-:param power_type`
+- `param power_type`
    The new power type for this rack controller. If you
-       use the default value, power_parameters will be set to the empty
-        string. Available to admin users. See the [Power types]() section for
-        a list of the available power types.
+   use the default value, power_parameters will be set to the empty
+   string. Available to admin users. See the [Power types]() section for
+   a list of the available power types.
 
-:type power_type`
+- `type power_type`
    unicode
 
-:param [power_parameters](){param1}`
+- `param power_parameters_{param1}`
    The new value for the 'param1'
-       power parameter. Note that this is dynamic as the available parameters
-        depend on the selected value of the rack controller's power_type.
-        Available to admin users. See the [Power types]() section for a list
-        of the available power parameters for each power type.
+   power parameter. Note that this is dynamic as the available parameters
+   depend on the selected value of the rack controller's power_type.
+   Available to admin users. See the [Power types]() section for a list
+   of the available power parameters for each power type.
 
-:type [power_parameters](){param1}`
+- `type power_parameters_{param1}`
    unicode
 
-:param power_parameters_skip_check`
+- `param power_parameters_skip_check`
    Whether or not the new power
-       parameters for this rack controller should be checked against the
-        expected power parameters for the rack controller's power type ('true'
-        or 'false'). The default is 'false'.
+   parameters for this rack controller should be checked against the
+   expected power parameters for the rack controller's power type ('true'
+   or 'false'). The default is 'false'.
 
-:type power_parameters_skip_check`
+- `type power_parameters_skip_check`
    unicode
 
-:param zone`
+- `param zone`
    Name of a valid physical zone in which to place this
-       rack controller.
+   rack controller.
 
-:type zone`
+- `type zone`
    unicode
 
 Returns 404 if the rack controller is not found. Returns 403 if the user does
@@ -5251,55 +5242,55 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only nodes relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to see multiple nodes.
+   with the matching hostname will be returned. This can be specified
+   multiple times to see multiple nodes.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param mac_address`
+- `param mac_address`
    An optional MAC address. Only nodes relating to the
-       node owning the specified MAC address will be returned. This can be
-        specified multiple times to see multiple nodes.
+   node owning the specified MAC address will be returned. This can be
+   specified multiple times to see multiple nodes.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes relating to the
-       nodes with matching system ids will be returned.
+   nodes with matching system ids will be returned.
 
-:type id`
+- `type id`
    unicode
 
-:param domain`
+- `param domain`
    An optional name for a dns domain. Only nodes relating
-       to the nodes in the domain will be returned.
+   to the nodes in the domain will be returned.
 
-:type domain`
+- `type domain`
    unicode
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes relating
-       to the nodes in the zone will be returned.
+   to the nodes in the zone will be returned.
 
-:type zone`
+- `type zone`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes relating to the
-       nodes with matching agent names will be returned.
+   nodes with matching agent names will be returned.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
 ##### `GET /api/2.0/rackcontrollers/ op=describe_power_types`
 
 Query all of the rack controllers for power information.
 
-:return`
+- `return`
    a list of dicts that describe the power types in this format.
 
 ##### `GET /api/2.0/rackcontrollers/ op=is_registered`
@@ -5307,16 +5298,16 @@ Query all of the rack controllers for power information.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-:param mac_address`
+- `param mac_address`
    The mac address to be checked.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:return`
+- `return`
    'true' or 'false'.
 
-:rtype`
+- `rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -5325,14 +5316,14 @@ Returns 400 if any mandatory parameters are missing.
 
 Retrieve power parameters for multiple machines.
 
-:param id`
+- `param id`
    An optional list of system ids. Only machines with
-       matching system ids will be returned.
+   matching system ids will be returned.
 
-:type id`
+- `type id`
    iterable
 
-:return`
+- `return`
    A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
@@ -5345,13 +5336,13 @@ Import the boot images on all rack controllers.
 
 Assign multiple nodes to a physical zone at once.
 
-:param zone`
+- `param zone`
    Zone name. If omitted, the zone is "none" and the nodes
-       will be taken out of their physical zones.
+   will be taken out of their physical zones.
 
-:param nodes`
+- `param nodes`
    system_ids of the nodes whose zones are to be set.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -5376,37 +5367,37 @@ Returns 404 if the machine or RAID is not found.
 
 Update RAID on a machine.
 
-:param name`
+- `param name`
    Name of the RAID.
 
-:param uuid`
+- `param uuid`
    UUID of the RAID.
 
-:param add_block_devices`
+- `param add_block_devices`
    Block devices to add to the RAID.
 
-:param remove_block_devices`
+- `param remove_block_devices`
    Block devices to remove from the RAID.
 
-:param add_spare_devices`
+- `param add_spare_devices`
    Spare block devices to add to the RAID.
 
-:param remove_spare_devices`
+- `param remove_spare_devices`
    Spare block devices to remove
-       from the RAID.
+   from the RAID.
 
-:param add_partitions`
+- `param add_partitions`
    Partitions to add to the RAID.
 
-:param remove_partitions`
+- `param remove_partitions`
    Partitions to remove from the RAID.
 
-:param add_spare_partitions`
+- `param add_spare_partitions`
    Spare partitions to add to the RAID.
 
-:param remove_spare_partitions`
+- `param remove_spare_partitions`
    Spare partitions to remove from the
-       RAID.
+   RAID.
 
 Returns 404 if the machine or RAID is not found. Returns 409 if the machine is
 not Ready.
@@ -5425,25 +5416,25 @@ Returns 404 if the machine is not found.
 
 Creates a RAID
 
-:param name`
+- `param name`
    Name of the RAID.
 
-:param uuid`
+- `param uuid`
    UUID of the RAID.
 
-:param level`
+- `param level`
    RAID level.
 
-:param block_devices`
+- `param block_devices`
    Block devices to add to the RAID.
 
-:param spare_devices`
+- `param spare_devices`
    Spare block devices to add to the RAID.
 
-:param partitions`
+- `param partitions`
    Partitions to add to the RAID.
 
-:param spare_partitions`
+- `param spare_partitions`
    Spare partitions to add to the RAID.
 
 Returns 404 if the machine is not found. Returns 409 if the machine is not
@@ -5475,8 +5466,8 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
-like "lldp" or "lshw".
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something like
+"lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
 mainly because JSON can't do binary content without applying additional
@@ -5501,39 +5492,39 @@ Returns 404 if the node is not found.
 
 Update a specific Region controller.
 
-:param power_type`
+- `param power_type`
    The new power type for this region controller. If
-       you use the default value, power_parameters will be set to the empty
-        string. Available to admin users. See the [Power types]() section for
-        a list of the available power types.
+   you use the default value, power_parameters will be set to the empty
+   string. Available to admin users. See the [Power types]() section for
+   a list of the available power types.
 
-:type power_type`
+- `type power_type`
    unicode
 
-:param [power_parameters](){param1}`
+- `param power_parameters_{param1}`
    The new value for the 'param1'
-       power parameter. Note that this is dynamic as the available parameters
-        depend on the selected value of the region controller's power_type.
-        Available to admin users. See the [Power types]() section for a list
-        of the available power parameters for each power type.
+   power parameter. Note that this is dynamic as the available parameters
+   depend on the selected value of the region controller's power_type.
+   Available to admin users. See the [Power types]() section for a list
+   of the available power parameters for each power type.
 
-:type [power_parameters](){param1}`
+- `type power_parameters_{param1}`
    unicode
 
-:param power_parameters_skip_check`
+- `param power_parameters_skip_check`
    Whether or not the new power
-       parameters for this region controller should be checked against the
-        expected power parameters for the region controller's power type
-        ('true' or 'false'). The default is 'false'.
+   parameters for this region controller should be checked against the
+   expected power parameters for the region controller's power type
+   ('true' or 'false'). The default is 'false'.
 
-:type power_parameters_skip_check`
+- `type power_parameters_skip_check`
    unicode
 
-:param zone`
+- `param zone`
    Name of a valid physical zone in which to place this
-       region controller.
+   region controller.
 
-:type zone`
+- `type zone`
    unicode
 
 Returns 404 if the region controller is not found. Returns 403 if the user
@@ -5549,48 +5540,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-:param hostname`
+- `param hostname`
    An optional hostname. Only nodes relating to the node
-       with the matching hostname will be returned. This can be specified
-        multiple times to see multiple nodes.
+   with the matching hostname will be returned. This can be specified
+   multiple times to see multiple nodes.
 
-:type hostname`
+- `type hostname`
    unicode
 
-:param mac_address`
+- `param mac_address`
    An optional MAC address. Only nodes relating to the
-       node owning the specified MAC address will be returned. This can be
-        specified multiple times to see multiple nodes.
+   node owning the specified MAC address will be returned. This can be
+   specified multiple times to see multiple nodes.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:param id`
+- `param id`
    An optional list of system ids. Only nodes relating to the
-       nodes with matching system ids will be returned.
+   nodes with matching system ids will be returned.
 
-:type id`
+- `type id`
    unicode
 
-:param domain`
+- `param domain`
    An optional name for a dns domain. Only nodes relating
-       to the nodes in the domain will be returned.
+   to the nodes in the domain will be returned.
 
-:type domain`
+- `type domain`
    unicode
 
-:param zone`
+- `param zone`
    An optional name for a physical zone. Only nodes relating
-       to the nodes in the zone will be returned.
+   to the nodes in the zone will be returned.
 
-:type zone`
+- `type zone`
    unicode
 
-:param agent_name`
+- `param agent_name`
    An optional agent name. Only nodes relating to the
-       nodes with matching agent names will be returned.
+   nodes with matching agent names will be returned.
 
-:type agent_name`
+- `type agent_name`
    unicode
 
 ##### `GET /api/2.0/regioncontrollers/ op=is_registered`
@@ -5598,16 +5589,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-:param mac_address`
+- `param mac_address`
    The mac address to be checked.
 
-:type mac_address`
+- `type mac_address`
    unicode
 
-:return`
+- `return`
    'true' or 'false'.
 
-:rtype`
+- `rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -5616,13 +5607,13 @@ Returns 400 if any mandatory parameters are missing.
 
 Assign multiple nodes to a physical zone at once.
 
-:param zone`
+- `param zone`
    Zone name. If omitted, the zone is "none" and the nodes
-       will be taken out of their physical zones.
+   will be taken out of their physical zones.
 
-:param nodes`
+- `param nodes`
    system_ids of the nodes whose zones are to be set.
-       (An empty list is acceptable).
+   (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -5664,8 +5655,8 @@ name is "key".
 
 Import the requesting user's SSH keys.
 
-Import SSH keys for a given protocol and authorization ID in
-protocol:auth_id format.
+Import SSH keys for a given protocol and authorization ID in protocol:auth_id
+format.
 
 ### SSL Key
 
@@ -5722,10 +5713,10 @@ Returns 404 if the space is not found.
 
 Update space.
 
-:param name`
+- `param name`
    Name of the space.
 
-:param description`
+- `param description`
    Description of the space.
 
 Returns 404 if the space is not found.
@@ -5742,10 +5733,10 @@ List all spaces.
 
 Create a space.
 
-:param name`
+- `param name`
    Name of the space.
 
-:param description`
+- `param description`
    Description of the space.
 
 ### Static route
@@ -5768,16 +5759,16 @@ Returns 404 if the static route is not found.
 
 Update static route.
 
-:param source`
+- `param source`
    Source subnet for the route.
 
-:param destination`
+- `param destination`
    Destination subnet for the route.
 
-:param gateway_ip`
+- `param gateway_ip`
    IP address of the gateway on the source subnet.
 
-:param metric`
+- `param metric`
    Weight of the route on a deployed machine.
 
 Returns 404 if the static route is not found.
@@ -5794,16 +5785,16 @@ List all static routes.
 
 Create a static route.
 
-:param source`
+- `param source`
    Source subnet for the route.
 
-:param destination`
+- `param destination`
    Destination subnet for the route.
 
-:param gateway_ip`
+- `param gateway_ip`
    IP address of the gateway on the source subnet.
 
-:param metric`
+- `param metric`
    Weight of the route on a deployed machine.
 
 ### Subnet
@@ -5830,11 +5821,11 @@ Returns a summary of IP addresses assigned to this subnet.
 
 with_username
    If False, suppresses the display of usernames associated with each
-    address. (Default: True)
+   address. (Default: True)
 
 with_summary
    If False, suppresses the display of nodes, BMCs, and and DNS records
-    associated with each address. (Default: True)
+   associated with each address. (Default: True)
 
 with_node_summary
    Deprecated form of with_summary.
@@ -5849,12 +5840,11 @@ Returns 404 if the subnet is not found.
 
 Returns statistics for the specified subnet, including:
 
-num_available: the number of available IP addresses
-largest_available: the largest number of contiguous free IP addresses
-num_unavailable: the number of unavailable IP addresses
-total_addresses: the sum of the available plus unavailable addresses
-usage: the (floating point) usage percentage of this subnet
-usage_string: the (formatted unicode) usage percentage of this subnet
+num_available: the number of available IP addresses largest_available: the
+largest number of contiguous free IP addresses num_unavailable: the number of
+unavailable IP addresses total_addresses: the sum of the available plus
+unavailable addresses usage: the (floating point) usage percentage of this
+subnet usage_string: the (formatted unicode) usage percentage of this subnet
 ranges: the specific IP ranges present in ths subnet (if specified)
 
 ###### Optional parameters
@@ -5864,7 +5854,7 @@ include_ranges
 
 include_suggestions
    If True, includes the suggested gateway and dynamic range for this subnet,
-    if it were to be configured.
+   if it were to be configured.
 
 Returns 404 if the subnet is not found.
 
@@ -5942,17 +5932,17 @@ description
 
 vlan
    VLAN this subnet belongs to. Defaults to the default VLAN for the provided
-    fabric or defaults to the default VLAN in the default fabric (if
-    unspecified).
+   fabric or defaults to the default VLAN in the default fabric (if
+   unspecified).
 
 fabric
    Fabric for the subnet. Defaults to the fabric the provided VLAN belongs
-    to, or defaults to the default fabric.
+   to, or defaults to the default fabric.
 
 vid
    VID of the VLAN this subnet belongs to. Only used when vlan is not
-    provided. Picks the VLAN with this VID in the provided fabric or the
-    default fabric if one is not given.
+   provided. Picks the VLAN with this VID in the provided fabric or the
+   default fabric if one is not given.
 
 space
    Space this subnet is in. Defaults to the default space.
@@ -5962,11 +5952,11 @@ gateway_ip
 
 rdns_mode
    How reverse DNS is handled for this subnet. One of: 0 (Disabled), 1
-    (Enabled), or 2 (RFC2317). Disabled means no reverse zone is created;
-    Enabled means generate the reverse zone; RFC2317 extends Enabled to create
-    the necessary parent zone with the appropriate CNAME resource records for
-    the network, if the network is small enough to require the support
-    described in RFC2317.
+   (Enabled), or 2 (RFC2317). Disabled means no reverse zone is created;
+   Enabled means generate the reverse zone; RFC2317 extends Enabled to create
+   the necessary parent zone with the appropriate CNAME resource records for
+   the network, if the network is small enough to require the support
+   described in RFC2317.
 
 allow_proxy
    Configure maas-proxy to allow requests from this subnet.
@@ -5977,16 +5967,16 @@ dns_servers
 managed
    In MAAS 2.0+, all subnets are assumed to be managed by default.
 
-    Only managed subnets allow DHCP to be enabled on their related dynamic
-    ranges. (Thus, dynamic ranges become "informational only"; an indication
-    that another DHCP server is currently handling them, or that MAAS will
-    handle them when the subnet is enabled for management.)
+   Only managed subnets allow DHCP to be enabled on their related dynamic
+   ranges. (Thus, dynamic ranges become "informational only"; an indication
+   that another DHCP server is currently handling them, or that MAAS will
+   handle them when the subnet is enabled for management.)
 
-    Managed subnets do not allow IP allocation by default. The meaning of a
-    "reserved" IP range is reversed for an unmanaged subnet. (That is, for
-    managed subnets, "reserved" means "MAAS cannot allocate any IP address
-    within this reserved block". For unmanaged subnets, "reserved" means "MAAS
-    must allocate IP addresses only from reserved IP ranges".
+   Managed subnets do not allow IP allocation by default. The meaning of a
+   "reserved" IP range is reversed for an unmanaged subnet. (That is, for
+   managed subnets, "reserved" means "MAAS cannot allocate any IP address
+   within this reserved block". For unmanaged subnets, "reserved" means "MAAS
+   must allocate IP addresses only from reserved IP ranges".
 
 ### Tag
 
@@ -6054,23 +6044,23 @@ Returns 404 if the tag is not found.
 
 Add or remove nodes being associated with this tag.
 
-:param add`
+- `param add`
    system_ids of nodes to add to this tag.
 
-:param remove`
+- `param remove`
    system_ids of nodes to remove from this tag.
 
-:param definition`
+- `param definition`
    (optional) If supplied, the definition will be
-       validated against the current definition of the tag. If the value does
-        not match, then the update will be dropped (assuming this was just a
-        case of a worker being out-of-date)
+   validated against the current definition of the tag. If the value does
+   not match, then the update will be dropped (assuming this was just a
+   case of a worker being out-of-date)
 
-:param rack_controller`
+- `param rack_controller`
    A system ID of a rack controller that did the
-       processing. This value is optional. If not supplied, the requester
-        must be a superuser. If supplied, then the requester must be the rack
-        controller.
+   processing. This value is optional. If not supplied, the requester
+   must be a superuser. If supplied, then the requester must be the rack
+   controller.
 
 Returns 404 if the tag is not found. Returns 401 if the user does not have
 permission to update the nodes. Returns 409 if 'definition' doesn't match the
@@ -6080,17 +6070,17 @@ current definition.
 
 Update a specific Tag.
 
-:param name`
+- `param name`
    The name of the Tag to be created. This should be a short
-       name, and will be used in the URL of the tag.
+   name, and will be used in the URL of the tag.
 
-:param comment`
+- `param comment`
    A long form description of what the tag is meant for.
-       It is meant as a human readable description of the tag.
+   It is meant as a human readable description of the tag.
 
-:param definition`
+- `param definition`
    An XPATH query that will be evaluated against the
-       hardware_details stored for all nodes (output of lshw -xml).
+   hardware_details stored for all nodes (output of lshw -xml).
 
 Returns 404 if the tag is not found.
 
@@ -6108,24 +6098,24 @@ Get a listing of all tags that are currently defined.
 
 Create a new Tag.
 
-:param name`
+- `param name`
    The name of the Tag to be created. This should be a short
-       name, and will be used in the URL of the tag.
+   name, and will be used in the URL of the tag.
 
-:param comment`
+- `param comment`
    A long form description of what the tag is meant for.
-       It is meant as a human readable description of the tag.
+   It is meant as a human readable description of the tag.
 
-:param definition`
+- `param definition`
    An XPATH query that will be evaluated against the
-       hardware_details stored for all nodes (output of lshw -xml).
+   hardware_details stored for all nodes (output of lshw -xml).
 
-:param kernel_opts`
+- `param kernel_opts`
    Can be None. If set, nodes associated with this tag
-       will add this string to their kernel options when booting. The value
-        overrides the global 'kernel_opts' setting. If more than one tag is
-        associated with a node, the one with the lowest alphabetical name will
-        be picked (eg 01-my-tag will be taken over 99-tag-name).
+   will add this string to their kernel options when booting. The value
+   overrides the global 'kernel_opts' setting. If more than one tag is
+   associated with a node, the one with the lowest alphabetical name will
+   be picked (eg 01-my-tag will be taken over 99-tag-name).
 
 Returns 401 if the user is not an admin.
 
@@ -6155,32 +6145,32 @@ Returns the currently logged in user.
 
 Create a MAAS user account.
 
-This is not safe: the password is sent in plaintext. Avoid it for
-production, unless you are confident that you can prevent eavesdroppers from
-observing the request.
+This is not safe: the password is sent in plaintext. Avoid it for production,
+unless you are confident that you can prevent eavesdroppers from observing the
+request.
 
-:param username`
+- `param username`
    Identifier-style username for the new user.
 
-:type username`
+- `type username`
    unicode
 
-:param email`
+- `param email`
    Email address for the new user.
 
-:type email`
+- `type email`
    unicode
 
-:param password`
+- `param password`
    Password for the new user.
 
-:type password`
+- `type password`
    unicode
 
-:param is_superuser`
+- `param is_superuser`
    Whether the new user is to be an administrator.
 
-:type is_superuser`
+- `type is_superuser`
    bool ('0' for False, '1' for True)
 
 Returns 400 if any mandatory parameters are missing.
@@ -6189,14 +6179,13 @@ Returns 400 if any mandatory parameters are missing.
 
 Information about this MAAS instance.
 
-> This returns a JSON dictionary with information about this MAAS
-> instance:`
+> This returns a JSON dictionary with information about this MAAS instance:
 >
-> > {
-> >    'version': '1.8.0', 'subversion'` 'alpha10+bzr3750',
-> >     'capabilities': \['capability1', 'capability2', ...\]
-> >
-> > }
+>     {
+>         'version': '1.8.0',
+>         'subversion': 'alpha10+bzr3750',
+>         'capabilities': ['capability1', 'capability2', ...]
+>     }
 
 ##### `GET /api/2.0/version/`
 
@@ -6222,64 +6211,64 @@ Returns 404 if the fabric or VLAN is not found.
 
 Update VLAN.
 
-:param name`
+- `param name`
    Name of the VLAN.
 
-:type name`
+- `type name`
    unicode
 
-:param description`
+- `param description`
    Description of the VLAN.
 
-:type description`
+- `type description`
    unicode
 
-:param vid`
+- `param vid`
    VLAN ID of the VLAN.
 
-:type vid`
+- `type vid`
    integer
 
-:param mtu`
+- `param mtu`
    The MTU to use on the VLAN.
 
-:type mtu`
+- `type mtu`
    integer
 
-:param dhcp_on`
+- `param dhcp_on`
    Whether or not DHCP should be managed on the VLAN.
 
-:type dhcp_on`
+- `type dhcp_on`
    boolean
 
-:param primary_rack`
+- `param primary_rack`
    The primary rack controller managing the VLAN.
 
-:type primary_rack`
+- `type primary_rack`
    system_id
 
-:param secondary_rack`
+- `param secondary_rack`
    The secondary rack controller manging the VLAN.
 
-:type secondary_rack`
+- `type secondary_rack`
    system_id
 
-:param relay_vlan`
+- `param relay_vlan`
    Only set when this VLAN will be using a DHCP relay
-       to forward DHCP requests to another VLAN that MAAS is or will run the
-        DHCP server. MAAS will not run the DHCP relay itself, it must be
-        configured to proxy reqests to the primary and/or secondary rack
-        controller interfaces for the VLAN specified in this field.
+   to forward DHCP requests to another VLAN that MAAS is or will run the
+   DHCP server. MAAS will not run the DHCP relay itself, it must be
+   configured to proxy reqests to the primary and/or secondary rack
+   controller interfaces for the VLAN specified in this field.
 
-:type relay_vlan`
+- `type relay_vlan`
    ID of VLAN
 
-:param space`
+- `param space`
    The space this VLAN should be placed in. Passing in an
-       empty string (or the string 'undefined') will cause the VLAN to be
-        placed in the 'undefined' space.
+   empty string (or the string 'undefined') will cause the VLAN to be
+   placed in the 'undefined' space.
 
-:type space`
+- `type space`
    unicode
 
 Returns 404 if the fabric or VLAN is not found.
@@ -6298,36 +6287,36 @@ Returns 404 if the fabric is not found.
 
 Create a VLAN.
 
-:param name`
+- `param name`
    Name of the VLAN.
 
-:type name`
+- `type name`
    unicode
 
-:param description`
+- `param description`
    Description of the VLAN.
 
-:type description`
+- `type description`
    unicode
 
-:param vid`
+- `param vid`
    VLAN ID of the VLAN.
 
-:type vid`
+- `type vid`
    integer
 
-:param mtu`
+- `param mtu`
    The MTU to use on the VLAN.
 
-:type mtu`
+- `type mtu`
    integer
 
-:param space`
+- `param space`
    The space this VLAN should be placed in. Passing in an
-       empty string (or the string 'undefined') will cause the VLAN to be
-        placed in the 'undefined' space.
+   empty string (or the string 'undefined') will cause the VLAN to be
+   placed in the 'undefined' space.
 
-:type space`
+- `type space`
    unicode
 
 ### Volume group
@@ -6351,13 +6340,13 @@ Returns 404 if the machine or volume group is not found.
 
 Create a logical volume in the volume group.
 
-:param name`
+- `param name`
    Name of the logical volume.
 
-:param uuid`
+- `param uuid`
    (optional) UUID of the logical volume.
 
-:param size`
+- `param size`
    Size of the logical volume.
 
 Returns 404 if the machine or volume group is not found. Returns 409 if the
@@ -6367,7 +6356,7 @@ machine is not Ready.
 
 Delete a logical volume in the volume group.
 
-:param id`
+- `param id`
    ID of the logical volume.
 
 Returns 403 if no logical volume with id. Returns 404 if the machine or volume
@@ -6377,23 +6366,23 @@ group is not found. Returns 409 if the machine is not Ready.
 
 Read volume group on a machine.
 
-:param name`
+- `param name`
    Name of the volume group.
 
-:param uuid`
+- `param uuid`
    UUID of the volume group.
 
-:param add_block_devices`
+- `param add_block_devices`
    Block devices to add to the volume group.
 
-:param remove_block_devices`
+- `param remove_block_devices`
    Block devices to remove from the
-       volume group.
+   volume group.
 
-:param add_partitions`
+- `param add_partitions`
    Partitions to add to the volume group.
 
-:param remove_partitions`
+- `param remove_partitions`
    Partitions to remove from the volume group.
 
 Returns 404 if the machine or volume group is not found. Returns 409 if the
@@ -6413,16 +6402,16 @@ Returns 404 if the machine is not found.
 
 Create a volume group belonging to machine.
 
-:param name`
+- `param name`
    Name of the volume group.
 
-:param uuid`
+- `param uuid`
    (optional) UUID of the volume group.
 
-:param block_devices`
+- `param block_devices`
    Block devices to add to the volume group.
 
-:param partitions`
+- `param partitions`
    Partitions to add to the volume group.
 
 Returns 404 if the machine is not found. Returns 409 if the machine is not
@@ -6433,9 +6422,9 @@ Ready.
 Manage a physical zone.
 
 > Any node is in a physical zone, or "zone" for short. The meaning of a
-> physical zone is up to you: it could identify e.g. a server rack, a
-> network, or a data centre. Users can then allocate nodes from specific
-> physical zones, to suit their redundancy or performance requirements.
+> physical zone is up to you: it could identify e.g. a server rack, a network,
+> or a data centre. Users can then allocate nodes from specific physical
+> zones, to suit their redundancy or performance requirements.
 >
 > This functionality is only available to administrators. Other users can view
 > physical zones, but not modify them.
@@ -6473,16 +6462,16 @@ Get a listing of all the physical zones.
 
 Create a new physical zone.
 
-:param name`
+- `param name`
    Identifier-style name for the new zone.
 
-:type name`
+- `type name`
    unicode
 
-:param description`
+- `param description`
    Free-form description of the new zone.
 
-:type description`
+- `type description`
    unicode
 
 ## Power types
@@ -6540,7 +6529,7 @@ Power parameters:
 Power parameters:
 
 -   power_driver (Power driver). Choices: 'LAN' (LAN \[IPMI 1.5\]),
-    'LAN_2_0' (LAN_2_0 \[IPMI 2.0\]) Default: 'LAN_2_0'.
+   'LAN_2_0' (LAN_2_0 \[IPMI 2.0\]) Default: 'LAN_2_0'.
 -   power_address (IP address).
 -   power_user (Power user).
 -   power_pass (Power password).
@@ -6567,7 +6556,7 @@ Power parameters:
 -   power_user (MSCM CLI API user).
 -   power_pass (MSCM CLI API password).
 -   node_id (Node ID - Must adhere to cXnY format (X=cartridge number, Y=node
-    number).).
+   number).).
 
 ### msftocs (Microsoft OCS - Chassis Manager)
 
@@ -6607,9 +6596,8 @@ Power parameters:
 -   power_address (Power address).
 -   power_user (Power user).
 -   power_pass (Power password).
--   power_control (Power control type). Choices: 'ipmi' (IPMI),
-    'restapi' (REST API v0.9), 'restapi2' (REST API v2.0) Default:
-    'ipmi'.
+-   power_control (Power control type). Choices: 'ipmi' (IPMI), 'restapi'
+   (REST API v0.9), 'restapi2' (REST API v2.0) Default: 'ipmi'.
 
 ### ucsm (Cisco UCS Manager)
 

--- a/en/api.md
+++ b/en/api.md
@@ -23,8 +23,8 @@ error message and the api version are returned as plaintext.
 
 ## HTTP methods and parameter-passing
 
-The following HTTP methods are available for accessing the API- `
-   -   GET (for information retrieval and queries),
+The following HTTP methods are available for accessing the API: 
+    -   GET (for information retrieval and queries),
     -   POST (for asking the system to do things),
     -   PUT (for updating objects), and
     -   DELETE (for deleting objects).

--- a/en/api.md
+++ b/en/api.md
@@ -51,14 +51,14 @@ For example, to list all machines, you might GET "/api/2.0/machines".
 
 Manage the current logged-in user.
 
-#### `GET /api/2.0/account/ op=list_authorisation_tokens`
+##### `GET /api/2.0/account/ op=list_authorisation_tokens`
 
 List authorisation tokens available to the currently logged-in user.
 
 - `return`
    list of dictionaries representing each key's name and token.
 
-#### `POST /api/2.0/account/ op=create_authorisation_token`
+##### `POST /api/2.0/account/ op=create_authorisation_token`
 
 Create an authorisation OAuth token and OAuth consumer.
 
@@ -69,13 +69,19 @@ Create an authorisation OAuth token and OAuth consumer.
    unicode
 
 - `return`
-   a json dict with four keys- ` 'token_key', 'token_secret', 'consumer_key' and 'name'(e.g. {token_key- `
-   's65244576fgqs', token_secret- ` 'qsdfdhv34', consumer_key- ` '68543fhj854fg', name` 'MAAS consumer'}).
+   a json dict with four keys- ` 'token_key',
+       'token_secret', 'consumer_key' and 'name'(e.g. {token_key- `
+        's65244576fgqs', token_secret- `
+
+    'qsdfdhv34',
+       consumer_key- ` '68543fhj854fg', name`
+
+    'MAAS consumer'}).
 
 - `rtype`
    string (json)
 
-#### `POST /api/2.0/account/ op=delete_authorisation_token`
+##### `POST /api/2.0/account/ op=delete_authorisation_token`
 
 Delete an authorisation OAuth token and the related OAuth consumer.
 
@@ -85,7 +91,7 @@ Delete an authorisation OAuth token and the related OAuth consumer.
 - `type token_key`
    unicode
 
-#### `POST /api/2.0/account/ op=update_token_name`
+##### `POST /api/2.0/account/ op=update_token_name`
 
 Modify the consumer name of an authorisation OAuth token.
 
@@ -105,20 +111,20 @@ Modify the consumer name of an authorisation OAuth token.
 
 Manage bcache cache set on a machine.
 
-#### `DELETE /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Delete cache set on a machine.
 
 Returns 400 if the cache set is in use. Returns 404 if the machine or cache
 set is not found. Returns 409 if the machine is not Ready.
 
-#### `GET /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Read bcache cache set on a machine.
 
 Returns 404 if the machine or cache set is not found.
 
-#### `PUT /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Delete bcache on a machine.
 
@@ -137,13 +143,13 @@ machine is not Ready.
 
 Manage bcache cache sets on a machine.
 
-#### `GET /api/2.0/nodes/{system_id}/bcache-cache-sets/`
+##### `GET /api/2.0/nodes/{system_id}/bcache-cache-sets/`
 
 List all bcache cache sets belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/bcache-cache-sets/`
+##### `POST /api/2.0/nodes/{system_id}/bcache-cache-sets/`
 
 Creates a Bcache Cache Set.
 
@@ -162,20 +168,20 @@ Ready.
 
 Manage bcache device on a machine.
 
-#### `DELETE /api/2.0/nodes/{system_id}/bcache/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Delete bcache on a machine.
 
 Returns 404 if the machine or bcache is not found. Returns 409 if the machine
 is not Ready.
 
-#### `GET /api/2.0/nodes/{system_id}/bcache/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Read bcache device on a machine.
 
 Returns 404 if the machine or bcache is not found.
 
-#### `PUT /api/2.0/nodes/{system_id}/bcache/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Delete bcache on a machine.
 
@@ -207,13 +213,13 @@ machine is not Ready.
 
 Manage bcache devices on a machine.
 
-#### `GET /api/2.0/nodes/{system_id}/bcaches/`
+##### `GET /api/2.0/nodes/{system_id}/bcaches/`
 
 List all bcache devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/bcaches/`
+##### `POST /api/2.0/nodes/{system_id}/bcaches/`
 
 Creates a Bcache.
 
@@ -245,7 +251,7 @@ Ready.
 
 Manage a block device on a machine.
 
-#### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Delete block device on a machine.
 
@@ -253,13 +259,13 @@ Returns 404 if the machine or block device is not found. Returns 403 if the
 user is not allowed to delete the block device. Returns 409 if the machine is
 not Ready.
 
-#### `GET /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Read block device on node.
 
 Returns 404 if the machine or block device is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=add_tag`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=add_tag`
 
 Add a tag to block device on a machine.
 
@@ -270,7 +276,7 @@ Returns 404 if the machine or block device is not found. Returns 403 if the
 user is not allowed to update the block device. Returns 409 if the machine is
 not Ready.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=format`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=format`
 
 Format block device with filesystem.
 
@@ -284,7 +290,7 @@ Returns 403 when the user doesn't have the ability to format the block device.
 Returns 404 if the machine or block device is not found. Returns 409 if the
 machine is not Ready or Allocated.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=mount`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=mount`
 
 Mount the filesystem on block device.
 
@@ -298,7 +304,7 @@ Returns 403 when the user doesn't have the ability to mount the block device.
 Returns 404 if the machine or block device is not found. Returns 409 if the
 machine is not Ready or Allocated.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=remove_tag`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=remove_tag`
 
 Remove a tag from block device on a machine.
 
@@ -309,7 +315,7 @@ Returns 404 if the machine or block device is not found. Returns 403 if the
 user is not allowed to update the block device. Returns 409 if the machine is
 not Ready.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=set_boot_disk`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=set_boot_disk`
 
 Set this block device as the boot disk for the machine.
 
@@ -318,7 +324,7 @@ machine or block device is not found. Returns 403 if the user is not allowed
 to update the block device. Returns 409 if the machine is not Ready or
 Allocated.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unformat`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unformat`
 
 Unformat block device with filesystem.
 
@@ -327,7 +333,7 @@ of a filesystem group. Returns 403 when the user doesn't have the ability to
 unformat the block device. Returns 404 if the machine or block device is not
 found. Returns 409 if the machine is not Ready or Allocated.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unmount`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unmount`
 
 Unmount the filesystem on block device.
 
@@ -336,7 +342,7 @@ Returns 403 when the user doesn't have the ability to unmount the block
 device. Returns 404 if the machine or block device is not found. Returns 409
 if the machine is not Ready or Allocated.
 
-#### `PUT /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Update block device on a machine.
 
@@ -386,13 +392,13 @@ not Ready.
 
 Manage block devices on a machine.
 
-#### `GET /api/2.0/nodes/{system_id}/blockdevices/`
+##### `GET /api/2.0/nodes/{system_id}/blockdevices/`
 
 List all block devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/`
 
 Create a physical block device.
 
@@ -422,11 +428,11 @@ Returns 404 if the node is not found.
 
 Manage a boot resource.
 
-#### `DELETE /api/2.0/boot-resources/{id}/`
+##### `DELETE /api/2.0/boot-resources/{id}/`
 
 Delete boot resource.
 
-#### `GET /api/2.0/boot-resources/{id}/`
+##### `GET /api/2.0/boot-resources/{id}/`
 
 Read a boot resource.
 
@@ -434,18 +440,18 @@ Read a boot resource.
 
 Manage the boot resources.
 
-#### `GET /api/2.0/boot-resources/`
+##### `GET /api/2.0/boot-resources/`
 
 List all boot resources.
 
 - `param type`
    Type of boot resources to list. Default- ` all
 
-#### `GET /api/2.0/boot-resources/ op=is_importing`
+##### `GET /api/2.0/boot-resources/ op=is_importing`
 
 Return import status.
 
-#### `POST /api/2.0/boot-resources/`
+##### `POST /api/2.0/boot-resources/`
 
 Uploads a new boot resource.
 
@@ -467,11 +473,11 @@ Uploads a new boot resource.
    Image content. Note- ` this is not a normal parameter,
        but a file upload.
 
-#### `POST /api/2.0/boot-resources/ op=import`
+##### `POST /api/2.0/boot-resources/ op=import`
 
 Import the boot resources.
 
-#### `POST /api/2.0/boot-resources/ op=stop_import`
+##### `POST /api/2.0/boot-resources/ op=stop_import`
 
 Stop import of boot resources.
 
@@ -479,15 +485,15 @@ Stop import of boot resources.
 
 Manage a boot source.
 
-#### `DELETE /api/2.0/boot-sources/{id}/`
+##### `DELETE /api/2.0/boot-sources/{id}/`
 
 Delete a specific boot source.
 
-#### `GET /api/2.0/boot-sources/{id}/`
+##### `GET /api/2.0/boot-sources/{id}/`
 
 Read a boot source.
 
-#### `PUT /api/2.0/boot-sources/{id}/`
+##### `PUT /api/2.0/boot-sources/{id}/`
 
 Update a specific boot source.
 
@@ -506,15 +512,15 @@ Update a specific boot source.
 
 Manage a boot source selection.
 
-#### `DELETE /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+##### `DELETE /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Delete a specific boot source.
 
-#### `GET /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+##### `GET /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Read a boot source selection.
 
-#### `PUT /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+##### `PUT /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Update a specific boot source selection.
 
@@ -538,13 +544,13 @@ Update a specific boot source selection.
 
 Manage the collection of boot source selections.
 
-#### `GET /api/2.0/boot-sources/{boot_source_id}/selections/`
+##### `GET /api/2.0/boot-sources/{boot_source_id}/selections/`
 
 List boot source selections.
 
 Get a listing of a boot source's selections.
 
-#### `POST /api/2.0/boot-sources/{boot_source_id}/selections/`
+##### `POST /api/2.0/boot-sources/{boot_source_id}/selections/`
 
 Create a new boot source selection.
 
@@ -568,13 +574,13 @@ Create a new boot source selection.
 
 Manage the collection of boot sources.
 
-#### `GET /api/2.0/boot-sources/`
+##### `GET /api/2.0/boot-sources/`
 
 List boot sources.
 
 Get a listing of boot sources.
 
-#### `POST /api/2.0/boot-sources/`
+##### `POST /api/2.0/boot-sources/`
 
 Create a new boot source.
 
@@ -597,15 +603,15 @@ Manage a custom commissioning script.
 >
 > This endpoint has been deprecated in favor of the node-script endpoint.
 
-#### `DELETE /api/2.0/commissioning-scripts/{name}`
+##### `DELETE /api/2.0/commissioning-scripts/{name}`
 
 Delete a commissioning script.
 
-#### `GET /api/2.0/commissioning-scripts/{name}`
+##### `GET /api/2.0/commissioning-scripts/{name}`
 
 Read a commissioning script.
 
-#### `PUT /api/2.0/commissioning-scripts/{name}`
+##### `PUT /api/2.0/commissioning-scripts/{name}`
 
 Update a commissioning script.
 
@@ -617,11 +623,11 @@ Manage custom commissioning scripts.
 >
 > This endpoint has been deprecated in favor of the node-scripts endpoint.
 
-#### `GET /api/2.0/commissioning-scripts/`
+##### `GET /api/2.0/commissioning-scripts/`
 
 List commissioning scripts.
 
-#### `POST /api/2.0/commissioning-scripts/`
+##### `POST /api/2.0/commissioning-scripts/`
 
 Create a new commissioning script.
 
@@ -663,19 +669,19 @@ Manage an individual DHCP snippet.
 
 > The DHCP snippet is identified by its id.
 
-#### `DELETE /api/2.0/dhcp-snippets/{id}/`
+##### `DELETE /api/2.0/dhcp-snippets/{id}/`
 
 Delete a DHCP snippet.
 
 Returns 404 if the DHCP snippet is not found.
 
-#### `GET /api/2.0/dhcp-snippets/{id}/`
+##### `GET /api/2.0/dhcp-snippets/{id}/`
 
 Read DHCP snippet.
 
 Returns 404 if the snippet is not found.
 
-#### `POST /api/2.0/dhcp-snippets/{id}/ op=revert`
+##### `POST /api/2.0/dhcp-snippets/{id}/ op=revert`
 
 Revert the value of a DHCP snippet to an earlier revision.
 
@@ -689,7 +695,7 @@ Revert the value of a DHCP snippet to an earlier revision.
 
 Returns 404 if the DHCP snippet is not found.
 
-#### `PUT /api/2.0/dhcp-snippets/{id}/`
+##### `PUT /api/2.0/dhcp-snippets/{id}/`
 
 Update a DHCP snippet.
 
@@ -745,11 +751,11 @@ Returns 404 if the DHCP snippet is not found.
 
 Manage the collection of all DHCP snippets in MAAS.
 
-#### `GET /api/2.0/dhcp-snippets/`
+##### `GET /api/2.0/dhcp-snippets/`
 
 List all DHCP snippets.
 
-#### `POST /api/2.0/dhcp-snippets/`
+##### `POST /api/2.0/dhcp-snippets/`
 
 Create a DHCP snippet.
 
@@ -806,20 +812,20 @@ Returns 404 if the DHCP snippet is not found.
 
 Manage dnsresource.
 
-#### `DELETE /api/2.0/dnsresources/{id}/`
+##### `DELETE /api/2.0/dnsresources/{id}/`
 
 Delete dnsresource.
 
 Returns 403 if the user does not have permission to delete the dnsresource.
 Returns 404 if the dnsresource is not found.
 
-#### `GET /api/2.0/dnsresources/{id}/`
+##### `GET /api/2.0/dnsresources/{id}/`
 
 Read dnsresource.
 
 Returns 404 if the dnsresource is not found.
 
-#### `PUT /api/2.0/dnsresources/{id}/`
+##### `PUT /api/2.0/dnsresources/{id}/`
 
 Update dnsresource.
 
@@ -836,20 +842,20 @@ Returns 404 if the dnsresource is not found.
 
 Manage dnsresourcerecord.
 
-#### `DELETE /api/2.0/dnsresourcerecords/{id}/`
+##### `DELETE /api/2.0/dnsresourcerecords/{id}/`
 
 Delete dnsresourcerecord.
 
 Returns 403 if the user does not have permission to delete the
 dnsresourcerecord. Returns 404 if the dnsresourcerecord is not found.
 
-#### `GET /api/2.0/dnsresourcerecords/{id}/`
+##### `GET /api/2.0/dnsresourcerecords/{id}/`
 
 Read dnsresourcerecord.
 
 Returns 404 if the dnsresourcerecord is not found.
 
-#### `PUT /api/2.0/dnsresourcerecords/{id}/`
+##### `PUT /api/2.0/dnsresourcerecords/{id}/`
 
 Update dnsresourcerecord.
 
@@ -866,7 +872,7 @@ dnsresourcerecord. Returns 404 if the dnsresourcerecord is not found.
 
 Manage DNS resource records (e.g. CNAME, MX, NS, SRV, TXT)
 
-#### `GET /api/2.0/dnsresourcerecords/`
+##### `GET /api/2.0/dnsresourcerecords/`
 
 List all dnsresourcerecords.
 
@@ -880,7 +886,7 @@ List all dnsresourcerecords.
    restrict the listing to entries which have
        records of the given rrtype.
 
-#### `POST /api/2.0/dnsresourcerecords/`
+##### `POST /api/2.0/dnsresourcerecords/`
 
 Create a DNS resource record.
 
@@ -909,7 +915,7 @@ Create a DNS resource record.
 
 Manage dnsresources.
 
-#### `GET /api/2.0/dnsresources/`
+##### `GET /api/2.0/dnsresources/`
 
 List all resources for the specified criteria.
 
@@ -923,7 +929,7 @@ List all resources for the specified criteria.
    restrict the listing to entries which have
        records of the given rrtype.
 
-#### `POST /api/2.0/dnsresources/`
+##### `POST /api/2.0/dnsresources/`
 
 Create a dnsresource.
 
@@ -951,7 +957,7 @@ Manage an individual device.
 
 > The device is identified by its system_id.
 
-#### `DELETE /api/2.0/devices/{system_id}/`
+##### `DELETE /api/2.0/devices/{system_id}/`
 
 Delete a specific Device.
 
@@ -959,13 +965,13 @@ Returns 404 if the device is not found. Returns 403 if the user does not have
 permission to delete the device. Returns 204 if the device is successfully
 deleted.
 
-#### `GET /api/2.0/devices/{system_id}/`
+##### `GET /api/2.0/devices/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/devices/{system_id}/ op=details`
+##### `GET /api/2.0/devices/{system_id}/ op=details`
 
 Obtain various system details.
 
@@ -980,7 +986,7 @@ encoding like base-64.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/devices/{system_id}/ op=power_parameters`
+##### `GET /api/2.0/devices/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
@@ -993,21 +999,21 @@ and secret keys.
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/devices/{system_id}/ op=restore_default_configuration`
+##### `POST /api/2.0/devices/{system_id}/ op=restore_default_configuration`
 
 Reset a device's configuration to its initial state.
 
 Returns 404 if the device is not found. Returns 403 if the user does not have
 permission to reset the device.
 
-#### `POST /api/2.0/devices/{system_id}/ op=restore_networking_configuration`
+##### `POST /api/2.0/devices/{system_id}/ op=restore_networking_configuration`
 
 Reset a device's network options.
 
 Returns 404 if the device is not found Returns 403 if the user does not have
 permission to reset the device.
 
-#### `POST /api/2.0/devices/{system_id}/ op=set_owner_data`
+##### `POST /api/2.0/devices/{system_id}/ op=set_owner_data`
 
 Set key/value data for the current owner.
 
@@ -1021,7 +1027,7 @@ allocated to a user.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission.
 
-#### `PUT /api/2.0/devices/{system_id}/`
+##### `PUT /api/2.0/devices/{system_id}/`
 
 Update a specific device.
 
@@ -1059,7 +1065,7 @@ permission to update the device.
 
 Manage the collection of all the devices in the MAAS.
 
-#### `GET /api/2.0/devices/`
+##### `GET /api/2.0/devices/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
@@ -1109,7 +1115,7 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 - `type agent_name`
    unicode
 
-#### `GET /api/2.0/devices/ op=is_registered`
+##### `GET /api/2.0/devices/ op=is_registered`
 
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
@@ -1128,7 +1134,7 @@ Returns whether or not the given MAC address is registered within this MAAS
 
 Returns 400 if any mandatory parameters are missing.
 
-#### `POST /api/2.0/devices/`
+##### `POST /api/2.0/devices/`
 
 Create a new device.
 
@@ -1157,7 +1163,7 @@ Create a new device.
 - `type parent`
    unicode
 
-#### `POST /api/2.0/devices/ op=set_zone`
+##### `POST /api/2.0/devices/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
@@ -1175,14 +1181,14 @@ Raises 403 if the user is not an admin.
 
 Query observed discoveries.
 
-#### `GET /api/2.0/discovery/`
+##### `GET /api/2.0/discovery/`
 
 Lists all the devices MAAS has discovered.
 
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-#### `GET /api/2.0/discovery/ op=by_unknown_ip`
+##### `GET /api/2.0/discovery/ op=by_unknown_ip`
 
 Lists all discovered devices which have an unknown IP address.
 
@@ -1193,7 +1199,7 @@ been observed using it after it was assigned by a MAAS-managed DHCP server.
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-#### `GET /api/2.0/discovery/ op=by_unknown_ip_and_mac`
+##### `GET /api/2.0/discovery/ op=by_unknown_ip_and_mac`
 
 Lists all discovered devices which are completely unknown to MAAS.
 
@@ -1204,7 +1210,7 @@ the discovery.
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-#### `GET /api/2.0/discovery/ op=by_unknown_mac`
+##### `GET /api/2.0/discovery/ op=by_unknown_mac`
 
 Lists all discovered devices which have an unknown IP address.
 
@@ -1214,7 +1220,7 @@ interface known to MAAS is configured with MAC address of the discovery.
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-#### `POST /api/2.0/discovery/ op=clear`
+##### `POST /api/2.0/discovery/ op=clear`
 
 Deletes all discovered neighbours and/or mDNS entries.
 
@@ -1227,7 +1233,7 @@ Deletes all discovered neighbours and/or mDNS entries.
 - `param all`
    if True, deletes all discovery data.
 
-#### `POST /api/2.0/discovery/ op=scan`
+##### `POST /api/2.0/discovery/ op=scan`
 
 Immediately run a neighbour discovery scan on all rack networks.
 
@@ -1290,26 +1296,26 @@ elapsed.
 
 Read or delete an observed discovery.
 
-#### `GET /api/2.0/discovery/{discovery_id}/`
+##### `GET /api/2.0/discovery/{discovery_id}/`
 
 ### Domain
 
 Manage domain.
 
-#### `DELETE /api/2.0/domains/{id}/`
+##### `DELETE /api/2.0/domains/{id}/`
 
 Delete domain.
 
 Returns 403 if the user does not have permission to update the dnsresource.
 Returns 404 if the domain is not found.
 
-#### `GET /api/2.0/domains/{id}/`
+##### `GET /api/2.0/domains/{id}/`
 
 Read domain.
 
 Returns 404 if the domain is not found.
 
-#### `PUT /api/2.0/domains/{id}/`
+##### `PUT /api/2.0/domains/{id}/`
 
 Update domain.
 
@@ -1329,11 +1335,11 @@ Returns 404 if the domain is not found.
 
 Manage domains.
 
-#### `GET /api/2.0/domains/`
+##### `GET /api/2.0/domains/`
 
 List all domains.
 
-#### `POST /api/2.0/domains/`
+##### `POST /api/2.0/domains/`
 
 Create a domain.
 
@@ -1343,7 +1349,7 @@ Create a domain.
 - `param authoritative`
    Class type of the domain.
 
-#### `POST /api/2.0/domains/ op=set_serial`
+##### `POST /api/2.0/domains/ op=set_serial`
 
 Set the SOA serial number (for all DNS zones.)
 
@@ -1357,7 +1363,7 @@ Retrieve filtered node events.
 > A specific Node's events is identified by specifying one or more ids,
 > hostnames, or mac addresses as a list.
 
-#### `GET /api/2.0/events/ op=query`
+##### `GET /api/2.0/events/ op=query`
 
 List Node events, optionally filtered by various criteria via URL query
 parameters.
@@ -1408,19 +1414,19 @@ parameters.
 
 Manage fabric.
 
-#### `DELETE /api/2.0/fabrics/{id}/`
+##### `DELETE /api/2.0/fabrics/{id}/`
 
 Delete fabric.
 
 Returns 404 if the fabric is not found.
 
-#### `GET /api/2.0/fabrics/{id}/`
+##### `GET /api/2.0/fabrics/{id}/`
 
 Read fabric.
 
 Returns 404 if the fabric is not found.
 
-#### `PUT /api/2.0/fabrics/{id}/`
+##### `PUT /api/2.0/fabrics/{id}/`
 
 Update fabric.
 
@@ -1439,11 +1445,11 @@ Returns 404 if the fabric is not found.
 
 Manage fabrics.
 
-#### `GET /api/2.0/fabrics/`
+##### `GET /api/2.0/fabrics/`
 
 List all fabrics.
 
-#### `POST /api/2.0/fabrics/`
+##### `POST /api/2.0/fabrics/`
 
 Create a fabric.
 
@@ -1460,19 +1466,19 @@ Create a fabric.
 
 Manage Fan Network.
 
-#### `DELETE /api/2.0/fannetworks/{id}/`
+##### `DELETE /api/2.0/fannetworks/{id}/`
 
 Delete fannetwork.
 
 Returns 404 if the fannetwork is not found.
 
-#### `GET /api/2.0/fannetworks/{id}/`
+##### `GET /api/2.0/fannetworks/{id}/`
 
 Read fannetwork.
 
 Returns 404 if the fannetwork is not found.
 
-#### `PUT /api/2.0/fannetworks/{id}/`
+##### `PUT /api/2.0/fannetworks/{id}/`
 
 Update fannetwork.
 
@@ -1503,11 +1509,11 @@ Returns 404 if the fannetwork is not found.
 
 Manage Fan Networks.
 
-#### `GET /api/2.0/fannetworks/`
+##### `GET /api/2.0/fannetworks/`
 
 List all fannetworks.
 
-#### `POST /api/2.0/fannetworks/`
+##### `POST /api/2.0/fannetworks/`
 
 Create a fannetwork.
 
@@ -1538,11 +1544,11 @@ Manage a FileStorage object.
 
 > The file is identified by its filename and owner.
 
-#### `DELETE /api/2.0/files/{filename}/`
+##### `DELETE /api/2.0/files/{filename}/`
 
 Delete a FileStorage object.
 
-#### `GET /api/2.0/files/{filename}/`
+##### `GET /api/2.0/files/{filename}/`
 
 GET a FileStorage object as a json object.
 
@@ -1552,7 +1558,7 @@ The 'content' of the file is base64-encoded.
 
 Manage the collection of all the files in this MAAS.
 
-#### `DELETE /api/2.0/files/`
+##### `DELETE /api/2.0/files/`
 
 Delete a FileStorage object.
 
@@ -1562,7 +1568,7 @@ Delete a FileStorage object.
 - `type filename`
    unicode
 
-#### `GET /api/2.0/files/`
+##### `GET /api/2.0/files/`
 
 List the files from the file storage.
 
@@ -1574,7 +1580,7 @@ The returned files are ordered by file name and the content is excluded.
 - `type prefix`
    string
 
-#### `GET /api/2.0/files/ op=get`
+##### `GET /api/2.0/files/ op=get`
 
 Get a named file from the file storage.
 
@@ -1587,7 +1593,7 @@ Get a named file from the file storage.
 - `return`
    The file is returned in the response content.
 
-#### `GET /api/2.0/files/ op=get_by_key`
+##### `GET /api/2.0/files/ op=get_by_key`
 
 Get a file from the file storage using its key.
 
@@ -1600,7 +1606,7 @@ Get a file from the file storage using its key.
 - `return`
    The file is returned in the response content.
 
-#### `POST /api/2.0/files/`
+##### `POST /api/2.0/files/`
 
 Add a new file to the file storage.
 
@@ -1623,7 +1629,7 @@ Returns 400 if any of these conditions apply- `
 
 Manage IP addresses allocated by MAAS.
 
-#### `GET /api/2.0/ipaddresses/`
+##### `GET /api/2.0/ipaddresses/`
 
 List IP addresses known to MAAS.
 
@@ -1655,7 +1661,7 @@ be supplied- `
 - `type user`
    unicode
 
-#### `POST /api/2.0/ipaddresses/ op=release`
+##### `POST /api/2.0/ipaddresses/ op=release`
 
 Release an IP address that was previously reserved by the user.
 
@@ -1681,7 +1687,7 @@ Release an IP address that was previously reserved by the user.
 
 Returns 404 if the provided IP address is not found.
 
-#### `POST /api/2.0/ipaddresses/ op=reserve`
+##### `POST /api/2.0/ipaddresses/ op=reserve`
 
 Reserve an IP address for use outside of MAAS.
 
@@ -1717,20 +1723,20 @@ Returns 503 if there are no more IP addresses available.
 
 Manage IP range.
 
-#### `DELETE /api/2.0/ipranges/{id}/`
+##### `DELETE /api/2.0/ipranges/{id}/`
 
 Delete IP range.
 
 Returns 403 if not owner of IP range. Returns 404 if the IP range is not
 found.
 
-#### `GET /api/2.0/ipranges/{id}/`
+##### `GET /api/2.0/ipranges/{id}/`
 
 Read IP range.
 
 Returns 404 if the IP range is not found.
 
-#### `PUT /api/2.0/ipranges/{id}/`
+##### `PUT /api/2.0/ipranges/{id}/`
 
 Update IP range.
 
@@ -1750,11 +1756,11 @@ found.
 
 Manage IP ranges.
 
-#### `GET /api/2.0/ipranges/`
+##### `GET /api/2.0/ipranges/`
 
 List all IP ranges.
 
-#### `POST /api/2.0/ipranges/`
+##### `POST /api/2.0/ipranges/`
 
 Create an IP range.
 
@@ -1779,19 +1785,19 @@ Returns 403 if standard users tries to create a dynamic IP range.
 
 Manage a node's or device's interface.
 
-#### `DELETE /api/2.0/nodes/{system_id}/interfaces/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Delete interface on node.
 
 Returns 404 if the node or interface is not found.
 
-#### `GET /api/2.0/nodes/{system_id}/interfaces/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Read interface on node.
 
 Returns 404 if the node or interface is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=add_tag`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=add_tag`
 
 Add a tag to interface on a node.
 
@@ -1801,7 +1807,7 @@ Add a tag to interface on a node.
 Returns 404 if the node or interface is not found. Returns 403 if the user is
 not allowed to update the interface.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=disconnect`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=disconnect`
 
 Disconnect an interface.
 
@@ -1810,7 +1816,7 @@ from any associated VLAN.
 
 Returns 404 if the node or interface is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=link_subnet`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=link_subnet`
 
 Link interface to a subnet.
 
@@ -1854,7 +1860,7 @@ AUTO, DHCP or STATIC links.
 
 Returns 404 if the node or interface is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=remove_tag`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=remove_tag`
 
 Remove a tag from interface on a node.
 
@@ -1864,7 +1870,7 @@ Remove a tag from interface on a node.
 Returns 404 if the node or interface is not found. Returns 403 if the user is
 not allowed to update the interface.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=set_default_gateway`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=set_default_gateway`
 
 Set the node to use this interface as the default gateway.
 
@@ -1879,7 +1885,7 @@ required.
 Returns 400 if the interface has not AUTO or STATIC links. Returns 404 if the
 node or interface is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=unlink_subnet`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=unlink_subnet`
 
 Unlink interface to a subnet.
 
@@ -1888,7 +1894,7 @@ Unlink interface to a subnet.
 
 Returns 404 if the node or interface is not found.
 
-#### `PUT /api/2.0/nodes/{system_id}/interfaces/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Update interface on node.
 
@@ -2040,13 +2046,13 @@ Returns 404 if the node or interface is not found.
 
 Manage interfaces on a node.
 
-#### `GET /api/2.0/nodes/{system_id}/interfaces/`
+##### `GET /api/2.0/nodes/{system_id}/interfaces/`
 
 List all interfaces belonging to a machine, device, or rack controller.
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bond`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bond`
 
 Create a bond interface on a machine.
 
@@ -2139,7 +2145,7 @@ Following are extra parameters that can be set on the interface- `
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bridge`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bridge`
 
 Create a bridge interface on a machine.
 
@@ -2181,7 +2187,7 @@ Following are extra parameters that can be set on the interface- `
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_physical`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_physical`
 
 Create a physical interface on a machine and device.
 
@@ -2211,7 +2217,7 @@ Following are extra parameters that can be set on the interface- `
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_vlan`
+##### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_vlan`
 
 Create a VLAN interface on a machine.
 
@@ -2241,15 +2247,15 @@ Returns 404 if the node is not found.
 
 Manage a license key.
 
-#### `DELETE /api/2.0/license-key/{osystem}/{distro_series}`
+##### `DELETE /api/2.0/license-key/{osystem}/{distro_series}`
 
 Delete license key.
 
-#### `GET /api/2.0/license-key/{osystem}/{distro_series}`
+##### `GET /api/2.0/license-key/{osystem}/{distro_series}`
 
 Read license key.
 
-#### `PUT /api/2.0/license-key/{osystem}/{distro_series}`
+##### `PUT /api/2.0/license-key/{osystem}/{distro_series}`
 
 Update license key.
 
@@ -2266,11 +2272,11 @@ Update license key.
 
 Manage the license keys.
 
-#### `GET /api/2.0/license-keys/`
+##### `GET /api/2.0/license-keys/`
 
 List license keys.
 
-#### `POST /api/2.0/license-keys/`
+##### `POST /api/2.0/license-keys/`
 
 Define a license key.
 
@@ -2287,7 +2293,7 @@ Define a license key.
 
 Manage the MAAS server.
 
-#### `GET /api/2.0/maas/ op=get_config`
+##### `GET /api/2.0/maas/ op=get_config`
 
 Get a config value.
 
@@ -2430,7 +2436,7 @@ Available configuration items- `
     the KMS Windows activation service. (Only needed for Windows deployments
     using KMS activation.)
 
-#### `POST /api/2.0/maas/ op=set_config`
+##### `POST /api/2.0/maas/ op=set_config`
 
 Set a config value.
 
@@ -2582,7 +2588,7 @@ Manage an individual Machine.
 
 > The Machine is identified by its system_id.
 
-#### `DELETE /api/2.0/machines/{system_id}/`
+##### `DELETE /api/2.0/machines/{system_id}/`
 
 Delete a specific Node.
 
@@ -2590,13 +2596,13 @@ Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to delete the node. Returns 204 if the node is successfully
 deleted.
 
-#### `GET /api/2.0/machines/{system_id}/`
+##### `GET /api/2.0/machines/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/machines/{system_id}/ op=details`
+##### `GET /api/2.0/machines/{system_id}/ op=details`
 
 Obtain various system details.
 
@@ -2611,14 +2617,14 @@ encoding like base-64.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/machines/{system_id}/ op=get_curtin_config`
+##### `GET /api/2.0/machines/{system_id}/ op=get_curtin_config`
 
 Return the rendered curtin configuration for the machine.
 
 Returns 404 if the machine could not be found. Returns 403 if the user does
 not have permission to get the curtin configuration.
 
-#### `GET /api/2.0/machines/{system_id}/ op=power_parameters`
+##### `GET /api/2.0/machines/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
@@ -2631,7 +2637,7 @@ and secret keys.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/machines/{system_id}/ op=query_power_state`
+##### `GET /api/2.0/machines/{system_id}/ op=query_power_state`
 
 Query the power state of a node.
 
@@ -2649,7 +2655,7 @@ an appserver thread while waiting.
 
 Returns 404 if the node is not found. Returns node's power state.
 
-#### `POST /api/2.0/machines/{system_id}/ op=abort`
+##### `POST /api/2.0/machines/{system_id}/ op=abort`
 
 Abort a node's current operation.
 
@@ -2662,7 +2668,7 @@ Abort a node's current operation.
 Returns 404 if the node could not be found. Returns 403 if the user does not
 have permission to abort the current operation.
 
-#### `POST /api/2.0/machines/{system_id}/ op=clear_default_gateways`
+##### `POST /api/2.0/machines/{system_id}/ op=clear_default_gateways`
 
 Clear any set default gateways on the machine.
 
@@ -2684,7 +2690,7 @@ interfaces set-default-gateway API.
 Returns 404 if the machine could not be found. Returns 403 if the user does
 not have permission to clear the default gateways.
 
-#### `POST /api/2.0/machines/{system_id}/ op=commission`
+##### `POST /api/2.0/machines/{system_id}/ op=commission`
 
 Begin commissioning process for a machine.
 
@@ -2735,7 +2741,7 @@ tests were changed after it previously commissioned.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/machines/{system_id}/ op=deploy`
+##### `POST /api/2.0/machines/{system_id}/ op=deploy`
 
 Deploy an operating system to a machine.
 
@@ -2812,7 +2818,7 @@ permission to start the machine. Returns 503 if the start-up attempted to
 allocate an IP address, and there were no IP addresses available on the
 relevant cluster interface.
 
-#### `POST /api/2.0/machines/{system_id}/ op=exit_rescue_mode`
+##### `POST /api/2.0/machines/{system_id}/ op=exit_rescue_mode`
 
 Exit rescue mode process for a machine.
 
@@ -2821,7 +2827,7 @@ A machine in the 'rescue mode' state may exit the rescue mode process.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to exit the rescue mode process for this machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=lock`
+##### `POST /api/2.0/machines/{system_id}/ op=lock`
 
 Mark a deployed machine as locked, to prevent changes.
 
@@ -2836,7 +2842,7 @@ A locked machine cannot be released or modified.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission lock the machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=mark_broken`
+##### `POST /api/2.0/machines/{system_id}/ op=mark_broken`
 
 Mark a node as 'broken'.
 
@@ -2852,7 +2858,7 @@ If the node is allocated, release it first.
 Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to mark the node broken.
 
-#### `POST /api/2.0/machines/{system_id}/ op=mark_fixed`
+##### `POST /api/2.0/machines/{system_id}/ op=mark_fixed`
 
 Mark a broken node as fixed and set its status as 'ready'.
 
@@ -2865,7 +2871,7 @@ Mark a broken node as fixed and set its status as 'ready'.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to mark the machine fixed.
 
-#### `POST /api/2.0/machines/{system_id}/ op=mount_special`
+##### `POST /api/2.0/machines/{system_id}/ op=mount_special`
 
 Mount a special-purpose filesystem, like tmpfs.
 
@@ -2881,7 +2887,7 @@ Mount a special-purpose filesystem, like tmpfs.
 
 Returns 403 when the user is not permitted to mount the partition.
 
-#### `POST /api/2.0/machines/{system_id}/ op=override_failed_testing`
+##### `POST /api/2.0/machines/{system_id}/ op=override_failed_testing`
 
 Ignore failed tests and put node back into a usable state.
 
@@ -2894,7 +2900,7 @@ Ignore failed tests and put node back into a usable state.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to ignore tests for the node.
 
-#### `POST /api/2.0/machines/{system_id}/ op=power_off`
+##### `POST /api/2.0/machines/{system_id}/ op=power_off`
 
 Power off a node.
 
@@ -2919,7 +2925,7 @@ Power off a node.
 Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to stop the node.
 
-#### `POST /api/2.0/machines/{system_id}/ op=power_on`
+##### `POST /api/2.0/machines/{system_id}/ op=power_on`
 
 Turn on a node.
 
@@ -2945,7 +2951,7 @@ permission to start the machine. Returns 503 if the start-up attempted to
 allocate an IP address, and there were no IP addresses available on the
 relevant cluster interface.
 
-#### `POST /api/2.0/machines/{system_id}/ op=release`
+##### `POST /api/2.0/machines/{system_id}/ op=release`
 
 Release a machine. Opposite of Machines.allocate.
 
@@ -2994,7 +3000,7 @@ Returns 404 if the machine is not found. Returns 403 if the user doesn't have
 permission to release the machine. Returns 409 if the machine is in a state
 where it may not be released.
 
-#### `POST /api/2.0/machines/{system_id}/ op=rescue_mode`
+##### `POST /api/2.0/machines/{system_id}/ op=rescue_mode`
 
 Begin rescue mode process for a machine.
 
@@ -3004,28 +3010,28 @@ process.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to start the rescue mode process for this machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=restore_default_configuration`
+##### `POST /api/2.0/machines/{system_id}/ op=restore_default_configuration`
 
 Reset a machine's configuration to its initial state.
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to reset the machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=restore_networking_configuration`
+##### `POST /api/2.0/machines/{system_id}/ op=restore_networking_configuration`
 
 Reset a machine's networking options to its initial state.
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to reset the machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=restore_storage_configuration`
+##### `POST /api/2.0/machines/{system_id}/ op=restore_storage_configuration`
 
 Reset a machine's storage options to its initial state.
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to reset the machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=set_owner_data`
+##### `POST /api/2.0/machines/{system_id}/ op=set_owner_data`
 
 Set key/value data for the current owner.
 
@@ -3039,7 +3045,7 @@ allocated to a user.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission.
 
-#### `POST /api/2.0/machines/{system_id}/ op=set_storage_layout`
+##### `POST /api/2.0/machines/{system_id}/ op=set_storage_layout`
 
 Changes the storage layout on the machine.
 
@@ -3095,7 +3101,7 @@ Returns 400 if the machine is currently not allocated. Returns 404 if the
 machine could not be found. Returns 403 if the user does not have permission
 to set the storage layout.
 
-#### `POST /api/2.0/machines/{system_id}/ op=test`
+##### `POST /api/2.0/machines/{system_id}/ op=test`
 
 Begin testing process for a node.
 
@@ -3122,7 +3128,7 @@ testing started.
 
 Returns 404 if the node is not found.
 
-#### `POST /api/2.0/machines/{system_id}/ op=unlock`
+##### `POST /api/2.0/machines/{system_id}/ op=unlock`
 
 Mark a machine as unlocked, allowing changes.
 
@@ -3135,7 +3141,7 @@ Mark a machine as unlocked, allowing changes.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission unlock the machine.
 
-#### `POST /api/2.0/machines/{system_id}/ op=unmount_special`
+##### `POST /api/2.0/machines/{system_id}/ op=unmount_special`
 
 Unmount a special-purpose filesystem, like tmpfs.
 
@@ -3144,7 +3150,7 @@ Unmount a special-purpose filesystem, like tmpfs.
 
 Returns 403 when the user is not permitted to unmount the partition.
 
-#### `PUT /api/2.0/machines/{system_id}/`
+##### `PUT /api/2.0/machines/{system_id}/`
 
 Update a specific Machine.
 
@@ -3242,7 +3248,7 @@ permission to update the machine.
 
 Manage the collection of all the machines in the MAAS.
 
-#### `GET /api/2.0/machines/`
+##### `GET /api/2.0/machines/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
@@ -3292,7 +3298,7 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 - `type agent_name`
    unicode
 
-#### `GET /api/2.0/machines/ op=is_registered`
+##### `GET /api/2.0/machines/ op=is_registered`
 
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
@@ -3311,11 +3317,11 @@ Returns whether or not the given MAC address is registered within this MAAS
 
 Returns 400 if any mandatory parameters are missing.
 
-#### `GET /api/2.0/machines/ op=list_allocated`
+##### `GET /api/2.0/machines/ op=list_allocated`
 
 Fetch Machines that were allocated to the User/oauth token.
 
-#### `GET /api/2.0/machines/ op=power_parameters`
+##### `GET /api/2.0/machines/ op=power_parameters`
 
 Retrieve power parameters for multiple machines.
 
@@ -3331,7 +3337,7 @@ Retrieve power parameters for multiple machines.
 
 Raises 403 if the user is not an admin.
 
-#### `POST /api/2.0/machines/`
+##### `POST /api/2.0/machines/`
 
 Create a new Machine.
 
@@ -3400,7 +3406,7 @@ cc- `dd`ee`ff")
 - `type power_type`
    unicode
 
-#### `POST /api/2.0/machines/ op=accept`
+##### `POST /api/2.0/machines/ op=accept`
 
 Accept declared machines into the MAAS.
 
@@ -3424,7 +3430,7 @@ that is already allocated, broken, etc. is.
 Returns 400 if any of the machines do not exist. Returns 403 if the user is
 not an admin.
 
-#### `POST /api/2.0/machines/ op=accept_all`
+##### `POST /api/2.0/machines/ op=accept_all`
 
 Accept all declared machines into the MAAS.
 
@@ -3437,7 +3443,7 @@ must first verify the authenticity of these enlistments, and accept them.
        by this call. Thus, machines that were already accepted are excluded
         from the result.
 
-#### `POST /api/2.0/machines/ op=add_chassis`
+##### `POST /api/2.0/machines/ op=add_chassis`
 
 Add special hardware types.
 
@@ -3449,7 +3455,7 @@ Add special hardware types.
         for the christmann RECS|Box servers. seamicro15k is the type for the
         Seamicro 1500 Chassis. ucsm is the type for the Cisco UCS Manager.
         virsh is the type for virtual machines managed by Virsh. vmware is the
-    - `type for virtual machines managed by VMware.`
+        type for virtual machines managed by VMware.
 
 - `type chassis_type`
    unicode
@@ -3542,7 +3548,7 @@ Returns 404 if no rack controller can be found which has access to the given
 URL. Returns 403 if the user does not have access to the rack controller.
 Returns 400 if the required parameters were not passed.
 
-#### `POST /api/2.0/machines/ op=allocate`
+##### `POST /api/2.0/machines/ op=allocate`
 
 Allocate an available machine for deployment.
 
@@ -3586,7 +3592,7 @@ constraints are provided, they are combined using 'AND' semantics.
 
 - `param mem`
    The minimum amount of memory (expressed in MB) the
-   - `return`ed machine must have. A machine with additional memory may be
+       returned machine must have. A machine with additional memory may be
         allocated if there is no exact match, or the 'cpu_count' constraint
         is not also specified.
 
@@ -3869,7 +3875,7 @@ constraints are provided, they are combined using 'AND' semantics.
 
 Returns 409 if a suitable machine matching the constraints could not be found.
 
-#### `POST /api/2.0/machines/ op=release`
+##### `POST /api/2.0/machines/ op=release`
 
 Release multiple machines.
 
@@ -3894,7 +3900,7 @@ Returns 400 if any of the machines cannot be found. Returns 403 if the user
 does not have permission to release any of the machines. Returns a 409 if any
 of the machines could not be released due to their current state.
 
-#### `POST /api/2.0/machines/ op=set_zone`
+##### `POST /api/2.0/machines/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
@@ -3914,35 +3920,35 @@ Manage a network.
 
 > This endpoint is deprecated. Use the new 'subnet' endpoint instead.
 
-#### `DELETE /api/2.0/networks/{name}/`
+##### `DELETE /api/2.0/networks/{name}/`
 
 Delete network definition.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-#### `GET /api/2.0/networks/{name}/`
+##### `GET /api/2.0/networks/{name}/`
 
 Read network definition.
 
-#### `GET /api/2.0/networks/{name}/ op=list_connected_macs`
+##### `GET /api/2.0/networks/{name}/ op=list_connected_macs`
 
 Returns the list of MAC addresses connected to this network.
 
 Only MAC addresses for nodes visible to the requesting user are returned.
 
-#### `POST /api/2.0/networks/{name}/ op=connect_macs`
+##### `POST /api/2.0/networks/{name}/ op=connect_macs`
 
 Connect the given MAC addresses to this network.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-#### `POST /api/2.0/networks/{name}/ op=disconnect_macs`
+##### `POST /api/2.0/networks/{name}/ op=disconnect_macs`
 
 Disconnect the given MAC addresses from this network.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-#### `PUT /api/2.0/networks/{name}/`
+##### `PUT /api/2.0/networks/{name}/`
 
 Update network definition.
 
@@ -3975,7 +3981,7 @@ Manage the networks.
 
 > This endpoint is deprecated. Use the new 'subnets' endpoint instead.
 
-#### `GET /api/2.0/networks/`
+##### `GET /api/2.0/networks/`
 
 List networks.
 
@@ -3984,7 +3990,7 @@ List networks.
        networks. If more than one node is given, the result will be
         restricted to networks that these nodes have in common.
 
-#### `POST /api/2.0/networks/`
+##### `POST /api/2.0/networks/`
 
 Define a network.
 
@@ -3996,7 +4002,7 @@ Manage an individual Node.
 
 > The Node is identified by its system_id.
 
-#### `DELETE /api/2.0/nodes/{system_id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/`
 
 Delete a specific Node.
 
@@ -4004,13 +4010,13 @@ Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to delete the node. Returns 204 if the node is successfully
 deleted.
 
-#### `GET /api/2.0/nodes/{system_id}/`
+##### `GET /api/2.0/nodes/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/nodes/{system_id}/ op=details`
+##### `GET /api/2.0/nodes/{system_id}/ op=details`
 
 Obtain various system details.
 
@@ -4025,7 +4031,7 @@ encoding like base-64.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/nodes/{system_id}/ op=power_parameters`
+##### `GET /api/2.0/nodes/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
@@ -4042,7 +4048,7 @@ Returns 404 if the node is not found.
 
 Read the collection of NodeResult in the MAAS.
 
-#### `GET /api/2.0/installation-results/`
+##### `GET /api/2.0/installation-results/`
 
 List NodeResult visible to the user, optionally filtered.
 
@@ -4071,11 +4077,11 @@ List NodeResult visible to the user, optionally filtered.
 
 Manage or view a custom script.
 
-#### `DELETE /api/2.0/scripts/{name}`
+##### `DELETE /api/2.0/scripts/{name}`
 
 Delete a script.
 
-#### `GET /api/2.0/scripts/{name}`
+##### `GET /api/2.0/scripts/{name}`
 
 Return a script's metadata.
 
@@ -4085,7 +4091,7 @@ Return a script's metadata.
 - `type include_script`
    bool
 
-#### `GET /api/2.0/scripts/{name} op=download`
+##### `GET /api/2.0/scripts/{name} op=download`
 
 Download a script.
 
@@ -4096,7 +4102,7 @@ Download a script.
 - `type revision`
    integer
 
-#### `POST /api/2.0/scripts/{name} op=add_tag`
+##### `POST /api/2.0/scripts/{name} op=add_tag`
 
 Add a single tag to a script.
 
@@ -4108,7 +4114,7 @@ Add a single tag to a script.
 
 Returns 404 if the script is not found.
 
-#### `POST /api/2.0/scripts/{name} op=remove_tag`
+##### `POST /api/2.0/scripts/{name} op=remove_tag`
 
 Remove a single tag to a script.
 
@@ -4120,7 +4126,7 @@ Remove a single tag to a script.
 
 Returns 404 if the script is not found.
 
-#### `POST /api/2.0/scripts/{name} op=revert`
+##### `POST /api/2.0/scripts/{name} op=revert`
 
 Revert a script to an earlier version.
 
@@ -4133,7 +4139,7 @@ Revert a script to an earlier version.
 
 Returns 404 if the script is not found.
 
-#### `PUT /api/2.0/scripts/{name}`
+##### `PUT /api/2.0/scripts/{name}`
 
 Update a commissioning script.
 
@@ -4247,14 +4253,14 @@ Update a commissioning script.
 
 Manage node script results.
 
-#### `DELETE /api/2.0/nodes/{system_id}/results/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/results/{id}/`
 
 Delete a set of results.
 
 id can either by the script set id, current-commissioning, current-testing, or
 current-installation.
 
-#### `GET /api/2.0/nodes/{system_id}/results/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/results/{id}/`
 
 View a specific set of results.
 
@@ -4281,7 +4287,7 @@ current-installation.
 - `type filters`
    unicode
 
-#### `GET /api/2.0/nodes/{system_id}/results/{id}/ op=download`
+##### `GET /api/2.0/nodes/{system_id}/results/{id}/ op=download`
 
 Download a compressed tar containing all results.
 
@@ -4319,7 +4325,7 @@ current-installation.
 
 Manage node script results.
 
-#### `GET /api/2.0/nodes/{system_id}/results/`
+##### `GET /api/2.0/nodes/{system_id}/results/`
 
 Return a list of script results grouped by run.
 
@@ -4356,7 +4362,7 @@ Manage custom scripts.
 
 > This functionality is only available to administrators.
 
-#### `GET /api/2.0/scripts/`
+##### `GET /api/2.0/scripts/`
 
 Return a list of stored scripts.
 
@@ -4387,7 +4393,7 @@ Return a list of stored scripts.
 - `type filters`
    unicode
 
-#### `POST /api/2.0/scripts/`
+##### `POST /api/2.0/scripts/`
 
 Create a new script.
 
@@ -4497,7 +4503,7 @@ Create a new script.
 
 Manage the collection of all the nodes in the MAAS.
 
-#### `GET /api/2.0/nodes/`
+##### `GET /api/2.0/nodes/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
@@ -4547,7 +4553,7 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 - `type agent_name`
    unicode
 
-#### `GET /api/2.0/nodes/ op=is_registered`
+##### `GET /api/2.0/nodes/ op=is_registered`
 
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
@@ -4566,7 +4572,7 @@ Returns whether or not the given MAC address is registered within this MAAS
 
 Returns 400 if any mandatory parameters are missing.
 
-#### `POST /api/2.0/nodes/ op=set_zone`
+##### `POST /api/2.0/nodes/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
@@ -4584,15 +4590,15 @@ Raises 403 if the user is not an admin.
 
 Manage an individual notification.
 
-#### `DELETE /api/2.0/notifications/{id}/`
+##### `DELETE /api/2.0/notifications/{id}/`
 
 Delete a specific notification.
 
-#### `GET /api/2.0/notifications/{id}/`
+##### `GET /api/2.0/notifications/{id}/`
 
 Read a specific notification.
 
-#### `POST /api/2.0/notifications/{id}/ op=dismiss`
+##### `POST /api/2.0/notifications/{id}/ op=dismiss`
 
 Dismiss a specific notification.
 
@@ -4601,7 +4607,7 @@ the invoking user.
 
 It is safe to call multiple times for the same notification.
 
-#### `PUT /api/2.0/notifications/{id}/`
+##### `PUT /api/2.0/notifications/{id}/`
 
 Update a specific notification.
 
@@ -4611,13 +4617,13 @@ See NotificationsHandler.create for field information.
 
 Manage the collection of all the notifications in MAAS.
 
-#### `GET /api/2.0/notifications/`
+##### `GET /api/2.0/notifications/`
 
 List notifications relevant to the invoking user.
 
 Notifications that have been dismissed are *not* returned.
 
-#### `POST /api/2.0/notifications/`
+##### `POST /api/2.0/notifications/`
 
 Create a notification.
 
@@ -4658,11 +4664,11 @@ not be seen by anyone.
 
 Manage the collection of all Package Repositories in MAAS.
 
-#### `GET /api/2.0/package-repositories/`
+##### `GET /api/2.0/package-repositories/`
 
 List all Package Repositories.
 
-#### `POST /api/2.0/package-repositories/`
+##### `POST /api/2.0/package-repositories/`
 
 Create a Package Repository.
 
@@ -4716,19 +4722,19 @@ Manage an individual Package Repository.
 
 > The Package Repository is identified by its id.
 
-#### `DELETE /api/2.0/package-repositories/{id}/`
+##### `DELETE /api/2.0/package-repositories/{id}/`
 
 Delete a Package Repository.
 
 Returns 404 if the Package Repository is not found.
 
-#### `GET /api/2.0/package-repositories/{id}/`
+##### `GET /api/2.0/package-repositories/{id}/`
 
 Read Package Repository.
 
 Returns 404 if the repository is not found.
 
-#### `PUT /api/2.0/package-repositories/{id}/`
+##### `PUT /api/2.0/package-repositories/{id}/`
 
 Update a Package Repository.
 
@@ -4782,19 +4788,19 @@ Returns 404 if the Package Repository is not found.
 
 Manage partition on a block device.
 
-#### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
+##### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
 
 Delete partition.
 
 Returns 404 if the node, block device, or partition are not found.
 
-#### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
+##### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
 
 Read partition.
 
 Returns 404 if the node, block device, or partition are not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=format`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=format`
 
 Format a partition.
 
@@ -4810,7 +4816,7 @@ Format a partition.
 Returns 403 when the user doesn't have the ability to format the partition.
 Returns 404 if the node, block device, or partition is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=mount`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=mount`
 
 Mount the filesystem on partition.
 
@@ -4823,11 +4829,11 @@ Mount the filesystem on partition.
 Returns 403 when the user doesn't have the ability to mount the partition.
 Returns 404 if the node, block device, or partition is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unformat`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unformat`
 
 Unformat a partition.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unmount`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unmount`
 
 Unmount the filesystem on partition.
 
@@ -4839,13 +4845,13 @@ Returns 404 if the node, block device, or partition is not found.
 
 Manage partitions on a block device.
 
-#### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
+##### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
 
 List all partitions on the block device.
 
 Returns 404 if the node or the block device are not found.
 
-#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
+##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
 
 Create a partition on the block device.
 
@@ -4855,7 +4861,7 @@ Create a partition on the block device.
 
 - `param uuid`
    UUID for the partition. Only used if the partition table
-   - `type for the block device is GPT.`
+       type for the block device is GPT.
 
 - `param bootable`
    If the partition should be marked bootable.
@@ -4868,16 +4874,16 @@ Manage an individual pod.
 
 > The pod is identified by its id.
 
-#### `DELETE /api/2.0/pods/{id}/`
+##### `DELETE /api/2.0/pods/{id}/`
 
 Delete a specific Pod.
 
 Returns 404 if the pod is not found. Returns 403 if the user does not have
 permission to delete the pod. Returns 204 if the pod is successfully deleted.
 
-#### `GET /api/2.0/pods/{id}/`
+##### `GET /api/2.0/pods/{id}/`
 
-#### `GET /api/2.0/pods/{id}/ op=parameters`
+##### `GET /api/2.0/pods/{id}/ op=parameters`
 
 Obtain pod parameters.
 
@@ -4890,7 +4896,7 @@ keys.
 
 Returns 404 if the pod is not found.
 
-#### `POST /api/2.0/pods/{id}/ op=add_tag`
+##### `POST /api/2.0/pods/{id}/ op=add_tag`
 
 Add a tag to Pod.
 
@@ -4900,7 +4906,7 @@ Add a tag to Pod.
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
 update the Pod.
 
-#### `POST /api/2.0/pods/{id}/ op=compose`
+##### `POST /api/2.0/pods/{id}/ op=compose`
 
 Compose a machine from Pod.
 
@@ -4943,7 +4949,7 @@ All fields below are optional- `
 Returns 404 if the pod is not found. Returns 403 if the user does not have
 permission to compose machine.
 
-#### `POST /api/2.0/pods/{id}/ op=refresh`
+##### `POST /api/2.0/pods/{id}/ op=refresh`
 
 Refresh a specific Pod.
 
@@ -4953,7 +4959,7 @@ machines.
 Returns 404 if the pod is not found. Returns 403 if the user does not have
 permission to refresh the pod.
 
-#### `POST /api/2.0/pods/{id}/ op=remove_tag`
+##### `POST /api/2.0/pods/{id}/ op=remove_tag`
 
 Remove a tag from Pod.
 
@@ -4963,7 +4969,7 @@ Remove a tag from Pod.
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
 update the Pod.
 
-#### `PUT /api/2.0/pods/{id}/`
+##### `PUT /api/2.0/pods/{id}/`
 
 Update a specific Pod.
 
@@ -4980,13 +4986,13 @@ permission to update the pod.
 
 Manage the collection of all the pod in the MAAS.
 
-#### `GET /api/2.0/pods/`
+##### `GET /api/2.0/pods/`
 
 List pods.
 
 Get a listing of all the pods.
 
-#### `POST /api/2.0/pods/`
+##### `POST /api/2.0/pods/`
 
 Create a Pod.
 
@@ -5011,7 +5017,7 @@ Manage an individual rack controller.
 
 > The rack controller is identified by its system_id.
 
-#### `DELETE /api/2.0/rackcontrollers/{system_id}/`
+##### `DELETE /api/2.0/rackcontrollers/{system_id}/`
 
 Delete a specific Node.
 
@@ -5019,13 +5025,13 @@ Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to delete the node. Returns 204 if the node is successfully
 deleted.
 
-#### `GET /api/2.0/rackcontrollers/{system_id}/`
+##### `GET /api/2.0/rackcontrollers/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/rackcontrollers/{system_id}/ op=details`
+##### `GET /api/2.0/rackcontrollers/{system_id}/ op=details`
 
 Obtain various system details.
 
@@ -5040,7 +5046,7 @@ encoding like base-64.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/rackcontrollers/{system_id}/ op=list_boot_images`
+##### `GET /api/2.0/rackcontrollers/{system_id}/ op=list_boot_images`
 
 List all available boot images.
 
@@ -5049,7 +5055,7 @@ region.
 
 Returns 404 if the rack controller is not found.
 
-#### `GET /api/2.0/rackcontrollers/{system_id}/ op=power_parameters`
+##### `GET /api/2.0/rackcontrollers/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
@@ -5062,7 +5068,7 @@ and secret keys.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/rackcontrollers/{system_id}/ op=query_power_state`
+##### `GET /api/2.0/rackcontrollers/{system_id}/ op=query_power_state`
 
 Query the power state of a node.
 
@@ -5080,7 +5086,7 @@ an appserver thread while waiting.
 
 Returns 404 if the node is not found. Returns node's power state.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=abort`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=abort`
 
 Abort a node's current operation.
 
@@ -5093,13 +5099,13 @@ Abort a node's current operation.
 Returns 404 if the node could not be found. Returns 403 if the user does not
 have permission to abort the current operation.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=import_boot_images`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=import_boot_images`
 
 Import the boot images on this rack controller.
 
 Returns 404 if the rack controller is not found.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=override_failed_testing`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=override_failed_testing`
 
 Ignore failed tests and put node back into a usable state.
 
@@ -5112,7 +5118,7 @@ Ignore failed tests and put node back into a usable state.
 Returns 404 if the machine is not found. Returns 403 if the user does not have
 permission to ignore tests for the node.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_off`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_off`
 
 Power off a node.
 
@@ -5137,7 +5143,7 @@ Power off a node.
 Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to stop the node.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_on`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_on`
 
 Turn on a node.
 
@@ -5163,7 +5169,7 @@ permission to start the machine. Returns 503 if the start-up attempted to
 allocate an IP address, and there were no IP addresses available on the
 relevant cluster interface.
 
-#### `POST /api/2.0/rackcontrollers/{system_id}/ op=test`
+##### `POST /api/2.0/rackcontrollers/{system_id}/ op=test`
 
 Begin testing process for a node.
 
@@ -5190,7 +5196,7 @@ testing started.
 
 Returns 404 if the node is not found.
 
-#### `PUT /api/2.0/rackcontrollers/{system_id}/`
+##### `PUT /api/2.0/rackcontrollers/{system_id}/`
 
 Update a specific Rack controller.
 
@@ -5236,7 +5242,7 @@ not have permission to update the rack controller.
 
 Manage the collection of all rack controllers in MAAS.
 
-#### `GET /api/2.0/rackcontrollers/`
+##### `GET /api/2.0/rackcontrollers/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
@@ -5286,14 +5292,14 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 - `type agent_name`
    unicode
 
-#### `GET /api/2.0/rackcontrollers/ op=describe_power_types`
+##### `GET /api/2.0/rackcontrollers/ op=describe_power_types`
 
 Query all of the rack controllers for power information.
 
 - `return`
    a list of dicts that describe the power types in this format.
 
-#### `GET /api/2.0/rackcontrollers/ op=is_registered`
+##### `GET /api/2.0/rackcontrollers/ op=is_registered`
 
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
@@ -5312,7 +5318,7 @@ Returns whether or not the given MAC address is registered within this MAAS
 
 Returns 400 if any mandatory parameters are missing.
 
-#### `GET /api/2.0/rackcontrollers/ op=power_parameters`
+##### `GET /api/2.0/rackcontrollers/ op=power_parameters`
 
 Retrieve power parameters for multiple machines.
 
@@ -5328,11 +5334,11 @@ Retrieve power parameters for multiple machines.
 
 Raises 403 if the user is not an admin.
 
-#### `POST /api/2.0/rackcontrollers/ op=import_boot_images`
+##### `POST /api/2.0/rackcontrollers/ op=import_boot_images`
 
 Import the boot images on all rack controllers.
 
-#### `POST /api/2.0/rackcontrollers/ op=set_zone`
+##### `POST /api/2.0/rackcontrollers/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
@@ -5350,20 +5356,20 @@ Raises 403 if the user is not an admin.
 
 Manage a specific RAID device on a machine.
 
-#### `DELETE /api/2.0/nodes/{system_id}/raid/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Delete RAID on a machine.
 
 Returns 404 if the machine or RAID is not found. Returns 409 if the machine is
 not Ready.
 
-#### `GET /api/2.0/nodes/{system_id}/raid/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Read RAID device on a machine.
 
 Returns 404 if the machine or RAID is not found.
 
-#### `PUT /api/2.0/nodes/{system_id}/raid/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Update RAID on a machine.
 
@@ -5406,13 +5412,13 @@ not Ready.
 
 Manage all RAID devices on a machine.
 
-#### `GET /api/2.0/nodes/{system_id}/raids/`
+##### `GET /api/2.0/nodes/{system_id}/raids/`
 
 List all RAID devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/raids/`
+##### `POST /api/2.0/nodes/{system_id}/raids/`
 
 Creates a RAID
 
@@ -5446,7 +5452,7 @@ Manage an individual region controller.
 
 > The region controller is identified by its system_id.
 
-#### `DELETE /api/2.0/regioncontrollers/{system_id}/`
+##### `DELETE /api/2.0/regioncontrollers/{system_id}/`
 
 Delete a specific Node.
 
@@ -5454,13 +5460,13 @@ Returns 404 if the node is not found. Returns 403 if the user does not have
 permission to delete the node. Returns 204 if the node is successfully
 deleted.
 
-#### `GET /api/2.0/regioncontrollers/{system_id}/`
+##### `GET /api/2.0/regioncontrollers/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/regioncontrollers/{system_id}/ op=details`
+##### `GET /api/2.0/regioncontrollers/{system_id}/ op=details`
 
 Obtain various system details.
 
@@ -5475,7 +5481,7 @@ encoding like base-64.
 
 Returns 404 if the node is not found.
 
-#### `GET /api/2.0/regioncontrollers/{system_id}/ op=power_parameters`
+##### `GET /api/2.0/regioncontrollers/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
@@ -5488,7 +5494,7 @@ and secret keys.
 
 Returns 404 if the node is not found.
 
-#### `PUT /api/2.0/regioncontrollers/{system_id}/`
+##### `PUT /api/2.0/regioncontrollers/{system_id}/`
 
 Update a specific Region controller.
 
@@ -5534,7 +5540,7 @@ does not have permission to update the region controller.
 
 Manage the collection of all region controllers in MAAS.
 
-#### `GET /api/2.0/regioncontrollers/`
+##### `GET /api/2.0/regioncontrollers/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
@@ -5584,7 +5590,7 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 - `type agent_name`
    unicode
 
-#### `GET /api/2.0/regioncontrollers/ op=is_registered`
+##### `GET /api/2.0/regioncontrollers/ op=is_registered`
 
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
@@ -5603,7 +5609,7 @@ Returns whether or not the given MAC address is registered within this MAAS
 
 Returns 400 if any mandatory parameters are missing.
 
-#### `POST /api/2.0/regioncontrollers/ op=set_zone`
+##### `POST /api/2.0/regioncontrollers/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
@@ -5623,14 +5629,14 @@ Manage an SSH key.
 
 > SSH keys can be retrieved or deleted.
 
-#### `DELETE /api/2.0/account/prefs/sshkeys/{id}/`
+##### `DELETE /api/2.0/account/prefs/sshkeys/{id}/`
 
 DELETE an SSH key.
 
 Returns 404 if the key does not exist. Returns 401 if the key does not belong
 to the calling user.
 
-#### `GET /api/2.0/account/prefs/sshkeys/{id}/`
+##### `GET /api/2.0/account/prefs/sshkeys/{id}/`
 
 GET an SSH key.
 
@@ -5640,18 +5646,18 @@ Returns 404 if the key does not exist.
 
 Manage the collection of all the SSH keys in this MAAS.
 
-#### `GET /api/2.0/account/prefs/sshkeys/`
+##### `GET /api/2.0/account/prefs/sshkeys/`
 
 List all keys belonging to the requesting user.
 
-#### `POST /api/2.0/account/prefs/sshkeys/`
+##### `POST /api/2.0/account/prefs/sshkeys/`
 
 Add a new SSH key to the requesting user's account.
 
 The request payload should contain the public SSH key data in form data whose
 name is "key".
 
-#### `POST /api/2.0/account/prefs/sshkeys/ op=import`
+##### `POST /api/2.0/account/prefs/sshkeys/ op=import`
 
 Import the requesting user's SSH keys.
 
@@ -5664,14 +5670,14 @@ Manage an SSL key.
 
 > SSL keys can be retrieved or deleted.
 
-#### `DELETE /api/2.0/account/prefs/sslkeys/{id}/`
+##### `DELETE /api/2.0/account/prefs/sslkeys/{id}/`
 
 DELETE an SSL key.
 
 Returns 401 if the key does not belong to the requesting user. Returns 204 if
 the key is successfully deleted.
 
-#### `GET /api/2.0/account/prefs/sslkeys/{id}/`
+##### `GET /api/2.0/account/prefs/sslkeys/{id}/`
 
 GET an SSL key.
 
@@ -5682,11 +5688,11 @@ belong to the requesting user.
 
 Operations on multiple keys.
 
-#### `GET /api/2.0/account/prefs/sslkeys/`
+##### `GET /api/2.0/account/prefs/sslkeys/`
 
 List all keys belonging to the requesting user.
 
-#### `POST /api/2.0/account/prefs/sslkeys/`
+##### `POST /api/2.0/account/prefs/sslkeys/`
 
 Add a new SSL key to the requesting user's account.
 
@@ -5697,19 +5703,19 @@ The request payload should contain the SSL key data in form data whose name is
 
 Manage space.
 
-#### `DELETE /api/2.0/spaces/{id}/`
+##### `DELETE /api/2.0/spaces/{id}/`
 
 Delete space.
 
 Returns 404 if the space is not found.
 
-#### `GET /api/2.0/spaces/{id}/`
+##### `GET /api/2.0/spaces/{id}/`
 
 Read space.
 
 Returns 404 if the space is not found.
 
-#### `PUT /api/2.0/spaces/{id}/`
+##### `PUT /api/2.0/spaces/{id}/`
 
 Update space.
 
@@ -5725,11 +5731,11 @@ Returns 404 if the space is not found.
 
 Manage spaces.
 
-#### `GET /api/2.0/spaces/`
+##### `GET /api/2.0/spaces/`
 
 List all spaces.
 
-#### `POST /api/2.0/spaces/`
+##### `POST /api/2.0/spaces/`
 
 Create a space.
 
@@ -5743,19 +5749,19 @@ Create a space.
 
 Manage static route.
 
-#### `DELETE /api/2.0/static-routes/{id}/`
+##### `DELETE /api/2.0/static-routes/{id}/`
 
 Delete static route.
 
 Returns 404 if the static route is not found.
 
-#### `GET /api/2.0/static-routes/{id}/`
+##### `GET /api/2.0/static-routes/{id}/`
 
 Read static route.
 
 Returns 404 if the static route is not found.
 
-#### `PUT /api/2.0/static-routes/{id}/`
+##### `PUT /api/2.0/static-routes/{id}/`
 
 Update static route.
 
@@ -5777,11 +5783,11 @@ Returns 404 if the static route is not found.
 
 Manage static routes.
 
-#### `GET /api/2.0/static-routes/`
+##### `GET /api/2.0/static-routes/`
 
 List all static routes.
 
-#### `POST /api/2.0/static-routes/`
+##### `POST /api/2.0/static-routes/`
 
 Create a static route.
 
@@ -5801,23 +5807,23 @@ Create a static route.
 
 Manage subnet.
 
-#### `DELETE /api/2.0/subnets/{id}/`
+##### `DELETE /api/2.0/subnets/{id}/`
 
 Delete subnet.
 
 Returns 404 if the subnet is not found.
 
-#### `GET /api/2.0/subnets/{id}/`
+##### `GET /api/2.0/subnets/{id}/`
 
 Read subnet.
 
 Returns 404 if the subnet is not found.
 
-#### `GET /api/2.0/subnets/{id}/ op=ip_addresses`
+##### `GET /api/2.0/subnets/{id}/ op=ip_addresses`
 
 Returns a summary of IP addresses assigned to this subnet.
 
-##### Optional parameters
+###### Optional parameters
 
 with_username
    If False, suppresses the display of usernames associated with each
@@ -5830,13 +5836,13 @@ with_summary
 with_node_summary
    Deprecated form of with_summary.
 
-#### `GET /api/2.0/subnets/{id}/ op=reserved_ip_ranges`
+##### `GET /api/2.0/subnets/{id}/ op=reserved_ip_ranges`
 
 Lists IP ranges currently reserved in the subnet.
 
 Returns 404 if the subnet is not found.
 
-#### `GET /api/2.0/subnets/{id}/ op=statistics`
+##### `GET /api/2.0/subnets/{id}/ op=statistics`
 
 Returns statistics for the specified subnet, including- `
 
@@ -5848,7 +5854,7 @@ usage- ` the (floating point) usage percentage of this subnet
 usage_string- ` the (formatted unicode) usage percentage of this subnet
 ranges- ` the specific IP ranges present in ths subnet (if specified)
 
-##### Optional parameters
+###### Optional parameters
 
 include_ranges
    If True, includes detailed information about the usage of this range.
@@ -5859,20 +5865,20 @@ include_suggestions
 
 Returns 404 if the subnet is not found.
 
-#### `GET /api/2.0/subnets/{id}/ op=unreserved_ip_ranges`
+##### `GET /api/2.0/subnets/{id}/ op=unreserved_ip_ranges`
 
 Lists IP ranges currently unreserved in the subnet.
 
 Returns 404 if the subnet is not found.
 
-#### `PUT /api/2.0/subnets/{id}/`
+##### `PUT /api/2.0/subnets/{id}/`
 
 Update the specified subnet.
 
 Please see the documentation for the 'create' operation for detailed
 descriptions of each parameter.
 
-##### Optional parameters
+###### Optional parameters
 
 name
    Name of the subnet.
@@ -5910,20 +5916,20 @@ Returns 404 if the subnet is not found.
 
 Manage subnets.
 
-#### `GET /api/2.0/subnets/`
+##### `GET /api/2.0/subnets/`
 
 List all subnets.
 
-#### `POST /api/2.0/subnets/`
+##### `POST /api/2.0/subnets/`
 
 Create a subnet.
 
-##### Required parameters
+###### Required parameters
 
 cidr
    The network CIDR for this subnet.
 
-##### Optional parameters
+###### Optional parameters
 
 name
    Name of the subnet.
@@ -5988,50 +5994,50 @@ Manage a Tag.
 >
 > A Tag is identified by its name.
 
-#### `DELETE /api/2.0/tags/{name}/`
+##### `DELETE /api/2.0/tags/{name}/`
 
 Delete a specific Tag.
 
 Returns 404 if the tag is not found. Returns 204 if the tag is successfully
 deleted.
 
-#### `GET /api/2.0/tags/{name}/`
+##### `GET /api/2.0/tags/{name}/`
 
 Read a specific Tag.
 
 Returns 404 if the tag is not found.
 
-#### `GET /api/2.0/tags/{name}/ op=devices`
+##### `GET /api/2.0/tags/{name}/ op=devices`
 
 Get the list of devices that have this tag.
 
 Returns 404 if the tag is not found.
 
-#### `GET /api/2.0/tags/{name}/ op=machines`
+##### `GET /api/2.0/tags/{name}/ op=machines`
 
 Get the list of machines that have this tag.
 
 Returns 404 if the tag is not found.
 
-#### `GET /api/2.0/tags/{name}/ op=nodes`
+##### `GET /api/2.0/tags/{name}/ op=nodes`
 
 Get the list of nodes that have this tag.
 
 Returns 404 if the tag is not found.
 
-#### `GET /api/2.0/tags/{name}/ op=rack_controllers`
+##### `GET /api/2.0/tags/{name}/ op=rack_controllers`
 
 Get the list of rack controllers that have this tag.
 
 Returns 404 if the tag is not found.
 
-#### `GET /api/2.0/tags/{name}/ op=region_controllers`
+##### `GET /api/2.0/tags/{name}/ op=region_controllers`
 
 Get the list of region controllers that have this tag.
 
 Returns 404 if the tag is not found.
 
-#### `POST /api/2.0/tags/{name}/ op=rebuild`
+##### `POST /api/2.0/tags/{name}/ op=rebuild`
 
 Manually trigger a rebuild the tag &lt;=&gt; node mapping.
 
@@ -6041,7 +6047,7 @@ trigger the appropriate changes.
 
 Returns 404 if the tag is not found.
 
-#### `POST /api/2.0/tags/{name}/ op=update_nodes`
+##### `POST /api/2.0/tags/{name}/ op=update_nodes`
 
 Add or remove nodes being associated with this tag.
 
@@ -6067,7 +6073,7 @@ Returns 404 if the tag is not found. Returns 401 if the user does not have
 permission to update the nodes. Returns 409 if 'definition' doesn't match the
 current definition.
 
-#### `PUT /api/2.0/tags/{name}/`
+##### `PUT /api/2.0/tags/{name}/`
 
 Update a specific Tag.
 
@@ -6089,13 +6095,13 @@ Returns 404 if the tag is not found.
 
 Manage the collection of all the Tags in this MAAS.
 
-#### `GET /api/2.0/tags/`
+##### `GET /api/2.0/tags/`
 
 List Tags.
 
 Get a listing of all tags that are currently defined.
 
-#### `POST /api/2.0/tags/`
+##### `POST /api/2.0/tags/`
 
 Create a new Tag.
 
@@ -6124,25 +6130,25 @@ Returns 401 if the user is not an admin.
 
 Manage a user account.
 
-#### `DELETE /api/2.0/users/{username}/`
+##### `DELETE /api/2.0/users/{username}/`
 
 Deletes a user
 
-#### `GET /api/2.0/users/{username}/`
+##### `GET /api/2.0/users/{username}/`
 
 ### Users
 
 Manage the user accounts of this MAAS.
 
-#### `GET /api/2.0/users/`
+##### `GET /api/2.0/users/`
 
 List users.
 
-#### `GET /api/2.0/users/ op=whoami`
+##### `GET /api/2.0/users/ op=whoami`
 
 Returns the currently logged in user.
 
-#### `POST /api/2.0/users/`
+##### `POST /api/2.0/users/`
 
 Create a MAAS user account.
 
@@ -6189,7 +6195,7 @@ Information about this MAAS instance.
 > >
 > > }
 
-#### `GET /api/2.0/version/`
+##### `GET /api/2.0/version/`
 
 Version and capabilities of this MAAS instance.
 
@@ -6197,19 +6203,19 @@ Version and capabilities of this MAAS instance.
 
 Manage VLAN on a fabric.
 
-#### `DELETE /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+##### `DELETE /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Delete VLAN on fabric.
 
 Returns 404 if the fabric or VLAN is not found.
 
-#### `GET /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+##### `GET /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Read VLAN on fabric.
 
 Returns 404 if the fabric or VLAN is not found.
 
-#### `PUT /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+##### `PUT /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Update VLAN.
 
@@ -6279,13 +6285,13 @@ Returns 404 if the fabric or VLAN is not found.
 
 Manage VLANs on a fabric.
 
-#### `GET /api/2.0/fabrics/{fabric_id}/vlans/`
+##### `GET /api/2.0/fabrics/{fabric_id}/vlans/`
 
 List all VLANs belonging to fabric.
 
 Returns 404 if the fabric is not found.
 
-#### `POST /api/2.0/fabrics/{fabric_id}/vlans/`
+##### `POST /api/2.0/fabrics/{fabric_id}/vlans/`
 
 Create a VLAN.
 
@@ -6325,20 +6331,20 @@ Create a VLAN.
 
 Manage volume group on a machine.
 
-#### `DELETE /api/2.0/nodes/{system_id}/volume-group/{id}/`
+##### `DELETE /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Delete volume group on a machine.
 
 Returns 404 if the machine or volume group is not found. Returns 409 if the
 machine is not Ready.
 
-#### `GET /api/2.0/nodes/{system_id}/volume-group/{id}/`
+##### `GET /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Read volume group on a machine.
 
 Returns 404 if the machine or volume group is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=create_logical_volume`
+##### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=create_logical_volume`
 
 Create a logical volume in the volume group.
 
@@ -6354,7 +6360,7 @@ Create a logical volume in the volume group.
 Returns 404 if the machine or volume group is not found. Returns 409 if the
 machine is not Ready.
 
-#### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=delete_logical_volume`
+##### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=delete_logical_volume`
 
 Delete a logical volume in the volume group.
 
@@ -6364,7 +6370,7 @@ Delete a logical volume in the volume group.
 Returns 403 if no logical volume with id. Returns 404 if the machine or volume
 group is not found. Returns 409 if the machine is not Ready.
 
-#### `PUT /api/2.0/nodes/{system_id}/volume-group/{id}/`
+##### `PUT /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Read volume group on a machine.
 
@@ -6394,13 +6400,13 @@ machine is not Ready.
 
 Manage volume groups on a machine.
 
-#### `GET /api/2.0/nodes/{system_id}/volume-groups/`
+##### `GET /api/2.0/nodes/{system_id}/volume-groups/`
 
 List all volume groups belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-#### `POST /api/2.0/nodes/{system_id}/volume-groups/`
+##### `POST /api/2.0/nodes/{system_id}/volume-groups/`
 
 Create a volume group belonging to machine.
 
@@ -6431,20 +6437,20 @@ Manage a physical zone.
 > This functionality is only available to administrators. Other users can view
 > physical zones, but not modify them.
 
-#### `DELETE /api/2.0/zones/{name}/`
+##### `DELETE /api/2.0/zones/{name}/`
 
 DELETE request. Delete zone.
 
 Returns 404 if the zone is not found. Returns 204 if the zone is successfully
 deleted.
 
-#### `GET /api/2.0/zones/{name}/`
+##### `GET /api/2.0/zones/{name}/`
 
 GET request. Return zone.
 
 Returns 404 if the zone is not found.
 
-#### `PUT /api/2.0/zones/{name}/`
+##### `PUT /api/2.0/zones/{name}/`
 
 PUT request. Update zone.
 
@@ -6454,13 +6460,13 @@ Returns 404 if the zone is not found.
 
 Manage physical zones.
 
-#### `GET /api/2.0/zones/`
+##### `GET /api/2.0/zones/`
 
 List zones.
 
 Get a listing of all the physical zones.
 
-#### `POST /api/2.0/zones/`
+##### `POST /api/2.0/zones/`
 
 Create a new physical zone.
 

--- a/en/api.md
+++ b/en/api.md
@@ -1,3 +1,6 @@
+Title: API | MAAS
+table_of_contents: True
+
 # MAAS API
 
 Restful MAAS API.

--- a/en/api.md
+++ b/en/api.md
@@ -23,7 +23,7 @@ error message and the api version are returned as plaintext.
 
 ## HTTP methods and parameter-passing
 
-The following HTTP methods are available for accessing the API: 
+The following HTTP methods are available for accessing the API:
     -   GET (for information retrieval and queries),
     -   POST (for asking the system to do things),
     -   PUT (for updating objects), and
@@ -31,7 +31,7 @@ The following HTTP methods are available for accessing the API:
 
 All methods except DELETE may take parameters, but they are not all passed in
 the same way. GET parameters are passed in the URL, as is normal with a
-GET- ` "/item/?foo=bar" passes parameter "foo" with value "bar".
+GET: "/item/?foo=bar" passes parameter "foo" with value "bar".
 
 POST and PUT are different. Your request should have MIME type
 "multipart/form-data"; each part represents one parameter (for POST) or
@@ -58,56 +58,56 @@ Manage the current logged-in user.
 
 List authorisation tokens available to the currently logged-in user.
 
-- `return`
+:return`
    list of dictionaries representing each key's name and token.
 
 ##### `POST /api/2.0/account/ op=create_authorisation_token`
 
 Create an authorisation OAuth token and OAuth consumer.
 
-- `param name`
+:param name`
    Optional name of the token that will be generated.
 
-- `type name`
+:type name`
    unicode
 
-- `return`
-   a json dict with four keys- ` 'token_key',
-       'token_secret', 'consumer_key' and 'name'(e.g. {token_key- `
-        's65244576fgqs', token_secret- `
+:return`
+   a json dict with four keys: 'token_key',
+       'token_secret', 'consumer_key' and 'name'(e.g. {token_key:
+        's65244576fgqs', token_secret:
 
     'qsdfdhv34',
-       consumer_key- ` '68543fhj854fg', name`
+       consumer_key: '68543fhj854fg', name`
 
     'MAAS consumer'}).
 
-- `rtype`
+:rtype`
    string (json)
 
 ##### `POST /api/2.0/account/ op=delete_authorisation_token`
 
 Delete an authorisation OAuth token and the related OAuth consumer.
 
-- `param token_key`
+:param token_key`
    The key of the token to be deleted.
 
-- `type token_key`
+:type token_key`
    unicode
 
 ##### `POST /api/2.0/account/ op=update_token_name`
 
 Modify the consumer name of an authorisation OAuth token.
 
-- `param token`
+:param token`
    Can be the whole token or only the token key.
 
-- `type token`
+:type token`
    unicode
 
-- `param name`
+:param name`
    New name of the token.
 
-- `type name`
+:type name`
    unicode
 
 ### Bcache Cache Set
@@ -131,10 +131,10 @@ Returns 404 if the machine or cache set is not found.
 
 Delete bcache on a machine.
 
-- `param cache_device`
+:param cache_device`
    Cache block device to replace current one.
 
-- `param cache_partition`
+:param cache_partition`
    Cache partition to replace current one.
 
 Specifying both a cache_device and a cache_partition is not allowed.
@@ -156,10 +156,10 @@ Returns 404 if the machine is not found.
 
 Creates a Bcache Cache Set.
 
-- `param cache_device`
+:param cache_device`
    Cache block device.
 
-- `param cache_partition`
+:param cache_partition`
    Cache partition.
 
 Specifying both a cache_device and a cache_partition is not allowed.
@@ -188,22 +188,22 @@ Returns 404 if the machine or bcache is not found.
 
 Delete bcache on a machine.
 
-- `param name`
+:param name`
    Name of the Bcache.
 
-- `param uuid`
+:param uuid`
    UUID of the Bcache.
 
-- `param cache_set`
+:param cache_set`
    Cache set to replace current one.
 
-- `param backing_device`
+:param backing_device`
    Backing block device to replace current one.
 
-- `param backing_partition`
+:param backing_partition`
    Backing partition to replace current one.
 
-- `param cache_mode`
+:param cache_mode`
    Cache mode (writeback, writethrough, writearound).
 
 Specifying both a device and a partition for a given role (cache or backing)
@@ -226,22 +226,22 @@ Returns 404 if the machine is not found.
 
 Creates a Bcache.
 
-- `param name`
+:param name`
    Name of the Bcache.
 
-- `param uuid`
+:param uuid`
    UUID of the Bcache.
 
-- `param cache_set`
+:param cache_set`
    Cache set.
 
-- `param backing_device`
+:param backing_device`
    Backing block device.
 
-- `param backing_partition`
+:param backing_partition`
    Backing partition.
 
-- `param cache_mode`
+:param cache_mode`
    Cache mode (WRITEBACK, WRITETHROUGH, WRITEAROUND).
 
 Specifying both a device and a partition for a given role (cache or backing)
@@ -272,7 +272,7 @@ Returns 404 if the machine or block device is not found.
 
 Add a tag to block device on a machine.
 
-- `param tag`
+:param tag`
    The tag being added.
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -283,10 +283,10 @@ not Ready.
 
 Format block device with filesystem.
 
-- `param fstype`
+:param fstype`
    Type of filesystem.
 
-- `param uuid`
+:param uuid`
    UUID of the filesystem.
 
 Returns 403 when the user doesn't have the ability to format the block device.
@@ -297,10 +297,10 @@ machine is not Ready or Allocated.
 
 Mount the filesystem on block device.
 
-- `param mount_point`
+:param mount_point`
    Path on the filesystem to mount.
 
-- `param mount_options`
+:param mount_options`
    Options to pass to mount(8).
 
 Returns 403 when the user doesn't have the ability to mount the block device.
@@ -311,7 +311,7 @@ machine is not Ready or Allocated.
 
 Remove a tag from block device on a machine.
 
-- `param tag`
+:param tag`
    The tag being removed.
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -354,37 +354,37 @@ with Deployed status can only have the name, model, serial, and/or id_path
 updated for a block device. This is intented to allow a bad block device to be
 replaced while the machine remains deployed.
 
-Fields for physical block device- `
+Fields for physical block device:
 
-- `param name`
+:param name`
    Name of the block device.
 
-- `param model`
+:param model`
    Model of the block device.
 
-- `param serial`
+:param serial`
    Serial number of the block device.
 
-- `param id_path`
+:param id_path`
    (optional) Only used if model and serial cannot be provided. This should
     be a path that is fixed and doesn't change depending on the boot order or
     kernel version.
 
-- `param size`
+:param size`
    Size of the block device.
 
-- `param block_size`
+:param block_size`
    Block size of the block device.
 
-Fields for virtual block device- `
+Fields for virtual block device:
 
-- `param name`
+:param name`
    Name of the block device.
 
-- `param uuid`
+:param uuid`
    UUID of the block device.
 
-- `param size`
+:param size`
    Size of the block device. (Only allowed for logical volumes.)
 
 Returns 404 if the machine or block device is not found. Returns 403 if the
@@ -405,24 +405,24 @@ Returns 404 if the machine is not found.
 
 Create a physical block device.
 
-- `param name`
+:param name`
    Name of the block device.
 
-- `param model`
+:param model`
    Model of the block device.
 
-- `param serial`
+:param serial`
    Serial number of the block device.
 
-- `param id_path`
+:param id_path`
    (optional) Only used if model and serial cannot be
        provided. This should be a path that is fixed and doesn't change
         depending on the boot order or kernel version.
 
-- `param size`
+:param size`
    Size of the block device.
 
-- `param block_size`
+:param block_size`
    Block size of the block device.
 
 Returns 404 if the node is not found.
@@ -447,8 +447,8 @@ Manage the boot resources.
 
 List all boot resources.
 
-- `param type`
-   Type of boot resources to list. Default- ` all
+:param type`
+   Type of boot resources to list. Default: all
 
 ##### `GET /api/2.0/boot-resources/ op=is_importing`
 
@@ -458,22 +458,22 @@ Return import status.
 
 Uploads a new boot resource.
 
-- `param name`
+:param name`
    Name of the boot resource.
 
-- `param title`
+:param title`
    Title for the boot resource.
 
-- `param architecture`
+:param architecture`
    Architecture the boot resource supports.
 
-- `param filetype`
-   Filetype for uploaded content. (Default- ` tgz,
-       Supported- ` tgz, ddtgz, ddtbz, ddtxz, ddtar, ddbz2, ddgz, ddxz,
+:param filetype`
+   Filetype for uploaded content. (Default: tgz,
+       Supported: tgz, ddtgz, ddtbz, ddtxz, ddtar, ddbz2, ddgz, ddxz,
         ddraw
 
-- `param content`
-   Image content. Note- ` this is not a normal parameter,
+:param content`
+   Image content. Note: this is not a normal parameter,
        but a file upload.
 
 ##### `POST /api/2.0/boot-resources/ op=import`
@@ -500,14 +500,14 @@ Read a boot source.
 
 Update a specific boot source.
 
-- `param url`
+:param url`
    The URL of the BootSource.
 
-- `param keyring_filename`
+:param keyring_filename`
    The path to the keyring file for this
        BootSource.
 
-- `param keyring_data`
+:param keyring_data`
    The GPG keyring for this BootSource,
        base64-encoded data.
 
@@ -527,20 +527,20 @@ Read a boot source selection.
 
 Update a specific boot source selection.
 
-- `param os`
+:param os`
    The OS (e.g. ubuntu, centos) for which to import resources.
 
-- `param release`
+:param release`
    The release for which to import resources.
 
-- `param arches`
+:param arches`
    The list of architectures for which to import resources.
 
-- `param subarches`
+:param subarches`
    The list of subarchitectures for which to import
        resources.
 
-- `param labels`
+:param labels`
    The list of labels for which to import resources.
 
 ### Boot source selections
@@ -557,20 +557,20 @@ Get a listing of a boot source's selections.
 
 Create a new boot source selection.
 
-- `param os`
+:param os`
    The OS (e.g. ubuntu, centos) for which to import resources.
 
-- `param release`
+:param release`
    The release for which to import resources.
 
-- `param arches`
+:param arches`
    The architecture list for which to import resources.
 
-- `param subarches`
+:param subarches`
    The subarchitecture list for which to import
        resources.
 
-- `param labels`
+:param labels`
    The label lists for which to import resources.
 
 ### Boot sources
@@ -587,14 +587,14 @@ Get a listing of boot sources.
 
 Create a new boot source.
 
-- `param url`
+:param url`
    The URL of the BootSource.
 
-- `param keyring_filename`
+:param keyring_filename`
    The path to the keyring file for
        this BootSource.
 
-- `param keyring_data`
+:param keyring_data`
    The GPG keyring for this BootSource,
        base64-encoded.
 
@@ -656,13 +656,13 @@ commissioning script might consist of a binary tool provided by a hardware
 vendor. Either way, the script gets passed to the commissioning machine in the
 exact form in which it was uploaded.
 
-- `param name`
+:param name`
    Unique identifying name for the script. Names should
        follow the pattern of "25-burn-in-hard-disk" (all ASCII, and with
         numbers greater than zero, and generally no "weird" characters).
 
-- `param content`
-   A script file, to be uploaded in binary form. Note- `
+:param content`
+   A script file, to be uploaded in binary form. Note:
        this is not a normal parameter, but a file upload. Its filename is
         ignored; MAAS will know it by the name you pass to the request.
 
@@ -688,12 +688,12 @@ Returns 404 if the snippet is not found.
 
 Revert the value of a DHCP snippet to an earlier revision.
 
-- `param to`
+:param to`
    What revision in the DHCP snippet's history to revert to.
        This can either be an ID or a negative number representing how far
         back to go.
 
-- `type to`
+:type to`
    integer
 
 Returns 404 if the DHCP snippet is not found.
@@ -702,50 +702,50 @@ Returns 404 if the DHCP snippet is not found.
 
 Update a DHCP snippet.
 
-- `param name`
+:param name`
    The name of the DHCP snippet.
 
-- `type name`
+:type name`
    unicode
 
-- `param value`
+:param value`
    The new value of the DHCP snippet to be used in
        dhcpd.conf. Previous values are stored and can be reverted.
 
-- `type value`
+:type value`
    unicode
 
-- `param description`
+:param description`
    A description of what the DHCP snippet does.
 
-- `type description`
+:type description`
    unicode
 
-- `param enabled`
+:param enabled`
    Whether or not the DHCP snippet is currently enabled.
 
-- `type enabled`
+:type enabled`
    boolean
 
-- `param node`
+:param node`
    The node the DHCP snippet is to be used for. Can not be
        set if subnet is set.
 
-- `type node`
+:type node`
    unicode
 
-- `param subnet`
+:param subnet`
    The subnet the DHCP snippet is to be used for. Can not
        be set if node is set.
 
-- `type subnet`
+:type subnet`
    unicode
 
-- `param global_snippet`
+:param global_snippet`
    Set the DHCP snippet to be a global option. This
        removes any node or subnet links.
 
-- `type global_snippet`
+:type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -762,51 +762,51 @@ List all DHCP snippets.
 
 Create a DHCP snippet.
 
-- `param name`
+:param name`
    The name of the DHCP snippet. This is required to create
        a new DHCP snippet.
 
-- `type name`
+:type name`
    unicode
 
-- `param value`
+:param value`
    The snippet of config inserted into dhcpd.conf. This is
        required to create a new DHCP snippet.
 
-- `type value`
+:type value`
    unicode
 
-- `param description`
+:param description`
    A description of what the snippet does.
 
-- `type description`
+:type description`
    unicode
 
-- `param enabled`
+:param enabled`
    Whether or not the snippet is currently enabled.
 
-- `type enabled`
+:type enabled`
    boolean
 
-- `param node`
+:param node`
    The node this snippet applies to. Cannot be used with
        subnet or global_snippet.
 
-- `type node`
+:type node`
    unicode
 
-- `param subnet`
+:param subnet`
    The subnet this snippet applies to. Cannot be used with
        node or global_snippet.
 
-- `type subnet`
+:type subnet`
    unicode
 
-- `param global_snippet`
+:param global_snippet`
    Whether or not this snippet is to be applied
        globally. Cannot be used with node or subnet.
 
-- `type global_snippet`
+:type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -832,10 +832,10 @@ Returns 404 if the dnsresource is not found.
 
 Update dnsresource.
 
-- `param fqdn`
+:param fqdn`
    Hostname (with domain) for the dnsresource.
 
-- `param ip_address`
+:param ip_address`
    Address to assign to the dnsresource.
 
 Returns 403 if the user does not have permission to update the dnsresource.
@@ -862,10 +862,10 @@ Returns 404 if the dnsresourcerecord is not found.
 
 Update dnsresourcerecord.
 
-- `param rrtype`
+:param rrtype`
    Resource Type
 
-- `param rrdata`
+:param rrdata`
    Resource Data (everything to the right of Type.)
 
 Returns 403 if the user does not have permission to update the
@@ -879,13 +879,13 @@ Manage DNS resource records (e.g. CNAME, MX, NS, SRV, TXT)
 
 List all dnsresourcerecords.
 
-- `param domain`
+:param domain`
    restrict the listing to entries for the domain.
 
-- `param name`
+:param name`
    restrict the listing to entries of the given name.
 
-- `param rrtype`
+:param rrtype`
    restrict the listing to entries which have
        records of the given rrtype.
 
@@ -893,24 +893,24 @@ List all dnsresourcerecords.
 
 Create a DNS resource record.
 
-- `param fqdn`
+:param fqdn`
    Hostname (with domain) for the dnsresource. Either fqdn
        or (name, domain) must be specified. Fqdn is ignored if either name or
         domain is given (e.g. www.your-maas.maas).
 
-- `param name`
+:param name`
    The name (or hostname without a domain) of the DNS
        resource record (e.g. www.your-maas)
 
-- `param domain`
+:param domain`
    The domain (name or id) where to create the DNS
        resource record (Domain (e.g. 'maas')
 
-- `param rrtype`
+:param rrtype`
    The resource record type (e.g 'cname', 'mx', 'ns',
        'srv', 'sshfp', 'txt')
 
-- `param rrdata`
+:param rrdata`
    The resource record data (e.g. 'your-maas',
        '10 mail.your-maas.maas')
 
@@ -922,13 +922,13 @@ Manage dnsresources.
 
 List all resources for the specified criteria.
 
-- `param domain`
+:param domain`
    restrict the listing to entries for the domain.
 
-- `param name`
+:param name`
    restrict the listing to entries of the given name.
 
-- `param rrtype`
+:param rrtype`
    restrict the listing to entries which have
        records of the given rrtype.
 
@@ -936,21 +936,21 @@ List all resources for the specified criteria.
 
 Create a dnsresource.
 
-- `param fqdn`
+:param fqdn`
    Hostname (with domain) for the dnsresource. Either fqdn
        or (name, domain) must be specified. Fqdn is ignored if either name or
         domain is given.
 
-- `param name`
+:param name`
    Hostname (without domain)
 
-- `param domain`
+:param domain`
    Domain (name or id)
 
-- `param address_ttl`
+:param address_ttl`
    Default ttl for entries in this zone.
 
-- `param ip_addresses`
+:param ip_addresses`
    (optional) Address (ip or id) to assign to the
        dnsresource.
 
@@ -980,7 +980,7 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
@@ -1034,31 +1034,31 @@ permission.
 
 Update a specific device.
 
-- `param hostname`
+:param hostname`
    The new hostname for this device.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param domain`
+:param domain`
    The domain for this device.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param parent`
+:param parent`
    Optional system_id to indicate this device's parent.
        If the parent is already set and this parameter is omitted, the parent
         will be unchanged.
 
-- `type parent`
+:type parent`
    unicode
 
-- `param zone`
+:param zone`
    Name of a valid physical zone in which to place this
        node.
 
-- `type zone`
+:type zone`
    unicode
 
 Returns 404 if the device is not found. Returns 403 if the user does not have
@@ -1074,48 +1074,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only nodes relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to see multiple nodes.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param mac_address`
+:param mac_address`
    An optional MAC address. Only nodes relating to the
        node owning the specified MAC address will be returned. This can be
         specified multiple times to see multiple nodes.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes relating to the
        nodes with matching system ids will be returned.
 
-- `type id`
+:type id`
    unicode
 
-- `param domain`
+:param domain`
    An optional name for a dns domain. Only nodes relating
        to the nodes in the domain will be returned.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes relating
        to the nodes in the zone will be returned.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes relating to the
        nodes with matching agent names will be returned.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
 ##### `GET /api/2.0/devices/ op=is_registered`
@@ -1123,16 +1123,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-- `param mac_address`
+:param mac_address`
    The mac address to be checked.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `return`
+:return`
    'true' or 'false'.
 
-- `rtype`
+:rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -1141,40 +1141,40 @@ Returns 400 if any mandatory parameters are missing.
 
 Create a new device.
 
-- `param hostname`
+:param hostname`
    A hostname. If not given, one will be generated.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param domain`
+:param domain`
    The domain of the device. If not given the default
        domain is used.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param mac_addresses`
+:param mac_addresses`
    One or more MAC addresses for the device.
 
-- `type mac_addresses`
+:type mac_addresses`
    unicode
 
-- `param parent`
+:param parent`
    The system id of the parent. Optional.
 
-- `type parent`
+:type parent`
    unicode
 
 ##### `POST /api/2.0/devices/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
-- `param zone`
+:param zone`
    Zone name. If omitted, the zone is "none" and the nodes
        will be taken out of their physical zones.
 
-- `param nodes`
+:param nodes`
    system_ids of the nodes whose zones are to be set.
        (An empty list is acceptable).
 
@@ -1227,13 +1227,13 @@ Discoveries are listed in the order they were last observed on the network
 
 Deletes all discovered neighbours and/or mDNS entries.
 
-- `param mdns`
+:param mdns`
    if True, deletes all mDNS entries.
 
-- `param neighbours`
+:param neighbours`
    if True, deletes all neighbour entries.
 
-- `param all`
+:param all`
    if True, deletes all discovery data.
 
 ##### `POST /api/2.0/discovery/ op=scan`
@@ -1251,46 +1251,46 @@ controllers that do not have 'nmap' installed and are connected to large
 networks.
 
 If the call is a success, this method will return a dictionary of results as
-follows- `
+follows:
 
-result- ` A human-readable string summarizing the results.
-scan_attempted_on- ` A list of rack 'system_id' values where a scan was
+result: A human-readable string summarizing the results.
+scan_attempted_on: A list of rack 'system_id' values where a scan was
 attempted. (That is, an RPC connection was successful and a subsequent call
 was intended.)
 
-failed_to_connect_to- ` A list of rack 'system_id' values where the RPC
+failed_to_connect_to: A list of rack 'system_id' values where the RPC
 connection failed.
 
-scan_started_on- ` A list of rack 'system_id' values where a scan was
+scan_started_on: A list of rack 'system_id' values where a scan was
 successfully started.
 
-scan_failed_on- ` A list of rack 'system_id' values where a scan was
+scan_failed_on: A list of rack 'system_id' values where a scan was
 attempted, but failed because a scan was already in progress.
 
-rpc_call_timed_out_on- ` A list of rack 'system_id' values where the
+rpc_call_timed_out_on: A list of rack 'system_id' values where the
 RPC connection was made, but the call timed out before a ten second timeout
 elapsed.
 
-- `param cidr`
+:param cidr`
    The subnet CIDR(s) to scan (can be specified multiple
        times). If not specified, defaults to all networks.
 
-- `param force`
+:param force`
    If True, will force the scan, even if all networks are
        specified. (This may not be the best idea, depending on acceptable use
         agreements, and the politics of the organization that owns the
-        network.) Default- ` False.
+        network.) Default: False.
 
-- `param always_use_ping`
+:param always_use_ping`
    If True, will force the scan to use 'ping' even
-       if 'nmap' is installed. Default- ` False.
+       if 'nmap' is installed. Default: False.
 
-- `param slow`
+:param slow`
    If True, and 'nmap' is being used, will limit the scan
        to nine packets per second. If the scanner is 'ping', this option has
-        no effect. Default- ` False.
+        no effect. Default: False.
 
-- `param threads`
+:param threads`
    The number of threads to use during scanning. If 'nmap'
        is the scanner, the default is one thread per 'nmap' process. If
         'ping' is the scanner, the default is four threads per CPU.
@@ -1322,13 +1322,13 @@ Returns 404 if the domain is not found.
 
 Update domain.
 
-- `param name`
+:param name`
    Name of the domain.
 
-- `param authoritative`
+:param authoritative`
    True if we are authoritative for this domain.
 
-- `param ttl`
+:param ttl`
    The default TTL for this domain.
 
 Returns 403 if the user does not have permission to update the dnsresource.
@@ -1346,17 +1346,17 @@ List all domains.
 
 Create a domain.
 
-- `param name`
+:param name`
    Name of the domain.
 
-- `param authoritative`
+:param authoritative`
    Class type of the domain.
 
 ##### `POST /api/2.0/domains/ op=set_serial`
 
 Set the SOA serial number (for all DNS zones.)
 
-- `param serial`
+:param serial`
    serial number to use next.
 
 ### Events
@@ -1371,45 +1371,45 @@ Retrieve filtered node events.
 List Node events, optionally filtered by various criteria via URL query
 parameters.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only events relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to get events relating to more than one node.
 
-- `param mac_address`
+:param mac_address`
    An optional list of MAC addresses. Only
        nodes with matching MAC addresses will be returned.
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes with
        matching system ids will be returned.
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes in the
        zone will be returned.
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes with
        matching agent names will be returned.
 
-- `param level`
+:param level`
    Desired minimum log level of returned events. Returns
-       this level of events and greater. Choose from- ` AUDIT, CRITICAL,
+       this level of events and greater. Choose from: AUDIT, CRITICAL,
         DEBUG, ERROR, INFO, WARNING. The default is INFO.
 
-- `param limit`
+:param limit`
    Optional number of events to return. Default 100.
-       Maximum- ` 1000.
+       Maximum: 1000.
 
-- `param before`
+:param before`
    Optional event id. Defines where to start returning
        older events.
 
-- `param after`
+:param after`
    Optional event id. Defines where to start returning
        newer events.
 
-- `param owner`
+:param owner`
    If specified, filters the list to show only events
        owned by the specified username.
 
@@ -1433,13 +1433,13 @@ Returns 404 if the fabric is not found.
 
 Update fabric.
 
-- `param name`
+:param name`
    Name of the fabric.
 
-- `param description`
+:param description`
    Description of the fabric.
 
-- `param class_type`
+:param class_type`
    Class type of the fabric.
 
 Returns 404 if the fabric is not found.
@@ -1456,13 +1456,13 @@ List all fabrics.
 
 Create a fabric.
 
-- `param name`
+:param name`
    Name of the fabric.
 
-- `param description`
+:param description`
    Description of the fabric.
 
-- `param class_type`
+:param class_type`
    Class type of the fabric.
 
 ### Fan Network
@@ -1485,25 +1485,25 @@ Returns 404 if the fannetwork is not found.
 
 Update fannetwork.
 
-- `param name`
+:param name`
    Name of the fannetwork.
 
-- `param overlay`
+:param overlay`
    Overlay network
 
-- `param underlay`
+:param underlay`
    Underlay network
 
-- `param dhcp`
+:param dhcp`
    confiugre dhcp server for overlay net
 
-- `param host_reserve`
+:param host_reserve`
    number of IP addresses to reserve for host
 
-- `param bridge`
+:param bridge`
    override bridge name
 
-- `param off`
+:param off`
    put this int he config, but disable it.
 
 Returns 404 if the fannetwork is not found.
@@ -1520,25 +1520,25 @@ List all fannetworks.
 
 Create a fannetwork.
 
-- `param name`
+:param name`
    Name of the fannetwork.
 
-- `param overlay`
+:param overlay`
    Overlay network
 
-- `param underlay`
+:param underlay`
    Underlay network
 
-- `param dhcp`
+:param dhcp`
    confiugre dhcp server for overlay net
 
-- `param host_reserve`
+:param host_reserve`
    number of IP addresses to reserve for host
 
-- `param bridge`
+:param bridge`
    override bridge name
 
-- `param off`
+:param off`
    put this int he config, but disable it.
 
 ### File
@@ -1565,10 +1565,10 @@ Manage the collection of all the files in this MAAS.
 
 Delete a FileStorage object.
 
-- `param filename`
+:param filename`
    The filename of the object to be deleted.
 
-- `type filename`
+:type filename`
    unicode
 
 ##### `GET /api/2.0/files/`
@@ -1577,53 +1577,53 @@ List the files from the file storage.
 
 The returned files are ordered by file name and the content is excluded.
 
-- `param prefix`
+:param prefix`
    Optional prefix used to filter out the returned files.
 
-- `type prefix`
+:type prefix`
    string
 
 ##### `GET /api/2.0/files/ op=get`
 
 Get a named file from the file storage.
 
-- `param filename`
+:param filename`
    The exact name of the file you want to get.
 
-- `type filename`
+:type filename`
    string
 
-- `return`
+:return`
    The file is returned in the response content.
 
 ##### `GET /api/2.0/files/ op=get_by_key`
 
 Get a file from the file storage using its key.
 
-- `param key`
+:param key`
    The exact key of the file you want to get.
 
-- `type key`
+:type key`
    string
 
-- `return`
+:return`
    The file is returned in the response content.
 
 ##### `POST /api/2.0/files/`
 
 Add a new file to the file storage.
 
-- `param filename`
+:param filename`
    The file name to use in the storage.
 
-- `type filename`
+:type filename`
    string
 
-- `param file`
+:param file`
    Actual file data with content type
        application/octet-stream
 
-Returns 400 if any of these conditions apply- `
+Returns 400 if any of these conditions apply:
    -   The filename is missing from the parameters
     -   The file data is missing
     -   More than one file is supplied
@@ -1639,50 +1639,50 @@ List IP addresses known to MAAS.
 By default, gets a listing of all IP addresses allocated to the requesting
 user.
 
-- `param ip`
+:param ip`
    If specified, will only display information for the
        specified IP address.
 
-- `type ip`
+:type ip`
    unicode (must be an IPv4 or IPv6 address)
 
 If the requesting user is a MAAS administrator, the following options may also
-be supplied- `
+be supplied:
 
-- `param all`
+:param all`
    If True, all reserved IP addresses will be shown. (By
        default, only addresses of type 'User reserved' that are assigned to
         the requesting user are shown.)
 
-- `type all`
+:type all`
    bool
 
-- `param owner`
+:param owner`
    If specified, filters the list to show only IP addresses
        owned by the specified username.
 
-- `type user`
+:type user`
    unicode
 
 ##### `POST /api/2.0/ipaddresses/ op=release`
 
 Release an IP address that was previously reserved by the user.
 
-- `param ip`
+:param ip`
    The IP address to release.
 
-- `type ip`
+:type ip`
    unicode
 
-- `param force`
+:param force`
    If True, allows a MAAS administrator to force an IP
        address to be released, even if it is not a user-reserved IP address
         or does not belong to the requesting user. Use with caution.
 
-- `type force`
+:type force`
    bool
 
-- `param discovered`
+:param discovered`
    If True, allows a MAAS administrator to release
        a discovered address. Only valid if 'force' is specified. If not
         specified, MAAS will attempt to release any type of address except for
@@ -1699,23 +1699,23 @@ use; it is free for use by the requesting user until released by the user.
 
 The user may supply either a subnet or a specific IP address within a subnet.
 
-- `param subnet`
+:param subnet`
    CIDR representation of the subnet on which the IP
        reservation is required. e.g. 10.1.2.0/24
 
-- `param ip`
+:param ip`
    The IP address, which must be within
        a known subnet.
 
-- `param ip_address`
+:param ip_address`
    (Deprecated.) Alias for 'ip' parameter. Provided
        for backward compatibility.
 
-- `param hostname`
+:param hostname`
    The hostname to use for the specified IP address. If
        no domain component is given, the default domain will be used.
 
-- `param mac`
+:param mac`
    The MAC address that should be linked to this reservation.
 
 Returns 400 if there is no subnet in MAAS matching the provided one, or a
@@ -1743,13 +1743,13 @@ Returns 404 if the IP range is not found.
 
 Update IP range.
 
-- `param start_ip`
+:param start_ip`
    Start IP address of this range (inclusive).
 
-- `param end_ip`
+:param end_ip`
    End IP address of this range (inclusive).
 
-- `param comment`
+:param comment`
    A description of this range. (optional)
 
 Returns 403 if not owner of IP range. Returns 404 if the IP Range is not
@@ -1767,19 +1767,19 @@ List all IP ranges.
 
 Create an IP range.
 
-- `param type`
+:param type`
    Type of this range. (dynamic or reserved)
 
-- `param start_ip`
+:param start_ip`
    Start IP address of this range (inclusive).
 
-- `param end_ip`
+:param end_ip`
    End IP address of this range (inclusive).
 
-- `param subnet`
+:param subnet`
    Subnet this range is associated with. (optional)
 
-- `param comment`
+:param comment`
    A description of this range. (optional)
 
 Returns 403 if standard users tries to create a dynamic IP range.
@@ -1804,7 +1804,7 @@ Returns 404 if the node or interface is not found.
 
 Add a tag to interface on a node.
 
-- `param tag`
+:param tag`
    The tag being added.
 
 Returns 404 if the node or interface is not found. Returns 403 if the user is
@@ -1823,30 +1823,30 @@ Returns 404 if the node or interface is not found.
 
 Link interface to a subnet.
 
-- `param mode`
+:param mode`
    AUTO, DHCP, STATIC or LINK_UP connection to subnet.
 
-- `param subnet`
+:param subnet`
    Subnet linked to interface.
 
-- `param ip_address`
+:param ip_address`
    IP address for the interface in subnet. Only used
        when mode is STATIC. If not provided an IP address from subnet will be
         auto selected.
 
-- `param force`
+:param force`
    If True, allows LINK_UP to be set on the interface
        even if other links already exist. Also allows the selection of any
         VLAN, even a VLAN MAAS does not believe the interface to currently be
         on. Using this option will cause all other links on the interface to
         be deleted. (Defaults to False.)
 
-- `param default_gateway`
+:param default_gateway`
    True sets the gateway IP address for the subnet
        as the default gateway for the node this interface belongs to. Option
         can only be used with the AUTO and STATIC modes.
 
-Mode definitions- ` AUTO - Assign this interface a static IP address from
+Mode definitions: AUTO - Assign this interface a static IP address from
 the provided subnet. The subnet must be a managed subnet. The IP address will
 not be assigned until the node goes to be deployed.
 
@@ -1867,7 +1867,7 @@ Returns 404 if the node or interface is not found.
 
 Remove a tag from interface on a node.
 
-- `param tag`
+:param tag`
    The tag being removed.
 
 Returns 404 if the node or interface is not found. Returns 403 if the user is
@@ -1881,7 +1881,7 @@ If this interface has more than one subnet with a gateway IP in the same IP
 address family then specifying the ID of the link on this interface is
 required.
 
-- `param link_id`
+:param link_id`
    ID of the link on this interface to select the
        default gateway IP address from.
 
@@ -1892,7 +1892,7 @@ node or interface is not found.
 
 Unlink interface to a subnet.
 
-- `param id`
+:param id`
    ID of the link on the interface to remove.
 
 Returns 404 if the node or interface is not found.
@@ -1906,106 +1906,106 @@ Machines with Deployed status can only have the name and/or mac_address
 updated for an interface. This is intented to allow a bad interface to be
 replaced while the machine remains deployed.
 
-Fields for physical interface- `
+Fields for physical interface:
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    Untagged VLAN the interface is connected to. If not set
        then the interface is considered disconnected.
 
-Fields for bond interface- `
+Fields for bond interface:
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    Untagged VLAN the interface is connected to. If not set
        then the interface is considered disconnected.
 
-- `param parents`
+:param parents`
    Parent interfaces that make this bond.
 
-Fields for VLAN interface- `
+Fields for VLAN interface:
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    Tagged VLAN the interface is connected to.
 
-- `param parent`
+:param parent`
    Parent interface for this VLAN interface.
 
-Fields for bridge interface- `
+Fields for bridge interface:
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    VLAN the interface is connected to.
 
-- `param parent`
+:param parent`
    Parent interface for this bridge interface.
 
-Following are extra parameters that can be set on all interface types- `
+Following are extra parameters that can be set on all interface types:
 
-- `param mtu`
+:param mtu`
    Maximum transmission unit.
 
-- `param accept_ra`
+:param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-- `param autoconf`
+:param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
-Following are parameters specific to bonds- `
+Following are parameters specific to bonds:
 
-- `param bond_mode`
+:param bond_mode`
    The operating mode of the bond.
-       (Default- ` active-backup).
+       (Default: active-backup).
 
-- `param bond_miimon`
+:param bond_miimon`
    The link monitoring freqeuncy in milliseconds.
-       (Default- ` 100).
+       (Default: 100).
 
-- `param bond_downdelay`
+:param bond_downdelay`
    Specifies the time, in milliseconds, to wait
        before disabling a slave after a link failure has been detected.
 
-- `param bond_updelay`
+:param bond_updelay`
    Specifies the time, in milliseconds, to wait
        before enabling a slave after a link recovery has been detected.
 
-- `param bond_lacp_rate`
+:param bond_lacp_rate`
    Option specifying the rate in which we'll ask
        our link partner to transmit LACPDU packets in 802.3ad mode. Available
-        options are fast or slow. (Default- ` slow).
+        options are fast or slow. (Default: slow).
 
-- `param bond_xmit_hash_policy`
+:param bond_xmit_hash_policy`
    The transmit hash policy to use for
        slave selection in balance-xor, 802.3ad, and tlb modes.
 
-Supported bonding modes (bond-mode)- `
+Supported bonding modes (bond-mode):
 
 balance-rr - Transmit packets in sequential order from the first available
 slave through the last. This mode provides load balancing and fault tolerance.
@@ -2026,22 +2026,22 @@ fault tolerance.
 that share the same speed and duplex settings. Utilizes all slaves in the
 active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing- ` channel bonding that does
+balance-tlb - Adaptive transmit load balancing: channel bonding that does
 not require any special switch support.
 
-balance-alb - Adaptive load balancing- ` includes balance-tlb plus receive
+balance-alb - Adaptive load balancing: includes balance-tlb plus receive
 load balancing (rlb) for IPV4 traffic, and does not require any special switch
 support. The receive load balancing is achieved by ARP negotiation.
 
-Following are parameters specific to bridges- `
+Following are parameters specific to bridges:
 
-- `param bridge_stp`
+:param bridge_stp`
    Turn spanning tree protocol on or off.
-       (Default- ` False).
+       (Default: False).
 
-- `param bridge_fd`
+:param bridge_fd`
    Set bridge forward delay to time seconds.
-       (Default- ` 15).
+       (Default: 15).
 
 Returns 404 if the node or interface is not found.
 
@@ -2059,56 +2059,56 @@ Returns 404 if the node is not found.
 
 Create a bond interface on a machine.
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    VLAN the interface is connected to. If not
        provided then the interface is considered disconnected.
 
-- `param parents`
+:param parents`
    Parent interfaces that make this bond.
 
-Following are parameters specific to bonds- `
+Following are parameters specific to bonds:
 
-- `param bond_mode`
+:param bond_mode`
    The operating mode of the bond.
-       (Default- ` active-backup).
+       (Default: active-backup).
 
-- `param bond_miimon`
+:param bond_miimon`
    The link monitoring freqeuncy in milliseconds.
-       (Default- ` 100).
+       (Default: 100).
 
-- `param bond_downdelay`
+:param bond_downdelay`
    Specifies the time, in milliseconds, to wait
        before disabling a slave after a link failure has been detected.
 
-- `param bond_updelay`
+:param bond_updelay`
    Specifies the time, in milliseconds, to wait
        before enabling a slave after a link recovery has been detected.
 
-- `param bond_lacp_rate`
+:param bond_lacp_rate`
    Option specifying the rate in which we'll ask
        our link partner to transmit LACPDU packets in 802.3ad mode. Available
-        options are fast or slow. (Default- ` slow).
+        options are fast or slow. (Default: slow).
 
-- `param bond_xmit_hash_policy`
+:param bond_xmit_hash_policy`
    The transmit hash policy to use for
-       slave selection in balance-xor, 802.3ad, and tlb modes. (Default- `
+       slave selection in balance-xor, 802.3ad, and tlb modes. (Default:
         layer2)
 
-- `param bond_num_grat_arp`
+:param bond_num_grat_arp`
    The number of peer notifications (IPv4 ARP
        or IPv6 Neighbour Advertisements) to be issued after a failover.
-        (Default- ` 1)
+        (Default: 1)
 
-Supported bonding modes (bond-mode)- ` balance-rr - Transmit packets in
+Supported bonding modes (bond-mode): balance-rr - Transmit packets in
 sequential order from the first available slave through the last. This mode
 provides load balancing and fault tolerance.
 
@@ -2128,22 +2128,22 @@ fault tolerance.
 that share the same speed and duplex settings. Utilizes all slaves in the
 active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing- ` channel bonding that does
+balance-tlb - Adaptive transmit load balancing: channel bonding that does
 not require any special switch support.
 
-balance-alb - Adaptive load balancing- ` includes balance-tlb plus receive
+balance-alb - Adaptive load balancing: includes balance-tlb plus receive
 load balancing (rlb) for IPV4 traffic, and does not require any special switch
 support. The receive load balancing is achieved by ARP negotiation.
 
-Following are extra parameters that can be set on the interface- `
+Following are extra parameters that can be set on the interface:
 
-- `param mtu`
+:param mtu`
    Maximum transmission unit.
 
-- `param accept_ra`
+:param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-- `param autoconf`
+:param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2152,40 +2152,40 @@ Returns 404 if the node is not found.
 
 Create a bridge interface on a machine.
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    VLAN the interface is connected to.
 
-- `param parent`
+:param parent`
    Parent interface for this bridge interface.
 
-Following are parameters specific to bridges- `
+Following are parameters specific to bridges:
 
-- `param bridge_stp`
+:param bridge_stp`
    Turn spanning tree protocol on or off.
-       (Default- ` False).
+       (Default: False).
 
-- `param bridge_fd`
+:param bridge_fd`
    Set bridge forward delay to time seconds.
-       (Default- ` 15).
+       (Default: 15).
 
-Following are extra parameters that can be set on the interface- `
+Following are extra parameters that can be set on the interface:
 
-- `param mtu`
+:param mtu`
    Maximum transmission unit.
 
-- `param accept_ra`
+:param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-- `param autoconf`
+:param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2194,28 +2194,28 @@ Returns 404 if the node is not found.
 
 Create a physical interface on a machine and device.
 
-- `param name`
+:param name`
    Name of the interface.
 
-- `param mac_address`
+:param mac_address`
    MAC address of the interface.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    Untagged VLAN the interface is connected to. If not
        provided then the interface is considered disconnected.
 
-Following are extra parameters that can be set on the interface- `
+Following are extra parameters that can be set on the interface:
 
-- `param mtu`
+:param mtu`
    Maximum transmission unit.
 
-- `param accept_ra`
+:param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-- `param autoconf`
+:param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2224,24 +2224,24 @@ Returns 404 if the node is not found.
 
 Create a VLAN interface on a machine.
 
-- `param tags`
+:param tags`
    Tags for the interface.
 
-- `param vlan`
+:param vlan`
    Tagged VLAN the interface is connected to.
 
-- `param parent`
+:param parent`
    Parent interface for this VLAN interface.
 
-Following are extra parameters that can be set on the interface- `
+Following are extra parameters that can be set on the interface:
 
-- `param mtu`
+:param mtu`
    Maximum transmission unit.
 
-- `param accept_ra`
+:param accept_ra`
    Accept router advertisements. (IPv6 only)
 
-- `param autoconf`
+:param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
 Returns 404 if the node is not found.
@@ -2262,13 +2262,13 @@ Read license key.
 
 Update license key.
 
-- `param osystem`
+:param osystem`
    Operating system that the key belongs to.
 
-- `param distro_series`
+:param distro_series`
    OS release that the key belongs to.
 
-- `param license_key`
+:param license_key`
    License key for osystem/distro_series combo.
 
 ### License Keys
@@ -2283,13 +2283,13 @@ List license keys.
 
 Define a license key.
 
-- `param osystem`
+:param osystem`
    Operating system that the key belongs to.
 
-- `param distro_series`
+:param distro_series`
    OS release that the key belongs to.
 
-- `param license_key`
+:param license_key`
    License key for osystem/distro_series combo.
 
 ### MAAS server
@@ -2300,106 +2300,106 @@ Manage the MAAS server.
 
 Get a config value.
 
-- `param name`
+:param name`
    The name of the config item to be retrieved.
 
-Available configuration items- `
+Available configuration items:
 
-- `active_discovery_interval`
+:active_discovery_interval`
    Active subnet mapping interval. When enabled, each rack will scan subnets
     enabled for active mapping. This helps ensure discovery information is
     accurate and complete.
 
-- `boot_images_auto_import`
+:boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-- `commissioning_distro_series`
+:commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-- `completed_intro`
+:completed_intro`
    Marks if the initial intro has been completed.
 
-- `curtin_verbose`
+:curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
     detail in the installation logs.
 
-- `default_distro_series`
+:default_distro_series`
    Default OS release used for deployment.
 
-- `default_dns_ttl`
+:default_dns_ttl`
    Default Time-To-Live for the DNS. If no TTL value is specified at a more
     specific point this is how long DNS responses are valid, in seconds.
 
-- `default_min_hwe_kernel`
+:default_min_hwe_kernel`
    Default Minimum Kernel Version. The default minimum kernel version used on
     all new and commissioned nodes.
 
-- `default_osystem`
+:default_osystem`
    Default operating system used for deployment.
 
-- `default_storage_layout`
+:default_storage_layout`
    Default storage layout. Storage layout that is applied to a node when it
-    is commissioned. Available choices are- ` 'bcache' (Bcache layout),
+    is commissioned. Available choices are: 'bcache' (Bcache layout),
     'flat' (Flat layout), 'lvm' (LVM layout).
 
-- `disk_erase_with_quick_erase`
+:disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
     erase; it wipes only the beginning and end of each disk.
 
-- `disk_erase_with_secure_erase`
+:disk_erase_with_secure_erase`
    Use secure erase by default when erasing disks. Will only be used on
     devices that support secure erase. Other devices will fall back to full
     wipe or quick erase depending on the selected options.
 
-- `dnssec_validation`
+:dnssec_validation`
    Enable DNSSEC validation of upstream zones. Only used when MAAS is running
     its own DNS server. This value is used as the value of
     'dnssec_validation' in the DNS server config.
 
-- `enable_analytics`
+:enable_analytics`
    Enable Google Analytics in MAAS UI to shape improvements in user
     experience.
 
-- `enable_disk_erasing_on_release`
+:enable_disk_erasing_on_release`
    Erase nodes' disks prior to releasing. Forces users to always erase disks
     when releasing.
 
-- `enable_http_proxy`
+:enable_http_proxy`
    Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
     built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
     proxy for downloading boot images.
 
-- `enable_third_party_drivers`
+:enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-- `http_proxy`
+:http_proxy`
    Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
     to use as a proxy for APT traffic. MAAS also uses the proxy for
     downloading boot images. If no URL is provided, the built-in MAAS proxy
     will be used.
 
-- `kernel_opts`
+:kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-- `maas_name`
+:maas_name`
    MAAS name.
 
-- `max_node_commissioning_results`
+:max_node_commissioning_results`
    The maximum number of commissioning results runs which are stored.
 
-- `max_node_installation_results`
+:max_node_installation_results`
    The maximum number of installation result runs which are stored.
 
-- `max_node_testing_results`
+:max_node_testing_results`
    The maximum number of testing results runs which are stored.
 
-- `network_discovery`
+:network_discovery`
    . When enabled, MAAS will use passive techniques (such as listening to ARP
     requests and mDNS advertisements) to observe networks attached to rack
     controllers. Active subnet mapping will also be available to be enabled on
     the configured subnets.
 
-- `ntp_external_only`
+:ntp_external_only`
    Use external NTP servers only. Configure all region controller hosts, rack
     controller hosts, and subsequently deployed machines to refer directly to
     the configured external NTP servers. Otherwise only region controller
@@ -2407,34 +2407,34 @@ Available configuration items- `
     hosts will in turn refer to the regions' NTP servers, and deployed
     machines will refer to the racks' NTP servers.
 
-- `ntp_servers`
+:ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
     hostnames delimited by commas and/or spaces, to be used as time references
     for MAAS itself, the machines MAAS deploys, and devices that make use of
     MAAS's DHCP services.
 
-- `prefer_v4_proxy`
+:prefer_v4_proxy`
    Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
     proxy will be set to prefer IPv4 DNS resolution before it attempts to
     perform IPv6 DNS resolution.
 
-- `subnet_ip_exhaustion_threshold_count`
+:subnet_ip_exhaustion_threshold_count`
    If the number of free IP addresses on a subnet becomes less than or equal
     to this threshold, an IP exhaustion warning will appear for that subnet.
 
-- `upstream_dns`
+:upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
     (space-separated IP addresses). Only used when MAAS is running its own DNS
     server. This value is used as the value of 'forwarders' in the DNS server
     config.
 
-- `use_peer_proxy`
+:use_peer_proxy`
    Use the built-in proxy with an external proxy as a peer. If
     enable_http_proxy is set, the built-in proxy will be configured to use
     http_proxy as a peer proxy. The deployed machines will be configured to
     use the built-in proxy.
 
-- `windows_kms_host`
+:windows_kms_host`
    Windows KMS activation host. FQDN or IP address of the host that provides
     the KMS Windows activation service. (Only needed for Windows deployments
     using KMS activation.)
@@ -2443,109 +2443,109 @@ Available configuration items- `
 
 Set a config value.
 
-- `param name`
+:param name`
    The name of the config item to be set.
 
-- `param value`
+:param value`
    The value of the config item to be set.
 
-Available configuration items- `
+Available configuration items:
 
-- `active_discovery_interval`
+:active_discovery_interval`
    Active subnet mapping interval. When enabled, each rack will scan subnets
     enabled for active mapping. This helps ensure discovery information is
     accurate and complete.
 
-- `boot_images_auto_import`
+:boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-- `commissioning_distro_series`
+:commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-- `completed_intro`
+:completed_intro`
    Marks if the initial intro has been completed.
 
-- `curtin_verbose`
+:curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
     detail in the installation logs.
 
-- `default_distro_series`
+:default_distro_series`
    Default OS release used for deployment.
 
-- `default_dns_ttl`
+:default_dns_ttl`
    Default Time-To-Live for the DNS. If no TTL value is specified at a more
     specific point this is how long DNS responses are valid, in seconds.
 
-- `default_min_hwe_kernel`
+:default_min_hwe_kernel`
    Default Minimum Kernel Version. The default minimum kernel version used on
     all new and commissioned nodes.
 
-- `default_osystem`
+:default_osystem`
    Default operating system used for deployment.
 
-- `default_storage_layout`
+:default_storage_layout`
    Default storage layout. Storage layout that is applied to a node when it
-    is commissioned. Available choices are- ` 'bcache' (Bcache layout),
+    is commissioned. Available choices are: 'bcache' (Bcache layout),
     'flat' (Flat layout), 'lvm' (LVM layout).
 
-- `disk_erase_with_quick_erase`
+:disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
     erase; it wipes only the beginning and end of each disk.
 
-- `disk_erase_with_secure_erase`
+:disk_erase_with_secure_erase`
    Use secure erase by default when erasing disks. Will only be used on
     devices that support secure erase. Other devices will fall back to full
     wipe or quick erase depending on the selected options.
 
-- `dnssec_validation`
+:dnssec_validation`
    Enable DNSSEC validation of upstream zones. Only used when MAAS is running
     its own DNS server. This value is used as the value of
     'dnssec_validation' in the DNS server config.
 
-- `enable_analytics`
+:enable_analytics`
    Enable Google Analytics in MAAS UI to shape improvements in user
     experience.
 
-- `enable_disk_erasing_on_release`
+:enable_disk_erasing_on_release`
    Erase nodes' disks prior to releasing. Forces users to always erase disks
     when releasing.
 
-- `enable_http_proxy`
+:enable_http_proxy`
    Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
     built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
     proxy for downloading boot images.
 
-- `enable_third_party_drivers`
+:enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-- `http_proxy`
+:http_proxy`
    Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
     to use as a proxy for APT traffic. MAAS also uses the proxy for
     downloading boot images. If no URL is provided, the built-in MAAS proxy
     will be used.
 
-- `kernel_opts`
+:kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-- `maas_name`
+:maas_name`
    MAAS name.
 
-- `max_node_commissioning_results`
+:max_node_commissioning_results`
    The maximum number of commissioning results runs which are stored.
 
-- `max_node_installation_results`
+:max_node_installation_results`
    The maximum number of installation result runs which are stored.
 
-- `max_node_testing_results`
+:max_node_testing_results`
    The maximum number of testing results runs which are stored.
 
-- `network_discovery`
+:network_discovery`
    . When enabled, MAAS will use passive techniques (such as listening to ARP
     requests and mDNS advertisements) to observe networks attached to rack
     controllers. Active subnet mapping will also be available to be enabled on
     the configured subnets.
 
-- `ntp_external_only`
+:ntp_external_only`
    Use external NTP servers only. Configure all region controller hosts, rack
     controller hosts, and subsequently deployed machines to refer directly to
     the configured external NTP servers. Otherwise only region controller
@@ -2553,34 +2553,34 @@ Available configuration items- `
     hosts will in turn refer to the regions' NTP servers, and deployed
     machines will refer to the racks' NTP servers.
 
-- `ntp_servers`
+:ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
     hostnames delimited by commas and/or spaces, to be used as time references
     for MAAS itself, the machines MAAS deploys, and devices that make use of
     MAAS's DHCP services.
 
-- `prefer_v4_proxy`
+:prefer_v4_proxy`
    Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
     proxy will be set to prefer IPv4 DNS resolution before it attempts to
     perform IPv6 DNS resolution.
 
-- `subnet_ip_exhaustion_threshold_count`
+:subnet_ip_exhaustion_threshold_count`
    If the number of free IP addresses on a subnet becomes less than or equal
     to this threshold, an IP exhaustion warning will appear for that subnet.
 
-- `upstream_dns`
+:upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
     (space-separated IP addresses). Only used when MAAS is running its own DNS
     server. This value is used as the value of 'forwarders' in the DNS server
     config.
 
-- `use_peer_proxy`
+:use_peer_proxy`
    Use the built-in proxy with an external proxy as a peer. If
     enable_http_proxy is set, the built-in proxy will be configured to use
     http_proxy as a peer proxy. The deployed machines will be configured to
     use the built-in proxy.
 
-- `windows_kms_host`
+:windows_kms_host`
    Windows KMS activation host. FQDN or IP address of the host that provides
     the KMS Windows activation service. (Only needed for Windows deployments
     using KMS activation.)
@@ -2611,7 +2611,7 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
@@ -2649,10 +2649,10 @@ state. The reply to this could be delayed by up to 30 seconds while waiting
 for the power controller to respond. Use this method sparingly as it ties up
 an appserver thread while waiting.
 
-- `param system_id`
+:param system_id`
    The node to query.
 
-- `return`
+:return`
    a dict whose key is "state" with a value of one of
        'on' or 'off'.
 
@@ -2662,10 +2662,10 @@ Returns 404 if the node is not found. Returns node's power state.
 
 Abort a node's current operation.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the node could not be found. Returns 403 if the user does not
@@ -2677,7 +2677,7 @@ Clear any set default gateways on the machine.
 
 This will clear both IPv4 and IPv6 gateways on the machine. This will
 transition the logic of identifing the best gateway to MAAS. This logic is
-determined based the following criteria- `
+determined based the following criteria:
 
 1.  Managed subnets over unmanaged subnets.
 2.  Bond interfaces over physical interfaces.
@@ -2697,43 +2697,43 @@ not have permission to clear the default gateways.
 
 Begin commissioning process for a machine.
 
-- `param enable_ssh`
+:param enable_ssh`
    Whether to enable SSH for the commissioning
        environment using the user's SSH key(s).
 
-- `type enable_ssh`
+:type enable_ssh`
    bool ('0' for False, '1' for True)
 
-- `param skip_networking`
+:param skip_networking`
    Whether to skip re-configuring the networking
        on the machine after the commissioning has completed.
 
-- `type skip_networking`
+:type skip_networking`
    bool ('0' for False, '1' for True)
 
-- `param skip_storage`
+:param skip_storage`
    Whether to skip re-configuring the storage
        on the machine after the commissioning has completed.
 
-- `type skip_storage`
+:type skip_storage`
    bool ('0' for False, '1' for True)
 
-- `param commissioning_scripts`
+:param commissioning_scripts`
    A comma seperated list of commissioning
        script names and tags to be run. By default all custom commissioning
         scripts are run. Builtin commissioning scripts always run. Selecting
         'update_firmware' or 'configure_hba' will run firmware updates or
         configure HBA's on matching machines.
 
-- `type commissioning_scripts`
+:type commissioning_scripts`
    string
 
-- `param testing_scripts`
+:param testing_scripts`
    A comma seperated list of testing script names
        and tags to be run. By default all tests tagged 'commissioning' will
         be run. Set to 'none' to disable running tests.
 
-- `type testing_scripts`
+:type testing_scripts`
    string
 
 A machine in the 'ready', 'declared' or 'failed test' state may initiate a
@@ -2748,68 +2748,68 @@ Returns 404 if the machine is not found.
 
 Deploy an operating system to a machine.
 
-- `param user_data`
+:param user_data`
    If present, this blob of user-data to be made
        available to the machines through the metadata service.
 
-- `type user_data`
+:type user_data`
    base64-encoded unicode
 
-- `param distro_series`
+:param distro_series`
    If present, this parameter specifies the
        OS release the machine will use.
 
-- `type distro_series`
+:type distro_series`
    unicode
 
-- `param hwe_kernel`
+:param hwe_kernel`
    If present, this parameter specified the kernel to
        be used on the machine
 
-- `type hwe_kernel`
+:type hwe_kernel`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name to attach to the
        acquired machine.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
-- `param bridge_all`
+:param bridge_all`
    Optionally create a bridge interface for every
        configured interface on the machine. The created bridges will be
-        removed once the machine is released. (Default- ` False)
+        removed once the machine is released. (Default: False)
 
-- `type bridge_all`
+:type bridge_all`
    boolean
 
-- `param bridge_stp`
+:param bridge_stp`
    Optionally turn spanning tree protocol on or off
-       for the bridges created on every configured interface. (Default- `
+       for the bridges created on every configured interface. (Default:
         off)
 
-- `type bridge_stp`
+:type bridge_stp`
    boolean
 
-- `param bridge_fd`
+:param bridge_fd`
    Optionally adjust the forward delay to time seconds.
-       (Default- ` 15)
+       (Default: 15)
 
-- `type bridge_fd`
+:type bridge_fd`
    integer
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
-- `param install_rackd`
+:param install_rackd`
    If True, the Rack Controller will be installed on
        this machine.
 
-- `type install_rackd`
+:type install_rackd`
    boolean
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -2836,10 +2836,10 @@ Mark a deployed machine as locked, to prevent changes.
 
 A locked machine cannot be released or modified.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2851,11 +2851,11 @@ Mark a node as 'broken'.
 
 If the node is allocated, release it first.
 
-- `param comment`
+:param comment`
    Optional comment for the event log. Will be
        displayed on the node as an error description until marked fixed.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -2865,10 +2865,10 @@ permission to mark the node broken.
 
 Mark a broken node as fixed and set its status as 'ready'.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2878,14 +2878,14 @@ permission to mark the machine fixed.
 
 Mount a special-purpose filesystem, like tmpfs.
 
-- `param fstype`
+:param fstype`
    The filesystem type. This must be a filesystem that
        does not require a block special device.
 
-- `param mount_point`
+:param mount_point`
    Path on the filesystem to mount.
 
-- `param mount_option`
+:param mount_option`
    Options to pass to mount(8).
 
 Returns 403 when the user is not permitted to mount the partition.
@@ -2894,10 +2894,10 @@ Returns 403 when the user is not permitted to mount the partition.
 
 Ignore failed tests and put node back into a usable state.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -2907,7 +2907,7 @@ permission to ignore tests for the node.
 
 Power off a node.
 
-- `param stop_mode`
+:param stop_mode`
    An optional power off mode. If 'soft',
        perform a soft power down if the node's power type supports it,
         otherwise perform a hard power off. For all values other than 'soft',
@@ -2916,13 +2916,13 @@ Power off a node.
         while a hard power off occurs immediately without any warning to the
         OS.
 
-- `type stop_mode`
+:type stop_mode`
    unicode
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -2932,17 +2932,17 @@ permission to stop the node.
 
 Turn on a node.
 
-- `param user_data`
+:param user_data`
    If present, this blob of user-data to be made
        available to the nodes through the metadata service.
 
-- `type user_data`
+:type user_data`
    base64-encoded unicode
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -2958,33 +2958,33 @@ relevant cluster interface.
 
 Release a machine. Opposite of Machines.allocate.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
-- `param erase`
+:param erase`
    Erase the disk when releasing.
 
-- `type erase`
+:type erase`
    boolean
 
-- `param secure_erase`
+:param secure_erase`
    Use the drive's secure erase feature if available.
        In some cases this can be much faster than overwriting the drive. Some
         drives implement secure erasure by overwriting themselves so this
         could still be slow.
 
-- `type secure_erase`
+:type secure_erase`
    boolean
 
-- `param quick_erase`
+:param quick_erase`
    Wipe 2MiB at the start and at the end of the drive
        to make data recovery inconvenient and unlikely to happen by accident.
         This is not secure.
 
-- `type quick_erase`
+:type quick_erase`
    boolean
 
 If neither secure_erase nor quick_erase are specified, MAAS will overwrite
@@ -3054,49 +3054,49 @@ Changes the storage layout on the machine.
 
 This operation can only be performed on a machine with a status of 'Ready'.
 
-Note- ` This will clear the current storage layout and any extra
+Note: This will clear the current storage layout and any extra
 configuration and replace it will the new layout.
 
-- `param storage_layout`
+:param storage_layout`
    Storage layout for the machine. (flat, lvm,
        and bcache)
 
-The following are optional for all layouts- `
+The following are optional for all layouts:
 
-- `param boot_size`
+:param boot_size`
    Size of the boot partition.
 
-- `param root_size`
+:param root_size`
    Size of the root partition.
 
-- `param root_device`
+:param root_device`
    Physical block device to place the root partition.
 
-The following are optional for LVM- `
+The following are optional for LVM:
 
-- `param vg_name`
+:param vg_name`
    Name of created volume group.
 
-- `param lv_name`
+:param lv_name`
    Name of created logical volume.
 
-- `param lv_size`
+:param lv_size`
    Size of created logical volume.
 
-The following are optional for Bcache- `
+The following are optional for Bcache:
 
-- `param cache_device`
+:param cache_device`
    Physical block device to use as the cache device.
 
-- `param cache_mode`
+:param cache_mode`
    Cache mode for bcache device. (writeback,
        writethrough, writearound)
 
-- `param cache_size`
+:param cache_size`
    Size of the cache partition to create on the cache
        device.
 
-- `param cache_no_part`
+:param cache_no_part`
    Don't create a partition on the cache device.
        Use the entire disk as the cache device.
 
@@ -3108,19 +3108,19 @@ to set the storage layout.
 
 Begin testing process for a node.
 
-- `param enable_ssh`
+:param enable_ssh`
    Whether to enable SSH for the testing environment
        using the user's SSH key(s).
 
-- `type enable_ssh`
+:type enable_ssh`
    bool ('0' for False, '1' for True)
 
-- `param testing_scripts`
+:param testing_scripts`
    A comma seperated list of testing script names
        and tags to be run. By default all tests tagged 'commissioning' will
         be run.
 
-- `type testing_scripts`
+:type testing_scripts`
    string
 
 A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
@@ -3135,10 +3135,10 @@ Returns 404 if the node is not found.
 
 Mark a machine as unlocked, allowing changes.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -3148,7 +3148,7 @@ permission unlock the machine.
 
 Unmount a special-purpose filesystem, like tmpfs.
 
-- `param mount_point`
+:param mount_point`
    Path on the filesystem to unmount.
 
 Returns 403 when the user is not permitted to unmount the partition.
@@ -3157,91 +3157,91 @@ Returns 403 when the user is not permitted to unmount the partition.
 
 Update a specific Machine.
 
-- `param hostname`
+:param hostname`
    The new hostname for this machine.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param domain`
+:param domain`
    The domain for this machine. If not given the default
        domain is used.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param architecture`
+:param architecture`
    The new architecture for this machine.
 
-- `type architecture`
+:type architecture`
    unicode
 
-- `param min_hwe_kernel`
+:param min_hwe_kernel`
    A string containing the minimum kernel version
        allowed to be ran on this machine.
 
-- `type min_hwe_kernel`
+:type min_hwe_kernel`
    unicode
 
-- `param power_type`
+:param power_type`
    The new power type for this machine. If you use the
        default value, power_parameters will be set to the empty string.
         Available to admin users. See the [Power types]() section for a list
         of the available power types.
 
-- `type power_type`
+:type power_type`
    unicode
 
-- `param [power_parameters](){param1}`
+:param [power_parameters](){param1}`
    The new value for the 'param1'
        power parameter. Note that this is dynamic as the available parameters
         depend on the selected value of the Machine's power_type. Available
         to admin users. See the [Power types]() section for a list of the
         available power parameters for each power type.
 
-- `type [power_parameters](){param1}`
+:type [power_parameters](){param1}`
    unicode
 
-- `param power_parameters_skip_check`
+:param power_parameters_skip_check`
    Whether or not the new power
        parameters for this machine should be checked against the expected
         power parameters for the machine's power type ('true' or 'false'). The
         default is 'false'.
 
-- `type power_parameters_skip_check`
+:type power_parameters_skip_check`
    unicode
 
-- `param zone`
+:param zone`
    Name of a valid physical zone in which to place this
        machine.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param swap_size`
+:param swap_size`
    Specifies the size of the swap file, in bytes. Field
        accept K, M, G and T suffixes for values expressed respectively in
         kilobytes, megabytes, gigabytes and terabytes.
 
-- `type swap_size`
+:type swap_size`
    unicode
 
-- `param disable_ipv4`
+:param disable_ipv4`
    Deprecated. If specified, must be False.
 
-- `type disable_ipv4`
+:type disable_ipv4`
    boolean
 
-- `param cpu_count`
+:param cpu_count`
    The amount of CPU cores the machine has.
 
-- `type cpu_count`
+:type cpu_count`
    integer
 
-- `param memory`
+:param memory`
    How much memory the machine has.
 
-- `type memory`
+:type memory`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -3257,48 +3257,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only nodes relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to see multiple nodes.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param mac_address`
+:param mac_address`
    An optional MAC address. Only nodes relating to the
        node owning the specified MAC address will be returned. This can be
         specified multiple times to see multiple nodes.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes relating to the
        nodes with matching system ids will be returned.
 
-- `type id`
+:type id`
    unicode
 
-- `param domain`
+:param domain`
    An optional name for a dns domain. Only nodes relating
        to the nodes in the domain will be returned.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes relating
        to the nodes in the zone will be returned.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes relating to the
        nodes with matching agent names will be returned.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
 ##### `GET /api/2.0/machines/ op=is_registered`
@@ -3306,16 +3306,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-- `param mac_address`
+:param mac_address`
    The mac address to be checked.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `return`
+:return`
    'true' or 'false'.
 
-- `rtype`
+:rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -3328,14 +3328,14 @@ Fetch Machines that were allocated to the User/oauth token.
 
 Retrieve power parameters for multiple machines.
 
-- `param id`
+:param id`
    An optional list of system ids. Only machines with
        matching system ids will be returned.
 
-- `type id`
+:type id`
    iterable
 
-- `return`
+:return`
    A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
@@ -3349,64 +3349,64 @@ re-install its operating system, in the event that it PXE boots. In anonymous
 enlistment (and when the enlistment is done by a non-admin), the machine is
 held in the "New" state for approval by a MAAS admin.
 
-The minimum data required is- ` architecture=&lt;arch string&gt; (e.g.
-"i386/generic") mac_addresses=&lt;value&gt; (e.g. "aa- `bb`
-cc- `dd`ee`ff")
+The minimum data required is: architecture=&lt;arch string&gt; (e.g.
+"i386/generic") mac_addresses=&lt;value&gt; (e.g. "aa:bb`
+cc:dd`ee`ff")
 
-- `param architecture`
+:param architecture`
    A string containing the architecture type of
        the machine. (For example, "i386", or "amd64".) To determine the
         supported architectures, use the boot-resources endpoint.
 
-- `type architecture`
+:type architecture`
    unicode
 
-- `param min_hwe_kernel`
+:param min_hwe_kernel`
    A string containing the minimum kernel version
        allowed to be ran on this machine.
 
-- `type min_hwe_kernel`
+:type min_hwe_kernel`
    unicode
 
-- `param subarchitecture`
+:param subarchitecture`
    A string containing the subarchitecture type
        of the machine. (For example, "generic" or "hwe-t".) To determine the
         supported subarchitectures, use the boot-resources endpoint.
 
-- `type subarchitecture`
+:type subarchitecture`
    unicode
 
-- `param mac_addresses`
+:param mac_addresses`
    One or more MAC addresses for the machine. To
        specify more than one MAC address, the parameter must be specified
-        twice. (such as "machines new mac_addresses=01- `02`
+        twice. (such as "machines new mac_addresses=01:02`
 
-03- `04`05`06
-   mac_addresses=02- `03`
+03:04`05`06
+   mac_addresses=02:03`
 
-> 04- `05`06`07")
+> 04:05`06`07")
 
-- `type mac_addresses`
+:type mac_addresses`
    unicode
 
-- `param hostname`
+:param hostname`
    A hostname. If not given, one will be generated.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param domain`
+:param domain`
    The domain of the machine. If not given the default
        domain is used.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param power_type`
+:param power_type`
    A power management type, if applicable (e.g.
        "virsh", "ipmi").
 
-- `type power_type`
+:type power_type`
    unicode
 
 ##### `POST /api/2.0/machines/ op=accept`
@@ -3421,11 +3421,11 @@ Enlistments can be accepted en masse, by passing multiple machines to this
 call. Accepting an already accepted machine is not an error, but accepting one
 that is already allocated, broken, etc. is.
 
-- `param machines`
+:param machines`
    system_ids of the machines whose enlistment is to be
        accepted. (An empty list is acceptable).
 
-- `return`
+:return`
    The system_ids of any machines that have their status changed
        by this call. Thus, machines that were already accepted are excluded
         from the result.
@@ -3441,7 +3441,7 @@ Machines can be enlisted in the MAAS anonymously or by non-admin users, as
 opposed to by an admin. These machines are held in the New state; a MAAS admin
 must first verify the authenticity of these enlistments, and accept them.
 
-- `return`
+:return`
    Representations of any machines that have their status changed
        by this call. Thus, machines that were already accepted are excluded
         from the result.
@@ -3450,7 +3450,7 @@ must first verify the authenticity of these enlistments, and accept them.
 
 Add special hardware types.
 
-- `param chassis_type`
+:param chassis_type`
    The type of hardware.
        mscm is the type for the Moonshot Chassis Manager. msftocs is the type
         for the Microsoft OCS Chassis Manager. powerkvm is the type for
@@ -3460,90 +3460,90 @@ Add special hardware types.
         virsh is the type for virtual machines managed by Virsh. vmware is the
         type for virtual machines managed by VMware.
 
-- `type chassis_type`
+:type chassis_type`
    unicode
 
-- `param hostname`
+:param hostname`
    The URL, hostname, or IP address to access the
        chassis.
 
-- `type url`
+:type url`
    unicode
 
-- `param username`
+:param username`
    The username used to access the chassis. This field
        is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
         ucsm chassis types.
 
-- `type username`
+:type username`
    unicode
 
-- `param password`
+:param password`
    The password used to access the chassis. This field
        is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
         ucsm chassis types.
 
-- `type password`
+:type password`
    unicode
 
-- `param accept_all`
+:param accept_all`
    If true, all enlisted machines will be
        commissioned.
 
-- `type accept_all`
+:type accept_all`
    unicode
 
-- `param rack_controller`
+:param rack_controller`
    The system_id of the rack controller to send
        the add chassis command through. If none is specifed MAAS will
         automatically determine the rack controller to use.
 
-- `type rack_controller`
+:type rack_controller`
    unicode
 
-- `param domain`
+:param domain`
    The domain that each new machine added should use.
 
-- `type domain`
+:type domain`
    unicode
 
 The following are optional if you are adding a virsh, vmware, or powerkvm
-chassis- `
+chassis:
 
-- `param prefix_filter`
+:param prefix_filter`
    Filter machines with supplied prefix.
 
-- `type prefix_filter`
+:type prefix_filter`
    unicode
 
-The following are optional if you are adding a seamicro15k chassis- `
+The following are optional if you are adding a seamicro15k chassis:
 
-- `param power_control`
+:param power_control`
    The power_control to use, either ipmi (default),
        restapi, or restapi2.
 
-- `type power_control`
+:type power_control`
    unicode
 
 The following are optional if you are adding a recs_box, vmware or msftocs
 chassis.
 
-- `param port`
+:param port`
    The port to use when accessing the chassis.
 
-- `type port`
+:type port`
    integer
 
-The following are optioanl if you are adding a vmware chassis- `
+The following are optioanl if you are adding a vmware chassis:
 
-- `param protocol`
+:param protocol`
    The protocol to use when accessing the VMware
-       chassis (default- ` https).
+       chassis (default: https).
 
-- `type protocol`
+:type protocol`
    unicode
 
-- `return`
+:return`
    A string containing the chassis powered on by which rack
        controller.
 
@@ -3559,20 +3559,20 @@ Constraints parameters can be used to allocate a machine that possesses
 certain characteristics. All the constraints are optional and when multiple
 constraints are provided, they are combined using 'AND' semantics.
 
-- `param name`
+:param name`
    Hostname or FQDN of the desired machine. If a FQDN is
        specified, both the domain and the hostname portions must match.
 
-- `type name`
+:type name`
    unicode
 
-- `param system_id`
+:param system_id`
    system_id of the desired machine.
 
-- `type system_id`
+:type system_id`
    unicode
 
-- `param arch`
+:param arch`
    Architecture of the returned machine (e.g. 'i386/generic',
        'amd64', 'armhf/highbank', etc.).
 
@@ -3581,54 +3581,54 @@ constraints are provided, they are combined using 'AND' semantics.
         architectures, this parameter must be repeated in the request with
         each value.
 
-- `type arch`
+:type arch`
    unicode (accepts multiple)
 
-- `param cpu_count`
+:param cpu_count`
    Minimum number of CPUs a returned machine must have.
 
     > A machine with additional CPUs may be allocated if there is no exact
     > match, or if the 'mem' constraint is not also specified.
 
-- `type cpu_count`
+:type cpu_count`
    positive integer
 
-- `param mem`
+:param mem`
    The minimum amount of memory (expressed in MB) the
        returned machine must have. A machine with additional memory may be
         allocated if there is no exact match, or the 'cpu_count' constraint
         is not also specified.
 
-- `type mem`
+:type mem`
    positive integer
 
-- `param tags`
+:param tags`
    Tags the machine must match in order to be acquired.
 
     > If multiple tag names are specified, the machine must be tagged with all
     > of them. To request multiple tags, this parameter must be repeated in
     > the request with each value.
 
-- `type tags`
+:type tags`
    unicode (accepts multiple)
 
-- `param not_tags`
+:param not_tags`
    Tags the machine must NOT match.
 
     > If multiple tag names are specified, the machine must NOT be tagged with
     > ANY of them. To request exclusion of multiple tags, this parameter must
     > be repeated in the request with each value.
 
-- `type tags`
+:type tags`
    unicode (accepts multiple)
 
-- `param zone`
+:param zone`
    Physical zone name the machine must be located in.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param not_in_zone`
+:param not_in_zone`
    List of physical zones from which the machine must
        not be acquired.
 
@@ -3636,34 +3636,34 @@ constraints are provided, they are combined using 'AND' semantics.
         with ANY of them. To request multiple zones to exclude, this parameter
         must be repeated in the request with each value.
 
-- `type not_in_zone`
+:type not_in_zone`
    unicode (accepts multiple)
 
-- `param pod`
+:param pod`
    Pod the machine must be located in.
 
-- `type pod`
+:type pod`
    unicode
 
-- `param not_pod`
+:param not_pod`
    Pod the machine must not be located in.
 
-- `type not_pod`
+:type not_pod`
    unicode
 
-- `param pod_type`
+:param pod_type`
    Pod type the machine must be located in.
 
-- `type pod_type`
+:type pod_type`
    unicode
 
-- `param not_pod_type`
+:param not_pod_type`
    Pod type the machine must not be located in.
 
-- `type not_pod_type`
+:type not_pod_type`
    unicode
 
-- `param subnets`
+:param subnets`
    Subnets that must be linked to the machine.
 
     > "Linked to" means the node must be configured to acquire an address in
@@ -3672,30 +3672,30 @@ constraints are provided, they are combined using 'AND' semantics.
     > commissioning time (which implies that it *could* have an address on the
     > specified subnet).
     >
-    > Subnets can be specified by one of the following criteria- `
+    > Subnets can be specified by one of the following criteria:
     >
-    > -   &lt;id&gt;- ` match the subnet by its 'id' field
-    > -   fabric- `&lt;fabric-spec&gt;`
+    > -   &lt;id&gt;: match the subnet by its 'id' field
+    > -   fabric:&lt;fabric-spec&gt;`
 
     match all subnets in a given fabric.
-       -   ip- `&lt;ip-address&gt;`
+       -   ip:&lt;ip-address&gt;`
 
     Match the subnet containing &lt;ip-address&gt; with
        the with the longest-prefix match.
 
-    > -   name- `&lt;subnet-name&gt;`
+    > -   name:&lt;subnet-name&gt;`
 
     Match a subnet with the given name.
-       -   space- `&lt;space-spec&gt;`
+       -   space:&lt;space-spec&gt;`
 
     Match all subnets in a given space.
-       -   vid- `&lt;vid-integer&gt;`
+       -   vid:&lt;vid-integer&gt;`
 
     Match a subnet on a VLAN with the specified
        VID. Valid values range from 0 through 4094 (inclusive). An untagged
         VLAN can be specified by using the value "0".
 
-    > -   vlan- `&lt;vlan-spec&gt;`
+    > -   vlan:&lt;vlan-spec&gt;`
 
     Match all subnets on the given VLAN.
 
@@ -3712,10 +3712,10 @@ constraints are provided, they are combined using 'AND' semantics.
     >
     > Note that this replaces the leagcy 'networks' constraint in MAAS 1.x.
 
-- `type subnets`
+:type subnets`
    unicode (accepts multiple)
 
-- `param not_subnets`
+:param not_subnets`
    Subnets that must NOT be linked to the machine.
 
     > See the 'subnets' constraint documentation above for more information
@@ -3729,55 +3729,55 @@ constraints are provided, they are combined using 'AND' semantics.
     > Note that this replaces the leagcy 'not_networks' constraint in MAAS
     > 1.x.
 
-- `type not_subnets`
+:type not_subnets`
    unicode (accepts multiple)
 
-- `param storage`
-   A list of storage constraint identifiers, in the form- `
-       &lt;label&gt;- `&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+:param storage`
+   A list of storage constraint identifiers, in the form:
+       &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
 
 > ...\]
 
-- `type storage`
+:type storage`
    unicode
 
-- `param interfaces`
+:param interfaces`
    A labeled constraint map associating constraint
        labels with interface properties that should be matched. Returned
         nodes must have one or more interface matching the specified
-        constraints. The labeled constraint map must be in the format- `
-        `<label>- `<key>=<value>[,<key2>=<value2>[,...]]`
+        constraints. The labeled constraint map must be in the format:
+        `<label>:<key>=<value>[,<key2>=<value2>[,...]]`
 
-        Each key can be one of the following- `
+        Each key can be one of the following:
 
-        -   id- ` Matches an interface with the specific id
-        -   fabric- ` Matches an interface attached to the specified
+        -   id: Matches an interface with the specific id
+        -   fabric: Matches an interface attached to the specified
             fabric.
-        -   fabric_class- ` Matches an interface attached to a fabric with
+        -   fabric_class: Matches an interface attached to a fabric with
             the specified class.
-        -   ip- ` Matches an interface with the specified IP address
+        -   ip: Matches an interface with the specified IP address
             assigned to it.
-        -   mode- ` Matches an interface with the specified mode.
+        -   mode: Matches an interface with the specified mode.
             (Currently, the only supported mode is "unconfigured".)
-        -   name- ` Matches an interface with the specified name. (For
+        -   name: Matches an interface with the specified name. (For
             example, "eth0".)
-        -   hostname- ` Matches an interface attached to the node with the
+        -   hostname: Matches an interface attached to the node with the
             specified hostname.
-        -   subnet- ` Matches an interface attached to the specified
+        -   subnet: Matches an interface attached to the specified
             subnet.
-        -   space- ` Matches an interface attached to the specified space.
-        -   subnet_cidr- ` Matches an interface attached to the specified
+        -   space: Matches an interface attached to the specified space.
+        -   subnet_cidr: Matches an interface attached to the specified
             subnet CIDR. (For example, "192.168.0.0/24".)
-        -   type- ` Matches an interface of the specified type. (Valid
-            types- ` "physical", "vlan", "bond", "bridge", or "unknown".)
-        -   vlan- ` Matches an interface on the specified VLAN.
-        -   vid- ` Matches an interface on a VLAN with the specified VID.
-        -   tag- ` Matches an interface tagged with the specified tag.
+        -   type: Matches an interface of the specified type. (Valid
+            types: "physical", "vlan", "bond", "bridge", or "unknown".)
+        -   vlan: Matches an interface on the specified VLAN.
+        -   vid: Matches an interface on a VLAN with the specified VID.
+        -   tag: Matches an interface tagged with the specified tag.
 
-- `type interfaces`
+:type interfaces`
    unicode
 
-- `param fabrics`
+:param fabrics`
    Set of fabrics that the machine must be associated with
        in order to be acquired.
 
@@ -3785,10 +3785,10 @@ constraints are provided, they are combined using 'AND' semantics.
         the specified fabrics. To request multiple possible fabrics to match,
         this parameter must be repeated in the request with each value.
 
-- `type fabrics`
+:type fabrics`
    unicode (accepts multiple)
 
-- `param not_fabrics`
+:param not_fabrics`
    Fabrics the machine must NOT be associated with in
        order to be acquired.
 
@@ -3796,10 +3796,10 @@ constraints are provided, they are combined using 'AND' semantics.
         ANY of them. To request exclusion of multiple fabrics, this parameter
         must be repeated in the request with each value.
 
-- `type not_fabrics`
+:type not_fabrics`
    unicode (accepts multiple)
 
-- `param fabric_classes`
+:param fabric_classes`
    Set of fabric class types whose fabrics the
        machine must be associated with in order to be acquired.
 
@@ -3808,10 +3808,10 @@ constraints are provided, they are combined using 'AND' semantics.
         to match, this parameter must be repeated in the request with each
         value.
 
-- `type fabric_classes`
+:type fabric_classes`
    unicode (accepts multiple)
 
-- `param not_fabric_classes`
+:param not_fabric_classes`
    Fabric class types whose fabrics the machine
        must NOT be associated with in order to be acquired.
 
@@ -3819,61 +3819,61 @@ constraints are provided, they are combined using 'AND' semantics.
         ANY of them. To request exclusion of multiple fabrics, this parameter
         must be repeated in the request with each value.
 
-- `type not_fabric_classes`
+:type not_fabric_classes`
    unicode (accepts multiple)
 
-- `param agent_name`
+:param agent_name`
    An optional agent name to attach to the
        acquired machine.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
-- `param bridge_all`
+:param bridge_all`
    Optionally create a bridge interface for every
        configured interface on the machine. The created bridges will be
-        removed once the machine is released. (Default- ` False)
+        removed once the machine is released. (Default: False)
 
-- `type bridge_all`
+:type bridge_all`
    boolean
 
-- `param bridge_stp`
+:param bridge_stp`
    Optionally turn spanning tree protocol on or off
-       for the bridges created on every configured interface. (Default- `
+       for the bridges created on every configured interface. (Default:
         off)
 
-- `type bridge_stp`
+:type bridge_stp`
    boolean
 
-- `param bridge_fd`
+:param bridge_fd`
    Optionally adjust the forward delay to time seconds.
-       (Default- ` 15)
+       (Default: 15)
 
-- `type bridge_fd`
+:type bridge_fd`
    integer
 
-- `param dry_run`
+:param dry_run`
    Optional boolean to indicate that the machine should
        not actually be acquired (this is for support/troubleshooting, or
         users who want to see which machine would match a constraint, without
         acquiring a machine). Defaults to False.
 
-- `type dry_run`
+:type dry_run`
    bool
 
-- `param verbose`
+:param verbose`
    Optional boolean to indicate that the user would like
        additional verbosity in the constraints_by_type field (each
         constraint will be prefixed by verbose_, and contain the full data
         structure that indicates which machine(s) matched).
 
-- `type verbose`
+:type verbose`
    bool
 
 Returns 409 if a suitable machine matching the constraints could not be found.
@@ -3884,17 +3884,17 @@ Release multiple machines.
 
 This places the machines back into the pool, ready to be reallocated.
 
-- `param machines`
+:param machines`
    system_ids of the machines which are to be released.
        (An empty list is acceptable).
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
-- `return`
+:return`
    The system_ids of any machines that have their status
        changed by this call. Thus, machines that were already released are
         excluded from the result.
@@ -3907,11 +3907,11 @@ of the machines could not be released due to their current state.
 
 Assign multiple nodes to a physical zone at once.
 
-- `param zone`
+:param zone`
    Zone name. If omitted, the zone is "none" and the nodes
        will be taken out of their physical zones.
 
-- `param nodes`
+:param nodes`
    system_ids of the nodes whose zones are to be set.
        (An empty list is acceptable).
 
@@ -3957,24 +3957,24 @@ Update network definition.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-- `param name`
+:param name`
    A simple name for the network, to make it easier to
        refer to. Must consist only of letters, digits, dashes, and
         underscores.
 
-- `param ip`
+:param ip`
    Base IP address for the network, e.g. 10.1.0.0. The host
        bits will be zeroed.
 
-- `param netmask`
+:param netmask`
    Subnet mask to indicate which parts of an IP address
        are part of the network address. For example, 255.255.255.0.
 
-- `param vlan_tag`
-   Optional VLAN tag- ` a number between 1 and 0xffe (4094)
+:param vlan_tag`
+   Optional VLAN tag: a number between 1 and 0xffe (4094)
        inclusive, or zero for an untagged network.
 
-- `param description`
+:param description`
    Detailed description of the network for the benefit
        of users and administrators.
 
@@ -3988,7 +3988,7 @@ Manage the networks.
 
 List networks.
 
-- `param node`
+:param node`
    Optionally, nodes which must be attached to any returned
        networks. If more than one node is given, the result will be
         restricted to networks that these nodes have in common.
@@ -4025,7 +4025,7 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
@@ -4055,25 +4055,25 @@ Read the collection of NodeResult in the MAAS.
 
 List NodeResult visible to the user, optionally filtered.
 
-- `param system_id`
+:param system_id`
    An optional list of system ids. Only the
        results related to the nodes with these system ids will be returned.
 
-- `type system_id`
+:type system_id`
    iterable
 
-- `param name`
+:param name`
    An optional list of names. Only the results
        with the specified names will be returned.
 
-- `type name`
+:type name`
    iterable
 
-- `param result_type`
+:param result_type`
    An optional result_type. Only the results
        with the specified result_type will be returned.
 
-- `type name`
+:type name`
    iterable
 
 ### Node Script
@@ -4088,31 +4088,31 @@ Delete a script.
 
 Return a script's metadata.
 
-- `param include_script`
+:param include_script`
    Include the base64 encoded script content.
 
-- `type include_script`
+:type include_script`
    bool
 
 ##### `GET /api/2.0/scripts/{name} op=download`
 
 Download a script.
 
-- `param revision`
+:param revision`
    What revision to download, latest by default. Can use
        rev as a shortcut.
 
-- `type revision`
+:type revision`
    integer
 
 ##### `POST /api/2.0/scripts/{name} op=add_tag`
 
 Add a single tag to a script.
 
-- `param tag`
+:param tag`
    The tag being added.
 
-- `type tag`
+:type tag`
    unicode
 
 Returns 404 if the script is not found.
@@ -4121,10 +4121,10 @@ Returns 404 if the script is not found.
 
 Remove a single tag to a script.
 
-- `param tag`
+:param tag`
    The tag being removed.
 
-- `type tag`
+:type tag`
    unicode
 
 Returns 404 if the script is not found.
@@ -4133,11 +4133,11 @@ Returns 404 if the script is not found.
 
 Revert a script to an earlier version.
 
-- `param to`
+:param to`
    What revision in the script's history to revert to. This can
        either be an ID or a negative number representing how far back to go.
 
-- `type to`
+:type to`
    integer
 
 Returns 404 if the script is not found.
@@ -4146,110 +4146,110 @@ Returns 404 if the script is not found.
 
 Update a commissioning script.
 
-- `param name`
+:param name`
    The name of the script.
 
-- `type name`
+:type name`
    unicode
 
-- `param title`
+:param title`
    The title of the script.
 
-- `type title`
+:type title`
    unicode
 
-- `param description`
+:param description`
    A description of what the script does.
 
-- `type description`
+:type description`
    unicode
 
-- `param tags`
+:param tags`
    A comma seperated list of tags for this script.
 
-- `type tags`
+:type tags`
    unicode
 
-- `param type`
+:param type`
    The type defines when the script should be used. Can be
        testing or commissioning, defaults to testing.
 
-- `type script_type`
+:type script_type`
    unicode
 
-- `param hardware_type`
+:param hardware_type`
    The hardware_type defines what type of hardware
        the script is assoicated with. May be CPU, memory, storage, or node.
 
-- `type hardware_type`
+:type hardware_type`
    unicode
 
-- `param parallel`
+:param parallel`
    Whether the script may be run in parallel with other
        scripts. May be disabled to run by itself, instance to run along
         scripts with the same name, or any to run along any script.
 
-- `type parallel`
+:type parallel`
    unicode
 
-- `param timeout`
+:param timeout`
    How long the script is allowed to run before failing.
        0 gives unlimited time, defaults to 0.
 
-- `type timeout`
+:type timeout`
    unicode
 
-- `param timeout`
+:param timeout`
    How long the script is allowed to run before failing.
        0 gives unlimited time, defaults to 0.
 
-- `type timeout`
+:type timeout`
    unicode
 
-- `param destructive`
+:param destructive`
    Whether or not the script overwrites data on any
        drive on the running system. Destructive scripts can not be run on
         deployed systems. Defaults to false.
 
-- `type destructive`
+:type destructive`
    boolean
 
-- `param script`
+:param script`
    The content of the script to be uploaded in binary form.
-       note- ` this is not a normal parameter, but a file upload. Its
+       note: this is not a normal parameter, but a file upload. Its
         filename is ignored; MAAS will know it by the name you pass to the
         request. Optionally you can ignore the name and script parameter in
         favor of uploading a single file as part of the request.
 
-- `param comment`
+:param comment`
    A comment about what this change does.
 
-- `type comment`
+:type comment`
    unicode
 
-- `param for_hardware`
+:param for_hardware`
    A list of modalias, PCI IDs, and/or USB IDs the
-       script will automatically run on. Must start with modalias- `,
-        pci- `
+       script will automatically run on. Must start with modalias:,
+        pci:
 
 ,
-   or usb- `.
+   or usb:.
 
-- `type for_hardware`
+:type for_hardware`
    unicode
 
-- `param may_reboot`
+:param may_reboot`
    Whether or not the script may reboot the system
        while running.
 
-- `type may_reboot`
+:type may_reboot`
    boolean
 
-- `param recommission`
+:param recommission`
    Whether builtin commissioning scripts should be
        rerun after successfully running this scripts.
 
-- `type recommission`
+:type recommission`
    boolean
 
 ### Node Script Result
@@ -4270,24 +4270,24 @@ View a specific set of results.
 id can either by the script set id, current-commissioning, current-testing, or
 current-installation.
 
-- `param hardware_type`
+:param hardware_type`
    Only return scripts for the given hardware type.
        Can be node, cpu, memory, or storage. Defaults to all.
 
-- `type script_type`
+:type script_type`
    unicode
 
-- `param include_output`
+:param include_output`
    Include base64 encoded output from the script.
 
-- `type include_output`
+:type include_output`
    bool
 
-- `param filters`
+:param filters`
    A comma seperated list to show only results that ran
        with a script name, tag, or id.
 
-- `type filters`
+:type filters`
    unicode
 
 ##### `GET /api/2.0/nodes/{system_id}/results/{id}/ op=download`
@@ -4297,31 +4297,31 @@ Download a compressed tar containing all results.
 id can either by the script set id, current-commissioning, current-testing, or
 current-installation.
 
-- `param hardware_type`
+:param hardware_type`
    Only return scripts for the given hardware type.
        Can be node, cpu, memory, or storage. Defaults to all.
 
-- `type script_type`
+:type script_type`
    unicode
 
-- `param filters`
+:param filters`
    A comma seperated list to show only results that ran
        with a script name or tag.
 
-- `type filters`
+:type filters`
    unicode
 
-- `param output`
+:param output`
    Can be either combined, stdout, stderr, or all. By
        default only the combined output is returned.
 
-- `type output`
+:type output`
    unicode
 
-- `param filetype`
+:param filetype`
    Filetype to output, can be txt or tar.xz
 
-- `type format`
+:type format`
    unicode
 
 ### Node Script Result
@@ -4332,31 +4332,31 @@ Manage node script results.
 
 Return a list of script results grouped by run.
 
-- `param type`
+:param type`
    Only return scripts with the given type. This can be
        commissioning, testing, or installion. Defaults to showing all.
 
-- `type type`
+:type type`
    unicode
 
-- `param hardware_type`
+:param hardware_type`
    Only return scripts for the given hardware type.
        Can be node, cpu, memory, or storage. Defaults to all.
 
-- `type script_type`
+:type script_type`
    unicode
 
-- `param include_output`
+:param include_output`
    Include base64 encoded output from the script.
 
-- `type include_output`
+:type include_output`
    bool
 
-- `param filters`
+:param filters`
    A comma seperated list to show only results
        with a script name or tag.
 
-- `type filters`
+:type filters`
    unicode
 
 ### Node Scripts
@@ -4369,137 +4369,137 @@ Manage custom scripts.
 
 Return a list of stored scripts.
 
-- `param type`
+:param type`
    Only return scripts with the given type. This can be
        testing or commissioning. Defaults to showing both.
 
-- `type type`
+:type type`
    unicode
 
-- `param hardware_type`
+:param hardware_type`
    Only return scripts for the given hardware type.
        Can be node, cpu, memory, or storage. Defaults to all.
 
-- `type hardware_type`
+:type hardware_type`
    unicode
 
-- `param include_script`
+:param include_script`
    Include the base64 encoded script content.
 
-- `type include_script`
+:type include_script`
    bool
 
-- `param filters`
+:param filters`
    A comma seperated list to show only results
        with a script name or tag.
 
-- `type filters`
+:type filters`
    unicode
 
 ##### `POST /api/2.0/scripts/`
 
 Create a new script.
 
-- `param name`
+:param name`
    The name of the script.
 
-- `type name`
+:type name`
    unicode
 
-- `param title`
+:param title`
    The title of the script.
 
-- `type title`
+:type title`
    unicode
 
-- `param description`
+:param description`
    A description of what the script does.
 
-- `type description`
+:type description`
    unicode
 
-- `param tags`
+:param tags`
    A comma seperated list of tags for this script.
 
-- `type tags`
+:type tags`
    unicode
 
-- `param type`
+:param type`
    The script_type defines when the script should be used.
        Can be testing or commissioning, defaults to testing.
 
-- `type script_type`
+:type script_type`
    unicode
 
-- `param hardware_type`
+:param hardware_type`
    The hardware_type defines what type of hardware
        the script is assoicated with. May be CPU, memory, storage, or node.
 
-- `type hardware_type`
+:type hardware_type`
    unicode
 
-- `param parallel`
+:param parallel`
    Whether the script may be run in parallel with other
        scripts. May be disabled to run by itself, instance to run along
         scripts with the same name, or any to run along any script.
 
-- `type parallel`
+:type parallel`
    unicode
 
-- `param timeout`
+:param timeout`
    How long the script is allowed to run before failing.
        0 gives unlimited time, defaults to 0.
 
-- `type timeout`
+:type timeout`
    unicode
 
-- `param destructive`
+:param destructive`
    Whether or not the script overwrites data on any
        drive on the running system. Destructive scripts can not be run on
         deployed systems. Defaults to false.
 
-- `type destructive`
+:type destructive`
    boolean
 
-- `param script`
+:param script`
    The content of the script to be uploaded in binary form.
-       note- ` this is not a normal parameter, but a file upload. Its
+       note: this is not a normal parameter, but a file upload. Its
         filename is ignored; MAAS will know it by the name you pass to the
         request. Optionally you can ignore the name and script parameter in
         favor of uploading a single file as part of the request.
 
-- `type script`
+:type script`
    unicode
 
-- `param comment`
+:param comment`
    A comment about what this change does.
 
-- `type comment`
+:type comment`
    unicode
 
-- `param for_hardware`
+:param for_hardware`
    A list of modalias, PCI IDs, and/or USB IDs the
-       script will automatically run on. Must start with modalias- `,
-        pci- `
+       script will automatically run on. Must start with modalias:,
+        pci:
 
 ,
-   or usb- `.
+   or usb:.
 
-- `type for_hardware`
+:type for_hardware`
    unicode
 
-- `param may_reboot`
+:param may_reboot`
    Whether or not the script may reboot the system
        while running.
 
-- `type may_reboot`
+:type may_reboot`
    boolean
 
-- `param recommission`
+:param recommission`
    Whether builtin commissioning scripts should be
        rerun after successfully running this scripts.
 
-- `type recommission`
+:type recommission`
    boolean
 
 ### Nodes
@@ -4512,48 +4512,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only nodes relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to see multiple nodes.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param mac_address`
+:param mac_address`
    An optional MAC address. Only nodes relating to the
        node owning the specified MAC address will be returned. This can be
         specified multiple times to see multiple nodes.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes relating to the
        nodes with matching system ids will be returned.
 
-- `type id`
+:type id`
    unicode
 
-- `param domain`
+:param domain`
    An optional name for a dns domain. Only nodes relating
        to the nodes in the domain will be returned.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes relating
        to the nodes in the zone will be returned.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes relating to the
        nodes with matching agent names will be returned.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
 ##### `GET /api/2.0/nodes/ op=is_registered`
@@ -4561,16 +4561,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-- `param mac_address`
+:param mac_address`
    The mac address to be checked.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `return`
+:return`
    'true' or 'false'.
 
-- `rtype`
+:rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -4579,11 +4579,11 @@ Returns 400 if any mandatory parameters are missing.
 
 Assign multiple nodes to a physical zone at once.
 
-- `param zone`
+:param zone`
    Zone name. If omitted, the zone is "none" and the nodes
        will be taken out of their physical zones.
 
-- `param nodes`
+:param nodes`
    system_ids of the nodes whose zones are to be set.
        (An empty list is acceptable).
 
@@ -4632,35 +4632,35 @@ Create a notification.
 
 This is available to admins *only*.
 
-- `param message`
+:param message`
    The message for this notification. May contain basic
        HTML; this will be sanitised before display.
 
-- `param context`
+:param context`
    Optional JSON context. The root object *must* be an
        object (i.e. a mapping). The values herein can be referenced by
         message with Python's "format" (not %) codes.
 
-- `param category`
-   Optional category. Choose from- ` error, warning,
+:param category`
+   Optional category. Choose from: error, warning,
        success, or info. Defaults to info.
 
-- `param ident`
+:param ident`
    Optional unique identifier for this notification.
 
-- `param user`
+:param user`
    Optional user ID this notification is intended for. By
        default it will not be targeted to any individual user.
 
-- `param users`
+:param users`
    Optional boolean, true to notify all users, defaults to
        false, i.e. not targeted to all users.
 
-- `param admins`
+:param admins`
    Optional boolean, true to notify all admins, defaults to
        false, i.e. not targeted to all admins.
 
-Note- ` if neither user nor users nor admins is set, the notification will
+Note: if neither user nor users nor admins is set, the notification will
 not be seen by anyone.
 
 ### Package Repositories
@@ -4675,48 +4675,48 @@ List all Package Repositories.
 
 Create a Package Repository.
 
-- `param name`
+:param name`
    The name of the Package Repository.
 
-- `type name`
+:type name`
    unicode
 
-- `param url`
+:param url`
    The url of the Package Repository.
 
-- `type url`
+:type url`
    unicode
 
-- `param distributions`
+:param distributions`
    Which package distributions to include.
 
-- `type distributions`
+:type distributions`
    unicode
 
-- `param disabled_pockets`
+:param disabled_pockets`
    The list of pockets to disable.
 
-- `param disabled_components`
+:param disabled_components`
    The list of components to disable. Only
        applicable to the default Ubuntu repositories.
 
-- `param components`
+:param components`
    The list of components to enable. Only applicable
        to custom repositories.
 
-- `param arches`
+:param arches`
    The list of supported architectures.
 
-- `param key`
+:param key`
    The authentication key to use with the repository.
 
-- `type key`
+:type key`
    unicode
 
-- `param enabled`
+:param enabled`
    Whether or not the repository is enabled.
 
-- `type enabled`
+:type enabled`
    boolean
 
 ### Package Repository
@@ -4741,48 +4741,48 @@ Returns 404 if the repository is not found.
 
 Update a Package Repository.
 
-- `param name`
+:param name`
    The name of the Package Repository.
 
-- `type name`
+:type name`
    unicode
 
-- `param url`
+:param url`
    The url of the Package Repository.
 
-- `type url`
+:type url`
    unicode
 
-- `param distributions`
+:param distributions`
    Which package distributions to include.
 
-- `type distributions`
+:type distributions`
    unicode
 
-- `param disabled_pockets`
+:param disabled_pockets`
    The list of pockets to disable.
 
-- `param disabled_components`
+:param disabled_components`
    The list of components to disable. Only
        applicable to the default Ubuntu repositories.
 
-- `param components`
+:param components`
    The list of components to enable. Only applicable
        to custom repositories.
 
-- `param arches`
+:param arches`
    The list of supported architectures.
 
-- `param key`
+:param key`
    The authentication key to use with the repository.
 
-- `type key`
+:type key`
    unicode
 
-- `param enabled`
+:param enabled`
    Whether or not the repository is enabled.
 
-- `type enabled`
+:type enabled`
    boolean
 
 Returns 404 if the Package Repository is not found.
@@ -4807,13 +4807,13 @@ Returns 404 if the node, block device, or partition are not found.
 
 Format a partition.
 
-- `param fstype`
+:param fstype`
    Type of filesystem.
 
-- `param uuid`
+:param uuid`
    The UUID for the filesystem.
 
-- `param label`
+:param label`
    The label for the filesystem.
 
 Returns 403 when the user doesn't have the ability to format the partition.
@@ -4823,10 +4823,10 @@ Returns 404 if the node, block device, or partition is not found.
 
 Mount the filesystem on partition.
 
-- `param mount_point`
+:param mount_point`
    Path on the filesystem to mount.
 
-- `param mount_options`
+:param mount_options`
    Options to pass to mount(8).
 
 Returns 403 when the user doesn't have the ability to mount the partition.
@@ -4858,15 +4858,15 @@ Returns 404 if the node or the block device are not found.
 
 Create a partition on the block device.
 
-- `param size`
+:param size`
    The size of the partition. If not specified, all
        available space will be used.
 
-- `param uuid`
+:param uuid`
    UUID for the partition. Only used if the partition table
        type for the block device is GPT.
 
-- `param bootable`
+:param bootable`
    If the partition should be marked bootable.
 
 Returns 404 if the node or the block device are not found.
@@ -4903,7 +4903,7 @@ Returns 404 if the pod is not found.
 
 Add a tag to Pod.
 
-- `param tag`
+:param tag`
    The tag being added.
 
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
@@ -4913,40 +4913,40 @@ update the Pod.
 
 Compose a machine from Pod.
 
-All fields below are optional- `
+All fields below are optional:
 
-- `param cores`
+:param cores`
    Minimum number of CPU cores.
 
-- `param memory`
+:param memory`
    Minimum amount of memory (MiB).
 
-- `param cpu_speed`
+:param cpu_speed`
    Minimum amount of CPU speed (MHz).
 
-- `param architecture`
+:param architecture`
    Architecture for the machine. Must be an
        architecture that the pod supports.
 
-- `param storage`
-   A list of storage constraint identifiers, in the form- `
-       &lt;label&gt;- `&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+:param storage`
+   A list of storage constraint identifiers, in the form:
+       &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
 
 > ...\]
 
-- `type storage`
+:type storage`
    unicode
 
-- `param hostname`
+:param hostname`
    Hostname for the newly composed machine.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param domain`
+:param domain`
    ID of domain to place the newly composed machine in.
 
-- `param zone`
+:param zone`
    ID of zone place the newly composed machine in.
 
 Returns 404 if the pod is not found. Returns 403 if the user does not have
@@ -4966,7 +4966,7 @@ permission to refresh the pod.
 
 Remove a tag from Pod.
 
-- `param tag`
+:param tag`
    The tag being removed.
 
 Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
@@ -4976,10 +4976,10 @@ update the Pod.
 
 Update a specific Pod.
 
-- `param name`
+:param name`
    Name for the pod (optional).
 
-Note- ` 'type' cannot be updated on a Pod. The Pod must be deleted and
+Note: 'type' cannot be updated on a Pod. The Pod must be deleted and
 re-added to change the type.
 
 Returns 404 if the pod is not found. Returns 403 if the user does not have
@@ -4999,16 +4999,16 @@ Get a listing of all the pods.
 
 Create a Pod.
 
-- `param type`
+:param type`
    Type of pod to create (rsd, virsh).
 
-- `param name`
+:param name`
    Name for the pod (optional).
 
-- `param zone`
+:param zone`
    Name of the zone for the pod (optional).
 
-- `param tags`
+:param tags`
    A tag or tags (separated by comma) for the pod.
 
 Returns 503 if the pod could not be discovered. Returns 404 if the pod is not
@@ -5040,7 +5040,7 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
@@ -5080,10 +5080,10 @@ state. The reply to this could be delayed by up to 30 seconds while waiting
 for the power controller to respond. Use this method sparingly as it ties up
 an appserver thread while waiting.
 
-- `param system_id`
+:param system_id`
    The node to query.
 
-- `return`
+:return`
    a dict whose key is "state" with a value of one of
        'on' or 'off'.
 
@@ -5093,10 +5093,10 @@ Returns 404 if the node is not found. Returns node's power state.
 
 Abort a node's current operation.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the node could not be found. Returns 403 if the user does not
@@ -5112,10 +5112,10 @@ Returns 404 if the rack controller is not found.
 
 Ignore failed tests and put node back into a usable state.
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the machine is not found. Returns 403 if the user does not have
@@ -5125,7 +5125,7 @@ permission to ignore tests for the node.
 
 Power off a node.
 
-- `param stop_mode`
+:param stop_mode`
    An optional power off mode. If 'soft',
        perform a soft power down if the node's power type supports it,
         otherwise perform a hard power off. For all values other than 'soft',
@@ -5134,13 +5134,13 @@ Power off a node.
         while a hard power off occurs immediately without any warning to the
         OS.
 
-- `type stop_mode`
+:type stop_mode`
    unicode
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Returns 404 if the node is not found. Returns 403 if the user does not have
@@ -5150,17 +5150,17 @@ permission to stop the node.
 
 Turn on a node.
 
-- `param user_data`
+:param user_data`
    If present, this blob of user-data to be made
        available to the nodes through the metadata service.
 
-- `type user_data`
+:type user_data`
    base64-encoded unicode
 
-- `param comment`
+:param comment`
    Optional comment for the event log.
 
-- `type comment`
+:type comment`
    unicode
 
 Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
@@ -5176,19 +5176,19 @@ relevant cluster interface.
 
 Begin testing process for a node.
 
-- `param enable_ssh`
+:param enable_ssh`
    Whether to enable SSH for the testing environment
        using the user's SSH key(s).
 
-- `type enable_ssh`
+:type enable_ssh`
    bool ('0' for False, '1' for True)
 
-- `param testing_scripts`
+:param testing_scripts`
    A comma seperated list of testing script names
        and tags to be run. By default all tests tagged 'commissioning' will
         be run.
 
-- `type testing_scripts`
+:type testing_scripts`
    string
 
 A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
@@ -5203,39 +5203,39 @@ Returns 404 if the node is not found.
 
 Update a specific Rack controller.
 
-- `param power_type`
+:param power_type`
    The new power type for this rack controller. If you
        use the default value, power_parameters will be set to the empty
         string. Available to admin users. See the [Power types]() section for
         a list of the available power types.
 
-- `type power_type`
+:type power_type`
    unicode
 
-- `param [power_parameters](){param1}`
+:param [power_parameters](){param1}`
    The new value for the 'param1'
        power parameter. Note that this is dynamic as the available parameters
         depend on the selected value of the rack controller's power_type.
         Available to admin users. See the [Power types]() section for a list
         of the available power parameters for each power type.
 
-- `type [power_parameters](){param1}`
+:type [power_parameters](){param1}`
    unicode
 
-- `param power_parameters_skip_check`
+:param power_parameters_skip_check`
    Whether or not the new power
        parameters for this rack controller should be checked against the
         expected power parameters for the rack controller's power type ('true'
         or 'false'). The default is 'false'.
 
-- `type power_parameters_skip_check`
+:type power_parameters_skip_check`
    unicode
 
-- `param zone`
+:param zone`
    Name of a valid physical zone in which to place this
        rack controller.
 
-- `type zone`
+:type zone`
    unicode
 
 Returns 404 if the rack controller is not found. Returns 403 if the user does
@@ -5251,55 +5251,55 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only nodes relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to see multiple nodes.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param mac_address`
+:param mac_address`
    An optional MAC address. Only nodes relating to the
        node owning the specified MAC address will be returned. This can be
         specified multiple times to see multiple nodes.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes relating to the
        nodes with matching system ids will be returned.
 
-- `type id`
+:type id`
    unicode
 
-- `param domain`
+:param domain`
    An optional name for a dns domain. Only nodes relating
        to the nodes in the domain will be returned.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes relating
        to the nodes in the zone will be returned.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes relating to the
        nodes with matching agent names will be returned.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
 ##### `GET /api/2.0/rackcontrollers/ op=describe_power_types`
 
 Query all of the rack controllers for power information.
 
-- `return`
+:return`
    a list of dicts that describe the power types in this format.
 
 ##### `GET /api/2.0/rackcontrollers/ op=is_registered`
@@ -5307,16 +5307,16 @@ Query all of the rack controllers for power information.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-- `param mac_address`
+:param mac_address`
    The mac address to be checked.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `return`
+:return`
    'true' or 'false'.
 
-- `rtype`
+:rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -5325,14 +5325,14 @@ Returns 400 if any mandatory parameters are missing.
 
 Retrieve power parameters for multiple machines.
 
-- `param id`
+:param id`
    An optional list of system ids. Only machines with
        matching system ids will be returned.
 
-- `type id`
+:type id`
    iterable
 
-- `return`
+:return`
    A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
@@ -5345,11 +5345,11 @@ Import the boot images on all rack controllers.
 
 Assign multiple nodes to a physical zone at once.
 
-- `param zone`
+:param zone`
    Zone name. If omitted, the zone is "none" and the nodes
        will be taken out of their physical zones.
 
-- `param nodes`
+:param nodes`
    system_ids of the nodes whose zones are to be set.
        (An empty list is acceptable).
 
@@ -5376,35 +5376,35 @@ Returns 404 if the machine or RAID is not found.
 
 Update RAID on a machine.
 
-- `param name`
+:param name`
    Name of the RAID.
 
-- `param uuid`
+:param uuid`
    UUID of the RAID.
 
-- `param add_block_devices`
+:param add_block_devices`
    Block devices to add to the RAID.
 
-- `param remove_block_devices`
+:param remove_block_devices`
    Block devices to remove from the RAID.
 
-- `param add_spare_devices`
+:param add_spare_devices`
    Spare block devices to add to the RAID.
 
-- `param remove_spare_devices`
+:param remove_spare_devices`
    Spare block devices to remove
        from the RAID.
 
-- `param add_partitions`
+:param add_partitions`
    Partitions to add to the RAID.
 
-- `param remove_partitions`
+:param remove_partitions`
    Partitions to remove from the RAID.
 
-- `param add_spare_partitions`
+:param add_spare_partitions`
    Spare partitions to add to the RAID.
 
-- `param remove_spare_partitions`
+:param remove_spare_partitions`
    Spare partitions to remove from the
        RAID.
 
@@ -5425,25 +5425,25 @@ Returns 404 if the machine is not found.
 
 Creates a RAID
 
-- `param name`
+:param name`
    Name of the RAID.
 
-- `param uuid`
+:param uuid`
    UUID of the RAID.
 
-- `param level`
+:param level`
    RAID level.
 
-- `param block_devices`
+:param block_devices`
    Block devices to add to the RAID.
 
-- `param spare_devices`
+:param spare_devices`
    Spare block devices to add to the RAID.
 
-- `param partitions`
+:param partitions`
    Partitions to add to the RAID.
 
-- `param spare_partitions`
+:param spare_partitions`
    Spare partitions to add to the RAID.
 
 Returns 404 if the machine is not found. Returns 409 if the machine is not
@@ -5475,7 +5475,7 @@ Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
 Note that this is returned as BSON and not JSON. This is for efficiency, but
@@ -5501,39 +5501,39 @@ Returns 404 if the node is not found.
 
 Update a specific Region controller.
 
-- `param power_type`
+:param power_type`
    The new power type for this region controller. If
        you use the default value, power_parameters will be set to the empty
         string. Available to admin users. See the [Power types]() section for
         a list of the available power types.
 
-- `type power_type`
+:type power_type`
    unicode
 
-- `param [power_parameters](){param1}`
+:param [power_parameters](){param1}`
    The new value for the 'param1'
        power parameter. Note that this is dynamic as the available parameters
         depend on the selected value of the region controller's power_type.
         Available to admin users. See the [Power types]() section for a list
         of the available power parameters for each power type.
 
-- `type [power_parameters](){param1}`
+:type [power_parameters](){param1}`
    unicode
 
-- `param power_parameters_skip_check`
+:param power_parameters_skip_check`
    Whether or not the new power
        parameters for this region controller should be checked against the
         expected power parameters for the region controller's power type
         ('true' or 'false'). The default is 'false'.
 
-- `type power_parameters_skip_check`
+:type power_parameters_skip_check`
    unicode
 
-- `param zone`
+:param zone`
    Name of a valid physical zone in which to place this
        region controller.
 
-- `type zone`
+:type zone`
    unicode
 
 Returns 404 if the region controller is not found. Returns 403 if the user
@@ -5549,48 +5549,48 @@ List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
-- `param hostname`
+:param hostname`
    An optional hostname. Only nodes relating to the node
        with the matching hostname will be returned. This can be specified
         multiple times to see multiple nodes.
 
-- `type hostname`
+:type hostname`
    unicode
 
-- `param mac_address`
+:param mac_address`
    An optional MAC address. Only nodes relating to the
        node owning the specified MAC address will be returned. This can be
         specified multiple times to see multiple nodes.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `param id`
+:param id`
    An optional list of system ids. Only nodes relating to the
        nodes with matching system ids will be returned.
 
-- `type id`
+:type id`
    unicode
 
-- `param domain`
+:param domain`
    An optional name for a dns domain. Only nodes relating
        to the nodes in the domain will be returned.
 
-- `type domain`
+:type domain`
    unicode
 
-- `param zone`
+:param zone`
    An optional name for a physical zone. Only nodes relating
        to the nodes in the zone will be returned.
 
-- `type zone`
+:type zone`
    unicode
 
-- `param agent_name`
+:param agent_name`
    An optional agent name. Only nodes relating to the
        nodes with matching agent names will be returned.
 
-- `type agent_name`
+:type agent_name`
    unicode
 
 ##### `GET /api/2.0/regioncontrollers/ op=is_registered`
@@ -5598,16 +5598,16 @@ Nodes are sorted by id (i.e. most recent last) and grouped by type.
 Returns whether or not the given MAC address is registered within this MAAS
 (and attached to a non-retired node).
 
-- `param mac_address`
+:param mac_address`
    The mac address to be checked.
 
-- `type mac_address`
+:type mac_address`
    unicode
 
-- `return`
+:return`
    'true' or 'false'.
 
-- `rtype`
+:rtype`
    unicode
 
 Returns 400 if any mandatory parameters are missing.
@@ -5616,11 +5616,11 @@ Returns 400 if any mandatory parameters are missing.
 
 Assign multiple nodes to a physical zone at once.
 
-- `param zone`
+:param zone`
    Zone name. If omitted, the zone is "none" and the nodes
        will be taken out of their physical zones.
 
-- `param nodes`
+:param nodes`
    system_ids of the nodes whose zones are to be set.
        (An empty list is acceptable).
 
@@ -5665,7 +5665,7 @@ name is "key".
 Import the requesting user's SSH keys.
 
 Import SSH keys for a given protocol and authorization ID in
-protocol- `auth_id format.
+protocol:auth_id format.
 
 ### SSL Key
 
@@ -5722,10 +5722,10 @@ Returns 404 if the space is not found.
 
 Update space.
 
-- `param name`
+:param name`
    Name of the space.
 
-- `param description`
+:param description`
    Description of the space.
 
 Returns 404 if the space is not found.
@@ -5742,10 +5742,10 @@ List all spaces.
 
 Create a space.
 
-- `param name`
+:param name`
    Name of the space.
 
-- `param description`
+:param description`
    Description of the space.
 
 ### Static route
@@ -5768,16 +5768,16 @@ Returns 404 if the static route is not found.
 
 Update static route.
 
-- `param source`
+:param source`
    Source subnet for the route.
 
-- `param destination`
+:param destination`
    Destination subnet for the route.
 
-- `param gateway_ip`
+:param gateway_ip`
    IP address of the gateway on the source subnet.
 
-- `param metric`
+:param metric`
    Weight of the route on a deployed machine.
 
 Returns 404 if the static route is not found.
@@ -5794,16 +5794,16 @@ List all static routes.
 
 Create a static route.
 
-- `param source`
+:param source`
    Source subnet for the route.
 
-- `param destination`
+:param destination`
    Destination subnet for the route.
 
-- `param gateway_ip`
+:param gateway_ip`
    IP address of the gateway on the source subnet.
 
-- `param metric`
+:param metric`
    Weight of the route on a deployed machine.
 
 ### Subnet
@@ -5830,11 +5830,11 @@ Returns a summary of IP addresses assigned to this subnet.
 
 with_username
    If False, suppresses the display of usernames associated with each
-    address. (Default- ` True)
+    address. (Default: True)
 
 with_summary
    If False, suppresses the display of nodes, BMCs, and and DNS records
-    associated with each address. (Default- ` True)
+    associated with each address. (Default: True)
 
 with_node_summary
    Deprecated form of with_summary.
@@ -5847,15 +5847,15 @@ Returns 404 if the subnet is not found.
 
 ##### `GET /api/2.0/subnets/{id}/ op=statistics`
 
-Returns statistics for the specified subnet, including- `
+Returns statistics for the specified subnet, including:
 
-num_available- ` the number of available IP addresses
-largest_available- ` the largest number of contiguous free IP addresses
-num_unavailable- ` the number of unavailable IP addresses
-total_addresses- ` the sum of the available plus unavailable addresses
-usage- ` the (floating point) usage percentage of this subnet
-usage_string- ` the (formatted unicode) usage percentage of this subnet
-ranges- ` the specific IP ranges present in ths subnet (if specified)
+num_available: the number of available IP addresses
+largest_available: the largest number of contiguous free IP addresses
+num_unavailable: the number of unavailable IP addresses
+total_addresses: the sum of the available plus unavailable addresses
+usage: the (floating point) usage percentage of this subnet
+usage_string: the (formatted unicode) usage percentage of this subnet
+ranges: the specific IP ranges present in ths subnet (if specified)
 
 ###### Optional parameters
 
@@ -5911,7 +5911,7 @@ dns_servers
    Comma-seperated list of DNS servers for this subnet.
 
 managed
-   If False, MAAS should not manage this subnet. (Default- ` True)
+   If False, MAAS should not manage this subnet. (Default: True)
 
 Returns 404 if the subnet is not found.
 
@@ -5961,7 +5961,7 @@ gateway_ip
    The gateway IP address for this subnet.
 
 rdns_mode
-   How reverse DNS is handled for this subnet. One of- ` 0 (Disabled), 1
+   How reverse DNS is handled for this subnet. One of: 0 (Disabled), 1
     (Enabled), or 2 (RFC2317). Disabled means no reverse zone is created;
     Enabled means generate the reverse zone; RFC2317 extends Enabled to create
     the necessary parent zone with the appropriate CNAME resource records for
@@ -6054,19 +6054,19 @@ Returns 404 if the tag is not found.
 
 Add or remove nodes being associated with this tag.
 
-- `param add`
+:param add`
    system_ids of nodes to add to this tag.
 
-- `param remove`
+:param remove`
    system_ids of nodes to remove from this tag.
 
-- `param definition`
+:param definition`
    (optional) If supplied, the definition will be
        validated against the current definition of the tag. If the value does
         not match, then the update will be dropped (assuming this was just a
         case of a worker being out-of-date)
 
-- `param rack_controller`
+:param rack_controller`
    A system ID of a rack controller that did the
        processing. This value is optional. If not supplied, the requester
         must be a superuser. If supplied, then the requester must be the rack
@@ -6080,15 +6080,15 @@ current definition.
 
 Update a specific Tag.
 
-- `param name`
+:param name`
    The name of the Tag to be created. This should be a short
        name, and will be used in the URL of the tag.
 
-- `param comment`
+:param comment`
    A long form description of what the tag is meant for.
        It is meant as a human readable description of the tag.
 
-- `param definition`
+:param definition`
    An XPATH query that will be evaluated against the
        hardware_details stored for all nodes (output of lshw -xml).
 
@@ -6108,19 +6108,19 @@ Get a listing of all tags that are currently defined.
 
 Create a new Tag.
 
-- `param name`
+:param name`
    The name of the Tag to be created. This should be a short
        name, and will be used in the URL of the tag.
 
-- `param comment`
+:param comment`
    A long form description of what the tag is meant for.
        It is meant as a human readable description of the tag.
 
-- `param definition`
+:param definition`
    An XPATH query that will be evaluated against the
        hardware_details stored for all nodes (output of lshw -xml).
 
-- `param kernel_opts`
+:param kernel_opts`
    Can be None. If set, nodes associated with this tag
        will add this string to their kernel options when booting. The value
         overrides the global 'kernel_opts' setting. If more than one tag is
@@ -6155,32 +6155,32 @@ Returns the currently logged in user.
 
 Create a MAAS user account.
 
-This is not safe- ` the password is sent in plaintext. Avoid it for
+This is not safe: the password is sent in plaintext. Avoid it for
 production, unless you are confident that you can prevent eavesdroppers from
 observing the request.
 
-- `param username`
+:param username`
    Identifier-style username for the new user.
 
-- `type username`
+:type username`
    unicode
 
-- `param email`
+:param email`
    Email address for the new user.
 
-- `type email`
+:type email`
    unicode
 
-- `param password`
+:param password`
    Password for the new user.
 
-- `type password`
+:type password`
    unicode
 
-- `param is_superuser`
+:param is_superuser`
    Whether the new user is to be an administrator.
 
-- `type is_superuser`
+:type is_superuser`
    bool ('0' for False, '1' for True)
 
 Returns 400 if any mandatory parameters are missing.
@@ -6190,11 +6190,11 @@ Returns 400 if any mandatory parameters are missing.
 Information about this MAAS instance.
 
 > This returns a JSON dictionary with information about this MAAS
-> instance- ``
+> instance:`
 >
 > > {
-> >    'version'- ` '1.8.0', 'subversion'` 'alpha10+bzr3750',
-> >     'capabilities'- ` \['capability1', 'capability2', ...\]
+> >    'version': '1.8.0', 'subversion'` 'alpha10+bzr3750',
+> >     'capabilities': \['capability1', 'capability2', ...\]
 > >
 > > }
 
@@ -6222,64 +6222,64 @@ Returns 404 if the fabric or VLAN is not found.
 
 Update VLAN.
 
-- `param name`
+:param name`
    Name of the VLAN.
 
-- `type name`
+:type name`
    unicode
 
-- `param description`
+:param description`
    Description of the VLAN.
 
-- `type description`
+:type description`
    unicode
 
-- `param vid`
+:param vid`
    VLAN ID of the VLAN.
 
-- `type vid`
+:type vid`
    integer
 
-- `param mtu`
+:param mtu`
    The MTU to use on the VLAN.
 
-- `type mtu`
+:type mtu`
    integer
 
-- `param dhcp_on`
+:param dhcp_on`
    Whether or not DHCP should be managed on the VLAN.
 
-- `type dhcp_on`
+:type dhcp_on`
    boolean
 
-- `param primary_rack`
+:param primary_rack`
    The primary rack controller managing the VLAN.
 
-- `type primary_rack`
+:type primary_rack`
    system_id
 
-- `param secondary_rack`
+:param secondary_rack`
    The secondary rack controller manging the VLAN.
 
-- `type secondary_rack`
+:type secondary_rack`
    system_id
 
-- `param relay_vlan`
+:param relay_vlan`
    Only set when this VLAN will be using a DHCP relay
        to forward DHCP requests to another VLAN that MAAS is or will run the
         DHCP server. MAAS will not run the DHCP relay itself, it must be
         configured to proxy reqests to the primary and/or secondary rack
         controller interfaces for the VLAN specified in this field.
 
-- `type relay_vlan`
+:type relay_vlan`
    ID of VLAN
 
-- `param space`
+:param space`
    The space this VLAN should be placed in. Passing in an
        empty string (or the string 'undefined') will cause the VLAN to be
         placed in the 'undefined' space.
 
-- `type space`
+:type space`
    unicode
 
 Returns 404 if the fabric or VLAN is not found.
@@ -6298,36 +6298,36 @@ Returns 404 if the fabric is not found.
 
 Create a VLAN.
 
-- `param name`
+:param name`
    Name of the VLAN.
 
-- `type name`
+:type name`
    unicode
 
-- `param description`
+:param description`
    Description of the VLAN.
 
-- `type description`
+:type description`
    unicode
 
-- `param vid`
+:param vid`
    VLAN ID of the VLAN.
 
-- `type vid`
+:type vid`
    integer
 
-- `param mtu`
+:param mtu`
    The MTU to use on the VLAN.
 
-- `type mtu`
+:type mtu`
    integer
 
-- `param space`
+:param space`
    The space this VLAN should be placed in. Passing in an
        empty string (or the string 'undefined') will cause the VLAN to be
         placed in the 'undefined' space.
 
-- `type space`
+:type space`
    unicode
 
 ### Volume group
@@ -6351,13 +6351,13 @@ Returns 404 if the machine or volume group is not found.
 
 Create a logical volume in the volume group.
 
-- `param name`
+:param name`
    Name of the logical volume.
 
-- `param uuid`
+:param uuid`
    (optional) UUID of the logical volume.
 
-- `param size`
+:param size`
    Size of the logical volume.
 
 Returns 404 if the machine or volume group is not found. Returns 409 if the
@@ -6367,7 +6367,7 @@ machine is not Ready.
 
 Delete a logical volume in the volume group.
 
-- `param id`
+:param id`
    ID of the logical volume.
 
 Returns 403 if no logical volume with id. Returns 404 if the machine or volume
@@ -6377,23 +6377,23 @@ group is not found. Returns 409 if the machine is not Ready.
 
 Read volume group on a machine.
 
-- `param name`
+:param name`
    Name of the volume group.
 
-- `param uuid`
+:param uuid`
    UUID of the volume group.
 
-- `param add_block_devices`
+:param add_block_devices`
    Block devices to add to the volume group.
 
-- `param remove_block_devices`
+:param remove_block_devices`
    Block devices to remove from the
        volume group.
 
-- `param add_partitions`
+:param add_partitions`
    Partitions to add to the volume group.
 
-- `param remove_partitions`
+:param remove_partitions`
    Partitions to remove from the volume group.
 
 Returns 404 if the machine or volume group is not found. Returns 409 if the
@@ -6413,16 +6413,16 @@ Returns 404 if the machine is not found.
 
 Create a volume group belonging to machine.
 
-- `param name`
+:param name`
    Name of the volume group.
 
-- `param uuid`
+:param uuid`
    (optional) UUID of the volume group.
 
-- `param block_devices`
+:param block_devices`
    Block devices to add to the volume group.
 
-- `param partitions`
+:param partitions`
    Partitions to add to the volume group.
 
 Returns 404 if the machine is not found. Returns 409 if the machine is not
@@ -6433,7 +6433,7 @@ Ready.
 Manage a physical zone.
 
 > Any node is in a physical zone, or "zone" for short. The meaning of a
-> physical zone is up to you- ` it could identify e.g. a server rack, a
+> physical zone is up to you: it could identify e.g. a server rack, a
 > network, or a data centre. Users can then allocate nodes from specific
 > physical zones, to suit their redundancy or performance requirements.
 >
@@ -6473,16 +6473,16 @@ Get a listing of all the physical zones.
 
 Create a new physical zone.
 
-- `param name`
+:param name`
    Identifier-style name for the new zone.
 
-- `type name`
+:type name`
    unicode
 
-- `param description`
+:param description`
    Free-form description of the new zone.
 
-- `type description`
+:type description`
    unicode
 
 ## Power types
@@ -6494,22 +6494,22 @@ is from an older version of MAAS.
 
 ### amt (Intel AMT)
 
-Power parameters- `
+Power parameters:
 
 -   power_pass (Power password).
 -   power_address (Power address).
 
 ### apc (American Power Conversion (APC) PDU)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (IP for APC PDU).
 -   node_outlet (APC PDU node outlet number (1-16)).
--   power_on_delay (Power ON outlet delay (seconds)). Default- ` '5'.
+-   power_on_delay (Power ON outlet delay (seconds)). Default: '5'.
 
 ### dli (Digital Loggers, Inc. PDU)
 
-Power parameters- `
+Power parameters:
 
 -   outlet_id (Outlet ID).
 -   power_address (Power address).
@@ -6518,7 +6518,7 @@ Power parameters- `
 
 ### fence_cdu (Sentry Switch CDU)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (Power address).
 -   power_id (Power ID).
@@ -6527,7 +6527,7 @@ Power parameters- `
 
 ### hmc (IBM Hardware Management Console (HMC))
 
-Power parameters- `
+Power parameters:
 
 -   power_address (IP for HMC).
 -   power_user (HMC username).
@@ -6537,10 +6537,10 @@ Power parameters- `
 
 ### ipmi (IPMI)
 
-Power parameters- `
+Power parameters:
 
--   power_driver (Power driver). Choices- ` 'LAN' (LAN \[IPMI 1.5\]),
-    'LAN_2_0' (LAN_2_0 \[IPMI 2.0\]) Default- ` 'LAN_2_0'.
+-   power_driver (Power driver). Choices: 'LAN' (LAN \[IPMI 1.5\]),
+    'LAN_2_0' (LAN_2_0 \[IPMI 2.0\]) Default: 'LAN_2_0'.
 -   power_address (IP address).
 -   power_user (Power user).
 -   power_pass (Power password).
@@ -6548,11 +6548,11 @@ Power parameters- `
 
 ### manual (Manual)
 
-Power parameters- `
+Power parameters:
 
 ### moonshot (HP Moonshot - iLO4 (IPMI))
 
-Power parameters- `
+Power parameters:
 
 -   power_address (Power address).
 -   power_user (Power user).
@@ -6561,7 +6561,7 @@ Power parameters- `
 
 ### mscm (HP Moonshot - iLO Chassis Manager)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (IP for MSCM CLI API).
 -   power_user (MSCM CLI API user).
@@ -6571,7 +6571,7 @@ Power parameters- `
 
 ### msftocs (Microsoft OCS - Chassis Manager)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (Power address).
 -   power_port (Power port).
@@ -6581,7 +6581,7 @@ Power parameters- `
 
 ### nova (OpenStack Nova)
 
-Power parameters- `
+Power parameters:
 
 -   nova_id (Host UUID).
 -   os_tenantname (Tenant name).
@@ -6591,7 +6591,7 @@ Power parameters- `
 
 ### recs_box (Christmann RECS|Box Power Driver)
 
-Power parameters- `
+Power parameters:
 
 -   node_id (Node ID).
 -   power_address (Power address).
@@ -6601,19 +6601,19 @@ Power parameters- `
 
 ### sm15k (SeaMicro 15000)
 
-Power parameters- `
+Power parameters:
 
 -   system_id (System ID).
 -   power_address (Power address).
 -   power_user (Power user).
 -   power_pass (Power password).
--   power_control (Power control type). Choices- ` 'ipmi' (IPMI),
-    'restapi' (REST API v0.9), 'restapi2' (REST API v2.0) Default- `
+-   power_control (Power control type). Choices: 'ipmi' (IPMI),
+    'restapi' (REST API v0.9), 'restapi2' (REST API v2.0) Default:
     'ipmi'.
 
 ### ucsm (Cisco UCS Manager)
 
-Power parameters- `
+Power parameters:
 
 -   uuid (Server UUID).
 -   power_address (URL for XML API).
@@ -6622,7 +6622,7 @@ Power parameters- `
 
 ### virsh (Virsh (virtual systems))
 
-Power parameters- `
+Power parameters:
 
 -   power_address (Virsh address).
 -   power_pass (Virsh password (optional)).
@@ -6630,7 +6630,7 @@ Power parameters- `
 
 ### vmware (VMware)
 
-Power parameters- `
+Power parameters:
 
 -   power_vm_name (VM Name (if UUID unknown)).
 -   power_uuid (VM UUID (if known)).
@@ -6642,7 +6642,7 @@ Power parameters- `
 
 ### wedge (Facebook's Wedge)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (IP address).
 -   power_user (Power user).
@@ -6650,7 +6650,7 @@ Power parameters- `
 
 ### rsd (Rack Scale Design)
 
-Power parameters- `
+Power parameters:
 
 -   power_address (Pod address).
 -   power_user (Pod user).
@@ -6666,7 +6666,7 @@ version of MAAS.
 
 ### rsd (Rack Scale Design)
 
-Parameters- `
+Parameters:
 
 -   power_address (Pod address).
 -   power_user (Pod user).
@@ -6675,7 +6675,7 @@ Parameters- `
 
 ### virsh (Virsh (virtual systems))
 
-Parameters- `
+Parameters:
 
 -   power_address (Virsh address).
 -   power_pass (Virsh password (optional)).

--- a/en/api.md
+++ b/en/api.md
@@ -1,7 +1,3 @@
-Title: API | MAAS
-table_of_contents: True
-
-
 # MAAS API
 
 Restful MAAS API.
@@ -24,16 +20,15 @@ error message and the api version are returned as plaintext.
 
 ## HTTP methods and parameter-passing
 
-The following HTTP methods are available for accessing the API:
-
--   GET (for information retrieval and queries),
--   POST (for asking the system to do things),
--   PUT (for updating objects), and
--   DELETE (for deleting objects).
+The following HTTP methods are available for accessing the API- `
+   -   GET (for information retrieval and queries),
+    -   POST (for asking the system to do things),
+    -   PUT (for updating objects), and
+    -   DELETE (for deleting objects).
 
 All methods except DELETE may take parameters, but they are not all passed in
-the same way. GET parameters are passed in the URL, as is normal with a GET:
-"/item/?foo=bar" passes parameter "foo" with value "bar".
+the same way. GET parameters are passed in the URL, as is normal with a
+GET- ` "/item/?foo=bar" passes parameter "foo" with value "bar".
 
 POST and PUT are different. Your request should have MIME type
 "multipart/form-data"; each part represents one parameter (for POST) or
@@ -56,14 +51,14 @@ For example, to list all machines, you might GET "/api/2.0/machines".
 
 Manage the current logged-in user.
 
-##### `GET /api/2.0/account/` `op=list_authorisation_tokens`
+#### `GET /api/2.0/account/ op=list_authorisation_tokens`
 
 List authorisation tokens available to the currently logged-in user.
 
 - `return`
    list of dictionaries representing each key's name and token.
 
-##### `POST /api/2.0/account/` `op=create_authorisation_token`
+#### `POST /api/2.0/account/ op=create_authorisation_token`
 
 Create an authorisation OAuth token and OAuth consumer.
 
@@ -74,25 +69,23 @@ Create an authorisation OAuth token and OAuth consumer.
    unicode
 
 - `return`
-   a json dict with four keys: 'token\_key', 'token\_secret',
-    'consumer\_key' and 'name'(e.g. {token\_key: 's65244576fgqs',
-    token\_secret: 'qsdfdhv34', consumer\_key: '68543fhj854fg', name:
-    'MAAS consumer'}).
+   a json dict with four keys- ` 'token_key', 'token_secret', 'consumer_key' and 'name'(e.g. {token_key- `
+   's65244576fgqs', token_secret- ` 'qsdfdhv34', consumer_key- ` '68543fhj854fg', name` 'MAAS consumer'}).
 
 - `rtype`
    string (json)
 
-##### `POST /api/2.0/account/` `op=delete_authorisation_token`
+#### `POST /api/2.0/account/ op=delete_authorisation_token`
 
 Delete an authorisation OAuth token and the related OAuth consumer.
 
-- `param token\_key`
+- `param token_key`
    The key of the token to be deleted.
 
-- `type token\_key`
+- `type token_key`
    unicode
 
-##### `POST /api/2.0/account/` `op=update_token_name`
+#### `POST /api/2.0/account/ op=update_token_name`
 
 Modify the consumer name of an authorisation OAuth token.
 
@@ -112,77 +105,77 @@ Modify the consumer name of an authorisation OAuth token.
 
 Manage bcache cache set on a machine.
 
-##### `DELETE /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Delete cache set on a machine.
 
-Returns 400 if the cache set is in use. Returns 404 if the machine or
-cache set is not found. Returns 409 if the machine is not Ready.
+Returns 400 if the cache set is in use. Returns 404 if the machine or cache
+set is not found. Returns 409 if the machine is not Ready.
 
-##### `GET /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Read bcache cache set on a machine.
 
 Returns 404 if the machine or cache set is not found.
 
-##### `PUT /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/bcache-cache-set/{id}/`
 
 Delete bcache on a machine.
 
-- `param cache\_device`
+- `param cache_device`
    Cache block device to replace current one.
 
-- `param cache\_partition`
+- `param cache_partition`
    Cache partition to replace current one.
 
-Specifying both a cache\_device and a cache\_partition is not allowed.
+Specifying both a cache_device and a cache_partition is not allowed.
 
-Returns 404 if the machine or the cache set is not found. Returns 409 if
-the machine is not Ready.
+Returns 404 if the machine or the cache set is not found. Returns 409 if the
+machine is not Ready.
 
 ### Bcache Cache Sets
 
 Manage bcache cache sets on a machine.
 
-##### `GET /api/2.0/nodes/{system_id}/bcache-cache-sets/`
+#### `GET /api/2.0/nodes/{system_id}/bcache-cache-sets/`
 
 List all bcache cache sets belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/bcache-cache-sets/`
+#### `POST /api/2.0/nodes/{system_id}/bcache-cache-sets/`
 
 Creates a Bcache Cache Set.
 
-- `param cache\_device`
+- `param cache_device`
    Cache block device.
 
-- `param cache\_partition`
+- `param cache_partition`
    Cache partition.
 
-Specifying both a cache\_device and a cache\_partition is not allowed.
+Specifying both a cache_device and a cache_partition is not allowed.
 
-Returns 404 if the machine is not found. Returns 409 if the machine is
-not Ready.
+Returns 404 if the machine is not found. Returns 409 if the machine is not
+Ready.
 
 ### Bcache Device
 
 Manage bcache device on a machine.
 
-##### `DELETE /api/2.0/nodes/{system_id}/bcache/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Delete bcache on a machine.
 
-Returns 404 if the machine or bcache is not found. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or bcache is not found. Returns 409 if the machine
+is not Ready.
 
-##### `GET /api/2.0/nodes/{system_id}/bcache/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Read bcache device on a machine.
 
 Returns 404 if the machine or bcache is not found.
 
-##### `PUT /api/2.0/nodes/{system_id}/bcache/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/bcache/{id}/`
 
 Delete bcache on a machine.
 
@@ -192,20 +185,20 @@ Delete bcache on a machine.
 - `param uuid`
    UUID of the Bcache.
 
-- `param cache\_set`
+- `param cache_set`
    Cache set to replace current one.
 
-- `param backing\_device`
+- `param backing_device`
    Backing block device to replace current one.
 
-- `param backing\_partition`
+- `param backing_partition`
    Backing partition to replace current one.
 
-- `param cache\_mode`
+- `param cache_mode`
    Cache mode (writeback, writethrough, writearound).
 
-Specifying both a device and a partition for a given role (cache
-or backing) is not allowed.
+Specifying both a device and a partition for a given role (cache or backing)
+is not allowed.
 
 Returns 404 if the machine or the bcache is not found. Returns 409 if the
 machine is not Ready.
@@ -214,13 +207,13 @@ machine is not Ready.
 
 Manage bcache devices on a machine.
 
-##### `GET /api/2.0/nodes/{system_id}/bcaches/`
+#### `GET /api/2.0/nodes/{system_id}/bcaches/`
 
 List all bcache devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/bcaches/`
+#### `POST /api/2.0/nodes/{system_id}/bcaches/`
 
 Creates a Bcache.
 
@@ -230,54 +223,54 @@ Creates a Bcache.
 - `param uuid`
    UUID of the Bcache.
 
-- `param cache\_set`
+- `param cache_set`
    Cache set.
 
-- `param backing\_device`
+- `param backing_device`
    Backing block device.
 
-- `param backing\_partition`
+- `param backing_partition`
    Backing partition.
 
-- `param cache\_mode`
+- `param cache_mode`
    Cache mode (WRITEBACK, WRITETHROUGH, WRITEAROUND).
 
-Specifying both a device and a partition for a given role (cache
-or backing) is not allowed.
+Specifying both a device and a partition for a given role (cache or backing)
+is not allowed.
 
-Returns 404 if the machine is not found. Returns 409 if the machine is
-not Ready.
+Returns 404 if the machine is not found. Returns 409 if the machine is not
+Ready.
 
 ### Block device
 
 Manage a block device on a machine.
 
-##### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Delete block device on a machine.
 
-Returns 404 if the machine or block device is not found. Returns 403 if
-the user is not allowed to delete the block device. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or block device is not found. Returns 403 if the
+user is not allowed to delete the block device. Returns 409 if the machine is
+not Ready.
 
-##### `GET /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Read block device on node.
 
 Returns 404 if the machine or block device is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=add_tag`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=add_tag`
 
 Add a tag to block device on a machine.
 
 - `param tag`
    The tag being added.
 
-Returns 404 if the machine or block device is not found. Returns 403 if
-the user is not allowed to update the block device. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or block device is not found. Returns 403 if the
+user is not allowed to update the block device. Returns 409 if the machine is
+not Ready.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=format`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=format`
 
 Format block device with filesystem.
 
@@ -287,72 +280,72 @@ Format block device with filesystem.
 - `param uuid`
    UUID of the filesystem.
 
-Returns 403 when the user doesn't have the ability to format the block
-device. Returns 404 if the machine or block device is not found. Returns
-409 if the machine is not Ready or Allocated.
+Returns 403 when the user doesn't have the ability to format the block device.
+Returns 404 if the machine or block device is not found. Returns 409 if the
+machine is not Ready or Allocated.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=mount`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=mount`
 
 Mount the filesystem on block device.
 
-- `param mount\_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-- `param mount\_options`
+- `param mount_options`
    Options to pass to mount(8).
 
-Returns 403 when the user doesn't have the ability to mount the block
-device. Returns 404 if the machine or block device is not found. Returns
-409 if the machine is not Ready or Allocated.
+Returns 403 when the user doesn't have the ability to mount the block device.
+Returns 404 if the machine or block device is not found. Returns 409 if the
+machine is not Ready or Allocated.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=remove_tag`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=remove_tag`
 
 Remove a tag from block device on a machine.
 
 - `param tag`
    The tag being removed.
 
-Returns 404 if the machine or block device is not found. Returns 403 if
-the user is not allowed to update the block device. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or block device is not found. Returns 403 if the
+user is not allowed to update the block device. Returns 409 if the machine is
+not Ready.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=set_boot_disk`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=set_boot_disk`
 
 Set this block device as the boot disk for the machine.
 
-Returns 400 if the block device is a virtual block device. Returns 404 if
-the machine or block device is not found. Returns 403 if the user is not
-allowed to update the block device. Returns 409 if the machine is not
-Ready or Allocated.
+Returns 400 if the block device is a virtual block device. Returns 404 if the
+machine or block device is not found. Returns 403 if the user is not allowed
+to update the block device. Returns 409 if the machine is not Ready or
+Allocated.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=unformat`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unformat`
 
 Unformat block device with filesystem.
 
-Returns 400 if the block device is not formatted, currently mounted, or
-part of a filesystem group. Returns 403 when the user doesn't have the
-ability to unformat the block device. Returns 404 if the machine or block
-device is not found. Returns 409 if the machine is not Ready or Allocated.
+Returns 400 if the block device is not formatted, currently mounted, or part
+of a filesystem group. Returns 403 when the user doesn't have the ability to
+unformat the block device. Returns 404 if the machine or block device is not
+found. Returns 409 if the machine is not Ready or Allocated.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/` `op=unmount`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{id}/ op=unmount`
 
 Unmount the filesystem on block device.
 
 Returns 400 if the block device is not formatted or not currently mounted.
 Returns 403 when the user doesn't have the ability to unmount the block
-device. Returns 404 if the machine or block device is not found. Returns
-409 if the machine is not Ready or Allocated.
+device. Returns 404 if the machine or block device is not found. Returns 409
+if the machine is not Ready or Allocated.
 
-##### `PUT /api/2.0/nodes/{system_id}/blockdevices/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/blockdevices/{id}/`
 
 Update block device on a machine.
 
-Machines must have a status of Ready to have access to all options.
-Machines with Deployed status can only have the name, model, serial,
-and/or id\_path updated for a block device. This is intented to allow a
-bad block device to be replaced while the machine remains deployed.
+Machines must have a status of Ready to have access to all options. Machines
+with Deployed status can only have the name, model, serial, and/or id_path
+updated for a block device. This is intented to allow a bad block device to be
+replaced while the machine remains deployed.
 
-Fields for physical block device:
+Fields for physical block device- `
 
 - `param name`
    Name of the block device.
@@ -363,18 +356,18 @@ Fields for physical block device:
 - `param serial`
    Serial number of the block device.
 
-- `param id\_path`
-   (optional) Only used if model and serial cannot be provided. This
-    should be a path that is fixed and doesn't change depending on the
-    boot order or kernel version.
+- `param id_path`
+   (optional) Only used if model and serial cannot be provided. This should
+    be a path that is fixed and doesn't change depending on the boot order or
+    kernel version.
 
 - `param size`
    Size of the block device.
 
-- `param block\_size`
+- `param block_size`
    Block size of the block device.
 
-Fields for virtual block device:
+Fields for virtual block device- `
 
 - `param name`
    Name of the block device.
@@ -385,21 +378,21 @@ Fields for virtual block device:
 - `param size`
    Size of the block device. (Only allowed for logical volumes.)
 
-Returns 404 if the machine or block device is not found. Returns 403 if
-the user is not allowed to update the block device. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or block device is not found. Returns 403 if the
+user is not allowed to update the block device. Returns 409 if the machine is
+not Ready.
 
 ### Block devices
 
 Manage block devices on a machine.
 
-##### `GET /api/2.0/nodes/{system_id}/blockdevices/`
+#### `GET /api/2.0/nodes/{system_id}/blockdevices/`
 
 List all block devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/`
 
 Create a physical block device.
 
@@ -412,15 +405,15 @@ Create a physical block device.
 - `param serial`
    Serial number of the block device.
 
-- `param id\_path`
-   (optional) Only used if model and serial cannot be provided. This
-    should be a path that is fixed and doesn't change depending on the
-    boot order or kernel version.
+- `param id_path`
+   (optional) Only used if model and serial cannot be
+       provided. This should be a path that is fixed and doesn't change
+        depending on the boot order or kernel version.
 
 - `param size`
    Size of the block device.
 
-- `param block\_size`
+- `param block_size`
    Block size of the block device.
 
 Returns 404 if the node is not found.
@@ -429,11 +422,11 @@ Returns 404 if the node is not found.
 
 Manage a boot resource.
 
-##### `DELETE /api/2.0/boot-resources/{id}/`
+#### `DELETE /api/2.0/boot-resources/{id}/`
 
 Delete boot resource.
 
-##### `GET /api/2.0/boot-resources/{id}/`
+#### `GET /api/2.0/boot-resources/{id}/`
 
 Read a boot resource.
 
@@ -441,18 +434,18 @@ Read a boot resource.
 
 Manage the boot resources.
 
-##### `GET /api/2.0/boot-resources/`
+#### `GET /api/2.0/boot-resources/`
 
 List all boot resources.
 
 - `param type`
-   Type of boot resources to list. Default: all
+   Type of boot resources to list. Default- ` all
 
-##### `GET /api/2.0/boot-resources/` `op=is_importing`
+#### `GET /api/2.0/boot-resources/ op=is_importing`
 
 Return import status.
 
-##### `POST /api/2.0/boot-resources/`
+#### `POST /api/2.0/boot-resources/`
 
 Uploads a new boot resource.
 
@@ -466,17 +459,19 @@ Uploads a new boot resource.
    Architecture the boot resource supports.
 
 - `param filetype`
-   Filetype for uploaded content. (Default: tgz)
+   Filetype for uploaded content. (Default- ` tgz,
+       Supported- ` tgz, ddtgz, ddtbz, ddtxz, ddtar, ddbz2, ddgz, ddxz,
+        ddraw
 
 - `param content`
-   Image content. Note: this is not a normal parameter, but a
-    file upload.
+   Image content. Note- ` this is not a normal parameter,
+       but a file upload.
 
-##### `POST /api/2.0/boot-resources/` `op=import`
+#### `POST /api/2.0/boot-resources/ op=import`
 
 Import the boot resources.
 
-##### `POST /api/2.0/boot-resources/` `op=stop_import`
+#### `POST /api/2.0/boot-resources/ op=stop_import`
 
 Stop import of boot resources.
 
@@ -484,42 +479,47 @@ Stop import of boot resources.
 
 Manage a boot source.
 
-##### `DELETE /api/2.0/boot-sources/{id}/`
+#### `DELETE /api/2.0/boot-sources/{id}/`
 
 Delete a specific boot source.
 
-##### `GET /api/2.0/boot-sources/{id}/`
+#### `GET /api/2.0/boot-sources/{id}/`
 
 Read a boot source.
 
-##### `PUT /api/2.0/boot-sources/{id}/`
+#### `PUT /api/2.0/boot-sources/{id}/`
 
 Update a specific boot source.
 
 - `param url`
    The URL of the BootSource.
 
-- `param keyring\_filename`
-   The path to the keyring file for this BootSource.
+- `param keyring_filename`
+   The path to the keyring file for this
+       BootSource.
 
-- `param keyring\_data`
-   The GPG keyring for this BootSource, base64-encoded data.
+- `param keyring_data`
+   The GPG keyring for this BootSource,
+       base64-encoded data.
 
 ### Boot source selection
 
 Manage a boot source selection.
 
-##### `DELETE /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+#### `DELETE /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Delete a specific boot source.
 
-##### `GET /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+#### `GET /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Read a boot source selection.
 
-##### `PUT /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
+#### `PUT /api/2.0/boot-sources/{boot_source_id}/selections/{id}/`
 
 Update a specific boot source selection.
+
+- `param os`
+   The OS (e.g. ubuntu, centos) for which to import resources.
 
 - `param release`
    The release for which to import resources.
@@ -528,7 +528,8 @@ Update a specific boot source selection.
    The list of architectures for which to import resources.
 
 - `param subarches`
-   The list of subarchitectures for which to import resources.
+   The list of subarchitectures for which to import
+       resources.
 
 - `param labels`
    The list of labels for which to import resources.
@@ -537,15 +538,18 @@ Update a specific boot source selection.
 
 Manage the collection of boot source selections.
 
-##### `GET /api/2.0/boot-sources/{boot_source_id}/selections/`
+#### `GET /api/2.0/boot-sources/{boot_source_id}/selections/`
 
 List boot source selections.
 
 Get a listing of a boot source's selections.
 
-##### `POST /api/2.0/boot-sources/{boot_source_id}/selections/`
+#### `POST /api/2.0/boot-sources/{boot_source_id}/selections/`
 
 Create a new boot source selection.
+
+- `param os`
+   The OS (e.g. ubuntu, centos) for which to import resources.
 
 - `param release`
    The release for which to import resources.
@@ -554,7 +558,8 @@ Create a new boot source selection.
    The architecture list for which to import resources.
 
 - `param subarches`
-   The subarchitecture list for which to import resources.
+   The subarchitecture list for which to import
+       resources.
 
 - `param labels`
    The label lists for which to import resources.
@@ -563,40 +568,44 @@ Create a new boot source selection.
 
 Manage the collection of boot sources.
 
-##### `GET /api/2.0/boot-sources/`
+#### `GET /api/2.0/boot-sources/`
 
 List boot sources.
 
 Get a listing of boot sources.
 
-##### `POST /api/2.0/boot-sources/`
+#### `POST /api/2.0/boot-sources/`
 
 Create a new boot source.
 
 - `param url`
    The URL of the BootSource.
 
-- `param keyring\_filename`
-   The path to the keyring file for this BootSource.
+- `param keyring_filename`
+   The path to the keyring file for
+       this BootSource.
 
-- `param keyring\_data`
-   The GPG keyring for this BootSource, base64-encoded.
+- `param keyring_data`
+   The GPG keyring for this BootSource,
+       base64-encoded.
 
 ### Commissioning script
 
 Manage a custom commissioning script.
 
 > This functionality is only available to administrators.
+>
+> This endpoint has been deprecated in favor of the node-script endpoint.
 
-##### `DELETE /api/2.0/commissioning-scripts/{name}`
+#### `DELETE /api/2.0/commissioning-scripts/{name}`
 
 Delete a commissioning script.
 
-##### `GET /api/2.0/commissioning-scripts/{name}`
+#### `GET /api/2.0/commissioning-scripts/{name}`
 
 Read a commissioning script.
 
-##### `PUT /api/2.0/commissioning-scripts/{name}`
+#### `PUT /api/2.0/commissioning-scripts/{name}`
 
 Update a commissioning script.
 
@@ -605,46 +614,48 @@ Update a commissioning script.
 Manage custom commissioning scripts.
 
 > This functionality is only available to administrators.
+>
+> This endpoint has been deprecated in favor of the node-scripts endpoint.
 
-##### `GET /api/2.0/commissioning-scripts/`
+#### `GET /api/2.0/commissioning-scripts/`
 
 List commissioning scripts.
 
-##### `POST /api/2.0/commissioning-scripts/`
+#### `POST /api/2.0/commissioning-scripts/`
 
 Create a new commissioning script.
 
 Each commissioning script is identified by a unique name.
 
 By convention the name should consist of a two-digit number, a dash, and a
-brief descriptive identifier consisting only of ASCII characters. You
-don't need to follow this convention, but not doing so opens you up to
-risks w.r.t. encoding and ordering. The name must not contain any
-whitespace, quotes, or apostrophes.
+brief descriptive identifier consisting only of ASCII characters. You don't
+need to follow this convention, but not doing so opens you up to risks w.r.t.
+encoding and ordering. The name must not contain any whitespace, quotes, or
+apostrophes.
 
-A commissioning machine will run each of the scripts in
-lexicographical order. There are no promises about how non-ASCII
-characters are sorted, or even how upper-case letters are sorted relative
-to lower-case letters. So where ordering matters, use unique numbers.
+A commissioning machine will run each of the scripts in lexicographical order.
+There are no promises about how non-ASCII characters are sorted, or even how
+upper-case letters are sorted relative to lower-case letters. So where
+ordering matters, use unique numbers.
 
-Scripts built into MAAS will have names starting with "00-maas" or
-"99-maas" to ensure that they run first or last, respectively.
+Scripts built into MAAS will have names starting with "00-maas" or "99-maas"
+to ensure that they run first or last, respectively.
 
-Usually a commissioning script will be just that, a script. Ideally a
-script should be ASCII text to avoid any confusion over encoding. But in
-some cases a commissioning script might consist of a binary tool provided
-by a hardware vendor. Either way, the script gets passed to the
-commissioning machine in the exact form in which it was uploaded.
+Usually a commissioning script will be just that, a script. Ideally a script
+should be ASCII text to avoid any confusion over encoding. But in some cases a
+commissioning script might consist of a binary tool provided by a hardware
+vendor. Either way, the script gets passed to the commissioning machine in the
+exact form in which it was uploaded.
 
 - `param name`
-   Unique identifying name for the script. Names should follow the
-    pattern of "25-burn-in-hard-disk" (all ASCII, and with numbers greater
-    than zero, and generally no "weird" characters).
+   Unique identifying name for the script. Names should
+       follow the pattern of "25-burn-in-hard-disk" (all ASCII, and with
+        numbers greater than zero, and generally no "weird" characters).
 
 - `param content`
-   A script file, to be uploaded in binary form. Note: this is not a
-    normal parameter, but a file upload. Its filename is ignored; MAAS
-    will know it by the name you pass to the request.
+   A script file, to be uploaded in binary form. Note- `
+       this is not a normal parameter, but a file upload. Its filename is
+        ignored; MAAS will know it by the name you pass to the request.
 
 ### DHCP Snippet
 
@@ -652,32 +663,33 @@ Manage an individual DHCP snippet.
 
 > The DHCP snippet is identified by its id.
 
-##### `DELETE /api/2.0/dhcp-snippets/{id}/`
+#### `DELETE /api/2.0/dhcp-snippets/{id}/`
 
 Delete a DHCP snippet.
 
 Returns 404 if the DHCP snippet is not found.
 
-##### `GET /api/2.0/dhcp-snippets/{id}/`
+#### `GET /api/2.0/dhcp-snippets/{id}/`
 
 Read DHCP snippet.
 
 Returns 404 if the snippet is not found.
 
-##### `POST /api/2.0/dhcp-snippets/{id}/` `op=revert`
+#### `POST /api/2.0/dhcp-snippets/{id}/ op=revert`
 
 Revert the value of a DHCP snippet to an earlier revision.
 
 - `param to`
-   What revision in the DHCP snippet's history to revert to. This can
-    either be an ID or a negative number representing how far back to go.
+   What revision in the DHCP snippet's history to revert to.
+       This can either be an ID or a negative number representing how far
+        back to go.
 
 - `type to`
    integer
 
 Returns 404 if the DHCP snippet is not found.
 
-##### `PUT /api/2.0/dhcp-snippets/{id}/`
+#### `PUT /api/2.0/dhcp-snippets/{id}/`
 
 Update a DHCP snippet.
 
@@ -688,8 +700,8 @@ Update a DHCP snippet.
    unicode
 
 - `param value`
-   The new value of the DHCP snippet to be used in dhcpd.conf. Previous
-    values are stored and can be reverted.
+   The new value of the DHCP snippet to be used in
+       dhcpd.conf. Previous values are stored and can be reverted.
 
 - `type value`
    unicode
@@ -707,24 +719,24 @@ Update a DHCP snippet.
    boolean
 
 - `param node`
-   The node the DHCP snippet is to be used for. Can not be set if subnet
-    is set.
+   The node the DHCP snippet is to be used for. Can not be
+       set if subnet is set.
 
 - `type node`
    unicode
 
 - `param subnet`
-   The subnet the DHCP snippet is to be used for. Can not be set if node
-    is set.
+   The subnet the DHCP snippet is to be used for. Can not
+       be set if node is set.
 
 - `type subnet`
    unicode
 
-- `param global\_snippet`
-   Set the DHCP snippet to be a global option. This removes any node or
-    subnet links.
+- `param global_snippet`
+   Set the DHCP snippet to be a global option. This
+       removes any node or subnet links.
 
-- `type global\_snippet`
+- `type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -733,24 +745,24 @@ Returns 404 if the DHCP snippet is not found.
 
 Manage the collection of all DHCP snippets in MAAS.
 
-##### `GET /api/2.0/dhcp-snippets/`
+#### `GET /api/2.0/dhcp-snippets/`
 
 List all DHCP snippets.
 
-##### `POST /api/2.0/dhcp-snippets/`
+#### `POST /api/2.0/dhcp-snippets/`
 
 Create a DHCP snippet.
 
 - `param name`
-   The name of the DHCP snippet. This is required to create a new
-    DHCP snippet.
+   The name of the DHCP snippet. This is required to create
+       a new DHCP snippet.
 
 - `type name`
    unicode
 
 - `param value`
-   The snippet of config inserted into dhcpd.conf. This is required to
-    create a new DHCP snippet.
+   The snippet of config inserted into dhcpd.conf. This is
+       required to create a new DHCP snippet.
 
 - `type value`
    unicode
@@ -768,24 +780,24 @@ Create a DHCP snippet.
    boolean
 
 - `param node`
-   The node this snippet applies to. Cannot be used with subnet
-    or global\_snippet.
+   The node this snippet applies to. Cannot be used with
+       subnet or global_snippet.
 
 - `type node`
    unicode
 
 - `param subnet`
-   The subnet this snippet applies to. Cannot be used with node
-    or global\_snippet.
+   The subnet this snippet applies to. Cannot be used with
+       node or global_snippet.
 
 - `type subnet`
    unicode
 
-- `param global\_snippet`
-   Whether or not this snippet is to be applied globally. Cannot be used
-    with node or subnet.
+- `param global_snippet`
+   Whether or not this snippet is to be applied
+       globally. Cannot be used with node or subnet.
 
-- `type global\_snippet`
+- `type global_snippet`
    boolean
 
 Returns 404 if the DHCP snippet is not found.
@@ -794,50 +806,50 @@ Returns 404 if the DHCP snippet is not found.
 
 Manage dnsresource.
 
-##### `DELETE /api/2.0/dnsresources/{id}/`
+#### `DELETE /api/2.0/dnsresources/{id}/`
 
 Delete dnsresource.
 
-Returns 403 if the user does not have permission to delete the
-dnsresource. Returns 404 if the dnsresource is not found.
+Returns 403 if the user does not have permission to delete the dnsresource.
+Returns 404 if the dnsresource is not found.
 
-##### `GET /api/2.0/dnsresources/{id}/`
+#### `GET /api/2.0/dnsresources/{id}/`
 
 Read dnsresource.
 
 Returns 404 if the dnsresource is not found.
 
-##### `PUT /api/2.0/dnsresources/{id}/`
+#### `PUT /api/2.0/dnsresources/{id}/`
 
 Update dnsresource.
 
 - `param fqdn`
    Hostname (with domain) for the dnsresource.
 
-- `param ip\_address`
+- `param ip_address`
    Address to assign to the dnsresource.
 
-Returns 403 if the user does not have permission to update the
-dnsresource. Returns 404 if the dnsresource is not found.
+Returns 403 if the user does not have permission to update the dnsresource.
+Returns 404 if the dnsresource is not found.
 
 ### DNSResourceRecord
 
 Manage dnsresourcerecord.
 
-##### `DELETE /api/2.0/dnsresourcerecords/{id}/`
+#### `DELETE /api/2.0/dnsresourcerecords/{id}/`
 
 Delete dnsresourcerecord.
 
 Returns 403 if the user does not have permission to delete the
 dnsresourcerecord. Returns 404 if the dnsresourcerecord is not found.
 
-##### `GET /api/2.0/dnsresourcerecords/{id}/`
+#### `GET /api/2.0/dnsresourcerecords/{id}/`
 
 Read dnsresourcerecord.
 
 Returns 404 if the dnsresourcerecord is not found.
 
-##### `PUT /api/2.0/dnsresourcerecords/{id}/`
+#### `PUT /api/2.0/dnsresourcerecords/{id}/`
 
 Update dnsresourcerecord.
 
@@ -852,9 +864,9 @@ dnsresourcerecord. Returns 404 if the dnsresourcerecord is not found.
 
 ### DNSResourceRecords
 
-Manage dnsresourcerecords.
+Manage DNS resource records (e.g. CNAME, MX, NS, SRV, TXT)
 
-##### `GET /api/2.0/dnsresourcerecords/`
+#### `GET /api/2.0/dnsresourcerecords/`
 
 List all dnsresourcerecords.
 
@@ -865,35 +877,39 @@ List all dnsresourcerecords.
    restrict the listing to entries of the given name.
 
 - `param rrtype`
-   restrict the listing to entries which have records of the
-    given rrtype.
+   restrict the listing to entries which have
+       records of the given rrtype.
 
-##### `POST /api/2.0/dnsresourcerecords/`
+#### `POST /api/2.0/dnsresourcerecords/`
 
-Create a dnsresourcerecord.
+Create a DNS resource record.
 
 - `param fqdn`
-   Hostname (with domain) for the dnsresource. Either fqdn or
-    (name, domain) must be specified. Fqdn is ignored if either name or
-    domain is given.
+   Hostname (with domain) for the dnsresource. Either fqdn
+       or (name, domain) must be specified. Fqdn is ignored if either name or
+        domain is given (e.g. www.your-maas.maas).
 
 - `param name`
-   Hostname (without domain)
+   The name (or hostname without a domain) of the DNS
+       resource record (e.g. www.your-maas)
 
 - `param domain`
-   Domain (name or id)
+   The domain (name or id) where to create the DNS
+       resource record (Domain (e.g. 'maas')
 
 - `param rrtype`
-   resource type to create
+   The resource record type (e.g 'cname', 'mx', 'ns',
+       'srv', 'sshfp', 'txt')
 
 - `param rrdata`
-   resource data (everything to the right of resource type.)
+   The resource record data (e.g. 'your-maas',
+       '10 mail.your-maas.maas')
 
 ### DNSResources
 
 Manage dnsresources.
 
-##### `GET /api/2.0/dnsresources/`
+#### `GET /api/2.0/dnsresources/`
 
 List all resources for the specified criteria.
 
@@ -904,17 +920,17 @@ List all resources for the specified criteria.
    restrict the listing to entries of the given name.
 
 - `param rrtype`
-   restrict the listing to entries which have records of the
-    given rrtype.
+   restrict the listing to entries which have
+       records of the given rrtype.
 
-##### `POST /api/2.0/dnsresources/`
+#### `POST /api/2.0/dnsresources/`
 
 Create a dnsresource.
 
 - `param fqdn`
-   Hostname (with domain) for the dnsresource. Either fqdn or
-    (name, domain) must be specified. Fqdn is ignored if either name or
-    domain is given.
+   Hostname (with domain) for the dnsresource. Either fqdn
+       or (name, domain) must be specified. Fqdn is ignored if either name or
+        domain is given.
 
 - `param name`
    Hostname (without domain)
@@ -922,89 +938,90 @@ Create a dnsresource.
 - `param domain`
    Domain (name or id)
 
-- `param address\_ttl`
+- `param address_ttl`
    Default ttl for entries in this zone.
 
-- `param ip\_addresses`
-   (optional) Address (ip or id) to assign to the dnsresource.
+- `param ip_addresses`
+   (optional) Address (ip or id) to assign to the
+       dnsresource.
 
 ### Device
 
 Manage an individual device.
 
-> The device is identified by its system\_id.
+> The device is identified by its system_id.
 
-##### `DELETE /api/2.0/devices/{system_id}/`
+#### `DELETE /api/2.0/devices/{system_id}/`
 
 Delete a specific Device.
 
-Returns 404 if the device is not found. Returns 403 if the user does not
-have permission to delete the device. Returns 204 if the device is
-successfully deleted.
+Returns 404 if the device is not found. Returns 403 if the user does not have
+permission to delete the device. Returns 204 if the device is successfully
+deleted.
 
-##### `GET /api/2.0/devices/{system_id}/`
+#### `GET /api/2.0/devices/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/devices/{system_id}/` `op=details`
+#### `GET /api/2.0/devices/{system_id}/ op=details`
 
 Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
-Note that this is returned as BSON and not JSON. This is for efficiency,
-but mainly because JSON can't do binary content without applying
-additional encoding like base-64.
+Note that this is returned as BSON and not JSON. This is for efficiency, but
+mainly because JSON can't do binary content without applying additional
+encoding like base-64.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/devices/{system_id}/` `op=power_parameters`
+#### `GET /api/2.0/devices/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
-This method is reserved for admin users and returns a 403 if the user is
-not one.
+This method is reserved for admin users and returns a 403 if the user is not
+one.
 
 This returns the power parameters, if any, configured for a node. For some
-types of power control this will include private information such as
-passwords and secret keys.
+types of power control this will include private information such as passwords
+and secret keys.
 
 Returns 404 if the node is not found.
 
-##### `POST /api/2.0/devices/{system_id}/` `op=restore_default_configuration`
+#### `POST /api/2.0/devices/{system_id}/ op=restore_default_configuration`
 
 Reset a device's configuration to its initial state.
 
-Returns 404 if the device is not found. Returns 403 if the user does not
-have permission to reset the device.
+Returns 404 if the device is not found. Returns 403 if the user does not have
+permission to reset the device.
 
-##### `POST /api/2.0/devices/{system_id}/` `op=restore_networking_configuration`
+#### `POST /api/2.0/devices/{system_id}/ op=restore_networking_configuration`
 
 Reset a device's network options.
 
-Returns 404 if the device is not found Returns 403 if the user does not
-have permission to reset the device.
+Returns 404 if the device is not found Returns 403 if the user does not have
+permission to reset the device.
 
-##### `POST /api/2.0/devices/{system_id}/` `op=set_owner_data`
+#### `POST /api/2.0/devices/{system_id}/ op=set_owner_data`
 
 Set key/value data for the current owner.
 
 Pass any key/value data to this method to add, modify, or remove. A key is
 removed when the value for that key is set to an empty string.
 
-This operation will not remove any previous keys unless explicitly passed
-with an empty string. All owner data is removed when the machine is no
-longer allocated to a user.
+This operation will not remove any previous keys unless explicitly passed with
+an empty string. All owner data is removed when the machine is no longer
+allocated to a user.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission.
 
-##### `PUT /api/2.0/devices/{system_id}/`
+#### `PUT /api/2.0/devices/{system_id}/`
 
 Update a specific device.
 
@@ -1021,77 +1038,97 @@ Update a specific device.
    unicode
 
 - `param parent`
-   Optional system\_id to indicate this device's parent. If the parent is
-    already set and this parameter is omitted, the parent will
-    be unchanged.
+   Optional system_id to indicate this device's parent.
+       If the parent is already set and this parameter is omitted, the parent
+        will be unchanged.
 
 - `type parent`
    unicode
 
 - `param zone`
-   Name of a valid physical zone in which to place this node.
+   Name of a valid physical zone in which to place this
+       node.
 
 - `type zone`
    unicode
 
-Returns 404 if the device is not found. Returns 403 if the user does not
-have permission to update the device.
+Returns 404 if the device is not found. Returns 403 if the user does not have
+permission to update the device.
 
 ### Devices
 
 Manage the collection of all the devices in the MAAS.
 
-##### `GET /api/2.0/devices/`
+#### `GET /api/2.0/devices/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
 - `param hostname`
-   An optional hostname. Only nodes relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to see multiple nodes.
+   An optional hostname. Only nodes relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to see multiple nodes.
 
 - `type hostname`
    unicode
 
-- `param mac\_address`
-   An optional MAC address. Only nodes relating to the node owning the
-    specified MAC address will be returned. This can be specified multiple
-    times to see multiple nodes.
+- `param mac_address`
+   An optional MAC address. Only nodes relating to the
+       node owning the specified MAC address will be returned. This can be
+        specified multiple times to see multiple nodes.
 
-- `type mac\_address`
+- `type mac_address`
    unicode
 
 - `param id`
-   An optional list of system ids. Only nodes relating to the nodes with
-    matching system ids will be returned.
+   An optional list of system ids. Only nodes relating to the
+       nodes with matching system ids will be returned.
 
 - `type id`
    unicode
 
 - `param domain`
-   An optional name for a dns domain. Only nodes relating to the nodes in
-    the domain will be returned.
+   An optional name for a dns domain. Only nodes relating
+       to the nodes in the domain will be returned.
 
 - `type domain`
    unicode
 
 - `param zone`
-   An optional name for a physical zone. Only nodes relating to the nodes
-    in the zone will be returned.
+   An optional name for a physical zone. Only nodes relating
+       to the nodes in the zone will be returned.
 
 - `type zone`
    unicode
 
-- `param agent\_name`
-   An optional agent name. Only nodes relating to the nodes with matching
-    agent names will be returned.
+- `param agent_name`
+   An optional agent name. Only nodes relating to the
+       nodes with matching agent names will be returned.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
-##### `POST /api/2.0/devices/`
+#### `GET /api/2.0/devices/ op=is_registered`
+
+Returns whether or not the given MAC address is registered within this MAAS
+(and attached to a non-retired node).
+
+- `param mac_address`
+   The mac address to be checked.
+
+- `type mac_address`
+   unicode
+
+- `return`
+   'true' or 'false'.
+
+- `rtype`
+   unicode
+
+Returns 400 if any mandatory parameters are missing.
+
+#### `POST /api/2.0/devices/`
 
 Create a new device.
 
@@ -1102,15 +1139,16 @@ Create a new device.
    unicode
 
 - `param domain`
-   The domain of the device. If not given the default domain is used.
+   The domain of the device. If not given the default
+       domain is used.
 
 - `type domain`
    unicode
 
-- `param mac\_addresses`
+- `param mac_addresses`
    One or more MAC addresses for the device.
 
-- `type mac\_addresses`
+- `type mac_addresses`
    unicode
 
 - `param parent`
@@ -1119,17 +1157,17 @@ Create a new device.
 - `type parent`
    unicode
 
-##### `POST /api/2.0/devices/` `op=set_zone`
+#### `POST /api/2.0/devices/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
 - `param zone`
-   Zone name. If omitted, the zone is "none" and the nodes will be taken
-    out of their physical zones.
+   Zone name. If omitted, the zone is "none" and the nodes
+       will be taken out of their physical zones.
 
 - `param nodes`
-   system\_ids of the nodes whose zones are to be set. (An empty list
-    is acceptable).
+   system_ids of the nodes whose zones are to be set.
+       (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -1137,48 +1175,46 @@ Raises 403 if the user is not an admin.
 
 Query observed discoveries.
 
-##### `GET /api/2.0/discovery/`
+#### `GET /api/2.0/discovery/`
 
 Lists all the devices MAAS has discovered.
 
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-##### `GET /api/2.0/discovery/` `op=by_unknown_ip`
+#### `GET /api/2.0/discovery/ op=by_unknown_ip`
 
 Lists all discovered devices which have an unknown IP address.
 
-Filters the list of discovered devices by excluding any discoveries where
-a known MAAS node is configured with the IP address of the discovery, or
-has been observed using it after it was assigned by a MAAS-managed
-DHCP server.
+Filters the list of discovered devices by excluding any discoveries where a
+known MAAS node is configured with the IP address of the discovery, or has
+been observed using it after it was assigned by a MAAS-managed DHCP server.
 
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-##### `GET /api/2.0/discovery/` `op=by_unknown_ip_and_mac`
+#### `GET /api/2.0/discovery/ op=by_unknown_ip_and_mac`
 
 Lists all discovered devices which are completely unknown to MAAS.
 
-Filters the list of discovered devices by excluding any discoveries where
-a known MAAS node is configured with either the MAC address or the IP
-address of the discovery.
-
-Discoveries are listed in the order they were last observed on the network
-(most recent first).
-
-##### `GET /api/2.0/discovery/` `op=by_unknown_mac`
-
-Lists all discovered devices which have an unknown IP address.
-
-Filters the list of discovered devices by excluding any discoveries where
-an interface known to MAAS is configured with MAC address of
+Filters the list of discovered devices by excluding any discoveries where a
+known MAAS node is configured with either the MAC address or the IP address of
 the discovery.
 
 Discoveries are listed in the order they were last observed on the network
 (most recent first).
 
-##### `POST /api/2.0/discovery/` `op=clear`
+#### `GET /api/2.0/discovery/ op=by_unknown_mac`
+
+Lists all discovered devices which have an unknown IP address.
+
+Filters the list of discovered devices by excluding any discoveries where an
+interface known to MAAS is configured with MAC address of the discovery.
+
+Discoveries are listed in the order they were last observed on the network
+(most recent first).
+
+#### `POST /api/2.0/discovery/ op=clear`
 
 Deletes all discovered neighbours and/or mDNS entries.
 
@@ -1191,86 +1227,89 @@ Deletes all discovered neighbours and/or mDNS entries.
 - `param all`
    if True, deletes all discovery data.
 
-##### `POST /api/2.0/discovery/` `op=scan`
+#### `POST /api/2.0/discovery/ op=scan`
 
 Immediately run a neighbour discovery scan on all rack networks.
 
-This command causes each connected rack controller to execute the
-'maas-rack scan-network' command, which will scan all CIDRs configured on
-the rack controller using 'nmap' (if it is installed) or 'ping'.
+This command causes each connected rack controller to execute the 'maas-rack
+scan-network' command, which will scan all CIDRs configured on the rack
+controller using 'nmap' (if it is installed) or 'ping'.
 
-Network discovery must not be set to 'disabled' for this command to
-be useful.
+Network discovery must not be set to 'disabled' for this command to be useful.
 
-Scanning will be started in the background, and could take a long time on
-rack controllers that do not have 'nmap' installed and are connected to
-large networks.
+Scanning will be started in the background, and could take a long time on rack
+controllers that do not have 'nmap' installed and are connected to large
+networks.
 
-If the call is a success, this method will return a dictionary of results
-as follows:
+If the call is a success, this method will return a dictionary of results as
+follows- `
 
-result: A human-readable string summarizing the results.
-scan\_attempted\_on: A list of rack 'system\_id' values where a scan
-was attempted. (That is, an RPC connection was successful and a subsequent
-call was intended.)
+result- ` A human-readable string summarizing the results.
+scan_attempted_on- ` A list of rack 'system_id' values where a scan was
+attempted. (That is, an RPC connection was successful and a subsequent call
+was intended.)
 
-failed\_to\_connect\_to: A list of rack 'system\_id' values where the RPC
+failed_to_connect_to- ` A list of rack 'system_id' values where the RPC
 connection failed.
 
-scan\_started\_on: A list of rack 'system\_id' values where a scan was
+scan_started_on- ` A list of rack 'system_id' values where a scan was
 successfully started.
 
-scan\_failed\_on: A list of rack 'system\_id' values where a scan was
+scan_failed_on- ` A list of rack 'system_id' values where a scan was
 attempted, but failed because a scan was already in progress.
 
-rpc\_call\_timed\_out\_on: A list of rack 'system\_id' values where the
-RPC connection was made, but the call timed out before a ten second
-timeout elapsed.
+rpc_call_timed_out_on- ` A list of rack 'system_id' values where the
+RPC connection was made, but the call timed out before a ten second timeout
+elapsed.
 
 - `param cidr`
-   The subnet CIDR(s) to scan (can be specified multiple times). If not
-    specified, defaults to all networks.
+   The subnet CIDR(s) to scan (can be specified multiple
+       times). If not specified, defaults to all networks.
 
 - `param force`
-   If True, will force the scan, even if all networks are specified.
-    (This may not be the best idea, depending on acceptable use
-    agreements, and the politics of the organization that owns
-    the network.) Default: False.
+   If True, will force the scan, even if all networks are
+       specified. (This may not be the best idea, depending on acceptable use
+        agreements, and the politics of the organization that owns the
+        network.) Default- ` False.
 
-- `param always\_use\_ping`
-   If True, will force the scan to use 'ping' even if 'nmap'
-    is installed. Default: False.
+- `param always_use_ping`
+   If True, will force the scan to use 'ping' even
+       if 'nmap' is installed. Default- ` False.
 
 - `param slow`
-   If True, and 'nmap' is being used, will limit the scan to nine packets
-    per second. If the scanner is 'ping', this option has no effect.
-    Default: False.
+   If True, and 'nmap' is being used, will limit the scan
+       to nine packets per second. If the scanner is 'ping', this option has
+        no effect. Default- ` False.
 
 - `param threads`
-   The number of threads to use during scanning. If 'nmap' is the
-    scanner, the default is one thread per 'nmap' process. If 'ping' is
-    the scanner, the default is four threads per CPU.
+   The number of threads to use during scanning. If 'nmap'
+       is the scanner, the default is one thread per 'nmap' process. If
+        'ping' is the scanner, the default is four threads per CPU.
 
 ### Discovery
 
 Read or delete an observed discovery.
 
-`GET /api/2.0/discovery/{discovery_id}/` Domain ====== Manage domain.
+#### `GET /api/2.0/discovery/{discovery_id}/`
 
-##### `DELETE /api/2.0/domains/{id}/`
+### Domain
+
+Manage domain.
+
+#### `DELETE /api/2.0/domains/{id}/`
 
 Delete domain.
 
-Returns 403 if the user does not have permission to update the
-dnsresource. Returns 404 if the domain is not found.
+Returns 403 if the user does not have permission to update the dnsresource.
+Returns 404 if the domain is not found.
 
-##### `GET /api/2.0/domains/{id}/`
+#### `GET /api/2.0/domains/{id}/`
 
 Read domain.
 
 Returns 404 if the domain is not found.
 
-##### `PUT /api/2.0/domains/{id}/`
+#### `PUT /api/2.0/domains/{id}/`
 
 Update domain.
 
@@ -1283,18 +1322,18 @@ Update domain.
 - `param ttl`
    The default TTL for this domain.
 
-Returns 403 if the user does not have permission to update the
-dnsresource. Returns 404 if the domain is not found.
+Returns 403 if the user does not have permission to update the dnsresource.
+Returns 404 if the domain is not found.
 
 ### Domains
 
 Manage domains.
 
-##### `GET /api/2.0/domains/`
+#### `GET /api/2.0/domains/`
 
 List all domains.
 
-##### `POST /api/2.0/domains/`
+#### `POST /api/2.0/domains/`
 
 Create a domain.
 
@@ -1304,7 +1343,7 @@ Create a domain.
 - `param authoritative`
    Class type of the domain.
 
-##### `POST /api/2.0/domains/` `op=set_serial`
+#### `POST /api/2.0/domains/ op=set_serial`
 
 Set the SOA serial number (for all DNS zones.)
 
@@ -1318,63 +1357,70 @@ Retrieve filtered node events.
 > A specific Node's events is identified by specifying one or more ids,
 > hostnames, or mac addresses as a list.
 
-##### `GET /api/2.0/events/` `op=query`
+#### `GET /api/2.0/events/ op=query`
 
-List Node events, optionally filtered by various criteria via URL
-query parameters.
+List Node events, optionally filtered by various criteria via URL query
+parameters.
 
 - `param hostname`
-   An optional hostname. Only events relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to get events relating to more than one node.
+   An optional hostname. Only events relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to get events relating to more than one node.
 
-- `param mac\_address`
-   An optional list of MAC addresses. Only nodes with matching MAC
-    addresses will be returned.
+- `param mac_address`
+   An optional list of MAC addresses. Only
+       nodes with matching MAC addresses will be returned.
 
 - `param id`
-   An optional list of system ids. Only nodes with matching system ids
-    will be returned.
+   An optional list of system ids. Only nodes with
+       matching system ids will be returned.
 
 - `param zone`
-   An optional name for a physical zone. Only nodes in the zone will
-    be returned.
+   An optional name for a physical zone. Only nodes in the
+       zone will be returned.
 
-- `param agent\_name`
-   An optional agent name. Only nodes with matching agent names will
-    be returned.
+- `param agent_name`
+   An optional agent name. Only nodes with
+       matching agent names will be returned.
 
 - `param level`
-   Desired minimum log level of returned events. Returns this level of
-    events and greater. Choose from: CRITICAL, DEBUG, ERROR, INFO,
-    WARNING. The default is INFO.
+   Desired minimum log level of returned events. Returns
+       this level of events and greater. Choose from- ` AUDIT, CRITICAL,
+        DEBUG, ERROR, INFO, WARNING. The default is INFO.
 
 - `param limit`
-   Optional number of events to return. Default 100. Maximum: 1000.
+   Optional number of events to return. Default 100.
+       Maximum- ` 1000.
 
 - `param before`
-   Optional event id. Defines where to start returning older events.
+   Optional event id. Defines where to start returning
+       older events.
 
 - `param after`
-   Optional event id. Defines where to start returning newer events.
+   Optional event id. Defines where to start returning
+       newer events.
+
+- `param owner`
+   If specified, filters the list to show only events
+       owned by the specified username.
 
 ### Fabric
 
 Manage fabric.
 
-##### `DELETE /api/2.0/fabrics/{id}/`
+#### `DELETE /api/2.0/fabrics/{id}/`
 
 Delete fabric.
 
 Returns 404 if the fabric is not found.
 
-##### `GET /api/2.0/fabrics/{id}/`
+#### `GET /api/2.0/fabrics/{id}/`
 
 Read fabric.
 
 Returns 404 if the fabric is not found.
 
-##### `PUT /api/2.0/fabrics/{id}/`
+#### `PUT /api/2.0/fabrics/{id}/`
 
 Update fabric.
 
@@ -1384,7 +1430,7 @@ Update fabric.
 - `param description`
    Description of the fabric.
 
-- `param class\_type`
+- `param class_type`
    Class type of the fabric.
 
 Returns 404 if the fabric is not found.
@@ -1393,11 +1439,11 @@ Returns 404 if the fabric is not found.
 
 Manage fabrics.
 
-##### `GET /api/2.0/fabrics/`
+#### `GET /api/2.0/fabrics/`
 
 List all fabrics.
 
-##### `POST /api/2.0/fabrics/`
+#### `POST /api/2.0/fabrics/`
 
 Create a fabric.
 
@@ -1407,26 +1453,26 @@ Create a fabric.
 - `param description`
    Description of the fabric.
 
-- `param class\_type`
+- `param class_type`
    Class type of the fabric.
 
 ### Fan Network
 
 Manage Fan Network.
 
-##### `DELETE /api/2.0/fannetworks/{id}/`
+#### `DELETE /api/2.0/fannetworks/{id}/`
 
 Delete fannetwork.
 
 Returns 404 if the fannetwork is not found.
 
-##### `GET /api/2.0/fannetworks/{id}/`
+#### `GET /api/2.0/fannetworks/{id}/`
 
 Read fannetwork.
 
 Returns 404 if the fannetwork is not found.
 
-##### `PUT /api/2.0/fannetworks/{id}/`
+#### `PUT /api/2.0/fannetworks/{id}/`
 
 Update fannetwork.
 
@@ -1442,7 +1488,7 @@ Update fannetwork.
 - `param dhcp`
    confiugre dhcp server for overlay net
 
-- `param host\_reserve`
+- `param host_reserve`
    number of IP addresses to reserve for host
 
 - `param bridge`
@@ -1457,11 +1503,11 @@ Returns 404 if the fannetwork is not found.
 
 Manage Fan Networks.
 
-##### `GET /api/2.0/fannetworks/`
+#### `GET /api/2.0/fannetworks/`
 
 List all fannetworks.
 
-##### `POST /api/2.0/fannetworks/`
+#### `POST /api/2.0/fannetworks/`
 
 Create a fannetwork.
 
@@ -1477,7 +1523,7 @@ Create a fannetwork.
 - `param dhcp`
    confiugre dhcp server for overlay net
 
-- `param host\_reserve`
+- `param host_reserve`
    number of IP addresses to reserve for host
 
 - `param bridge`
@@ -1492,11 +1538,11 @@ Manage a FileStorage object.
 
 > The file is identified by its filename and owner.
 
-##### `DELETE /api/2.0/files/{filename}/`
+#### `DELETE /api/2.0/files/{filename}/`
 
 Delete a FileStorage object.
 
-##### `GET /api/2.0/files/{filename}/`
+#### `GET /api/2.0/files/{filename}/`
 
 GET a FileStorage object as a json object.
 
@@ -1506,7 +1552,7 @@ The 'content' of the file is base64-encoded.
 
 Manage the collection of all the files in this MAAS.
 
-##### `DELETE /api/2.0/files/`
+#### `DELETE /api/2.0/files/`
 
 Delete a FileStorage object.
 
@@ -1516,7 +1562,7 @@ Delete a FileStorage object.
 - `type filename`
    unicode
 
-##### `GET /api/2.0/files/`
+#### `GET /api/2.0/files/`
 
 List the files from the file storage.
 
@@ -1528,7 +1574,7 @@ The returned files are ordered by file name and the content is excluded.
 - `type prefix`
    string
 
-##### `GET /api/2.0/files/` `op=get`
+#### `GET /api/2.0/files/ op=get`
 
 Get a named file from the file storage.
 
@@ -1541,7 +1587,7 @@ Get a named file from the file storage.
 - `return`
    The file is returned in the response content.
 
-##### `GET /api/2.0/files/` `op=get_by_key`
+#### `GET /api/2.0/files/ op=get_by_key`
 
 Get a file from the file storage using its key.
 
@@ -1554,7 +1600,7 @@ Get a file from the file storage using its key.
 - `return`
    The file is returned in the response content.
 
-##### `POST /api/2.0/files/`
+#### `POST /api/2.0/files/`
 
 Add a new file to the file storage.
 
@@ -1565,50 +1611,51 @@ Add a new file to the file storage.
    string
 
 - `param file`
-   Actual file data with content type application/octet-stream
+   Actual file data with content type
+       application/octet-stream
 
-Returns 400 if any of these conditions apply:
+Returns 400 if any of these conditions apply- `
    -   The filename is missing from the parameters
--   The file data is missing
--   More than one file is supplied
+    -   The file data is missing
+    -   More than one file is supplied
 
 ### IP Addresses
 
 Manage IP addresses allocated by MAAS.
 
-##### `GET /api/2.0/ipaddresses/`
+#### `GET /api/2.0/ipaddresses/`
 
 List IP addresses known to MAAS.
 
-By default, gets a listing of all IP addresses allocated to the
-requesting user.
+By default, gets a listing of all IP addresses allocated to the requesting
+user.
 
 - `param ip`
-   If specified, will only display information for the specified
-    IP address.
+   If specified, will only display information for the
+       specified IP address.
 
 - `type ip`
    unicode (must be an IPv4 or IPv6 address)
 
-If the requesting user is a MAAS administrator, the following options may
-also be supplied:
+If the requesting user is a MAAS administrator, the following options may also
+be supplied- `
 
 - `param all`
-   If True, all reserved IP addresses will be shown. (By default, only
-    addresses of type 'User reserved' that are assigned to the requesting
-    user are shown.)
+   If True, all reserved IP addresses will be shown. (By
+       default, only addresses of type 'User reserved' that are assigned to
+        the requesting user are shown.)
 
 - `type all`
    bool
 
 - `param owner`
-   If specified, filters the list to show only IP addresses owned by the
-    specified username.
+   If specified, filters the list to show only IP addresses
+       owned by the specified username.
 
 - `type user`
    unicode
 
-##### `POST /api/2.0/ipaddresses/` `op=release`
+#### `POST /api/2.0/ipaddresses/ op=release`
 
 Release an IP address that was previously reserved by the user.
 
@@ -1619,100 +1666,105 @@ Release an IP address that was previously reserved by the user.
    unicode
 
 - `param force`
-   If True, allows a MAAS administrator to force an IP address to be
-    released, even if it is not a user-reserved IP address or does not
-    belong to the requesting user. Use with caution.
+   If True, allows a MAAS administrator to force an IP
+       address to be released, even if it is not a user-reserved IP address
+        or does not belong to the requesting user. Use with caution.
 
 - `type force`
    bool
 
+- `param discovered`
+   If True, allows a MAAS administrator to release
+       a discovered address. Only valid if 'force' is specified. If not
+        specified, MAAS will attempt to release any type of address except for
+        discovered addresses.
+
 Returns 404 if the provided IP address is not found.
 
-##### `POST /api/2.0/ipaddresses/` `op=reserve`
+#### `POST /api/2.0/ipaddresses/ op=reserve`
 
 Reserve an IP address for use outside of MAAS.
 
-Returns an IP adddress, which MAAS will not allow any of its known nodes
-to use; it is free for use by the requesting user until released by
-the user.
+Returns an IP adddress, which MAAS will not allow any of its known nodes to
+use; it is free for use by the requesting user until released by the user.
 
-The user may supply either a subnet or a specific IP address within
-a subnet.
+The user may supply either a subnet or a specific IP address within a subnet.
 
 - `param subnet`
-   CIDR representation of the subnet on which the IP reservation
-    is required. e.g. 10.1.2.0/24
+   CIDR representation of the subnet on which the IP
+       reservation is required. e.g. 10.1.2.0/24
 
 - `param ip`
-   The IP address, which must be within a known subnet.
+   The IP address, which must be within
+       a known subnet.
 
-- `param ip\_address`
-   (Deprecated.) Alias for 'ip' parameter. Provided for
-    backward compatibility.
+- `param ip_address`
+   (Deprecated.) Alias for 'ip' parameter. Provided
+       for backward compatibility.
 
 - `param hostname`
-   The hostname to use for the specified IP address. If no domain
-    component is given, the default domain will be used.
+   The hostname to use for the specified IP address. If
+       no domain component is given, the default domain will be used.
 
 - `param mac`
    The MAC address that should be linked to this reservation.
 
 Returns 400 if there is no subnet in MAAS matching the provided one, or a
-ip\_address is supplied, but a corresponding subnet could not be found.
+ip_address is supplied, but a corresponding subnet could not be found.
 Returns 503 if there are no more IP addresses available.
 
 ### IP Range
 
 Manage IP range.
 
-##### `DELETE /api/2.0/ipranges/{id}/`
+#### `DELETE /api/2.0/ipranges/{id}/`
 
 Delete IP range.
 
-Returns 403 if not owner of IP range. Returns 404 if the IP range is
-not found.
+Returns 403 if not owner of IP range. Returns 404 if the IP range is not
+found.
 
-##### `GET /api/2.0/ipranges/{id}/`
+#### `GET /api/2.0/ipranges/{id}/`
 
 Read IP range.
 
 Returns 404 if the IP range is not found.
 
-##### `PUT /api/2.0/ipranges/{id}/`
+#### `PUT /api/2.0/ipranges/{id}/`
 
 Update IP range.
 
-- `param start\_ip`
+- `param start_ip`
    Start IP address of this range (inclusive).
 
-- `param end\_ip`
+- `param end_ip`
    End IP address of this range (inclusive).
 
 - `param comment`
    A description of this range. (optional)
 
-Returns 403 if not owner of IP range. Returns 404 if the IP Range is
-not found.
+Returns 403 if not owner of IP range. Returns 404 if the IP Range is not
+found.
 
 ### IP Ranges
 
 Manage IP ranges.
 
-##### `GET /api/2.0/ipranges/`
+#### `GET /api/2.0/ipranges/`
 
 List all IP ranges.
 
-##### `POST /api/2.0/ipranges/`
+#### `POST /api/2.0/ipranges/`
 
 Create an IP range.
 
 - `param type`
    Type of this range. (dynamic or reserved)
 
-- `param start\_ip`
+- `param start_ip`
    Start IP address of this range (inclusive).
 
-- `param end\_ip`
+- `param end_ip`
    End IP address of this range (inclusive).
 
 - `param subnet`
@@ -1727,29 +1779,29 @@ Returns 403 if standard users tries to create a dynamic IP range.
 
 Manage a node's or device's interface.
 
-##### `DELETE /api/2.0/nodes/{system_id}/interfaces/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Delete interface on node.
 
 Returns 404 if the node or interface is not found.
 
-##### `GET /api/2.0/nodes/{system_id}/interfaces/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Read interface on node.
 
 Returns 404 if the node or interface is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=add_tag`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=add_tag`
 
 Add a tag to interface on a node.
 
 - `param tag`
    The tag being added.
 
-Returns 404 if the node or interface is not found. Returns 403 if the user
-is not allowed to update the interface.
+Returns 404 if the node or interface is not found. Returns 403 if the user is
+not allowed to update the interface.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=disconnect`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=disconnect`
 
 Disconnect an interface.
 
@@ -1758,75 +1810,76 @@ from any associated VLAN.
 
 Returns 404 if the node or interface is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=link_subnet`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=link_subnet`
 
 Link interface to a subnet.
 
 - `param mode`
-   AUTO, DHCP, STATIC or LINK\_UP connection to subnet.
+   AUTO, DHCP, STATIC or LINK_UP connection to subnet.
 
 - `param subnet`
    Subnet linked to interface.
 
-- `param ip\_address`
-   IP address for the interface in subnet. Only used when mode is STATIC.
-    If not provided an IP address from subnet will be auto selected.
+- `param ip_address`
+   IP address for the interface in subnet. Only used
+       when mode is STATIC. If not provided an IP address from subnet will be
+        auto selected.
 
 - `param force`
-   If True, allows LINK\_UP to be set on the interface even if other
-    links already exist. Also allows the selection of any VLAN, even a
-    VLAN MAAS does not believe the interface to currently be on. Using
-    this option will cause all other links on the interface to be deleted.
-    (Defaults to False.)
+   If True, allows LINK_UP to be set on the interface
+       even if other links already exist. Also allows the selection of any
+        VLAN, even a VLAN MAAS does not believe the interface to currently be
+        on. Using this option will cause all other links on the interface to
+        be deleted. (Defaults to False.)
 
-- `param default\_gateway`
-   True sets the gateway IP address for the subnet as the default gateway
-    for the node this interface belongs to. Option can only be used with
-    the AUTO and STATIC modes.
+- `param default_gateway`
+   True sets the gateway IP address for the subnet
+       as the default gateway for the node this interface belongs to. Option
+        can only be used with the AUTO and STATIC modes.
 
-Mode definitions: AUTO - Assign this interface a static IP address from
-the provided subnet. The subnet must be a managed subnet. The IP address
-will not be assigned until the node goes to be deployed.
+Mode definitions- ` AUTO - Assign this interface a static IP address from
+the provided subnet. The subnet must be a managed subnet. The IP address will
+not be assigned until the node goes to be deployed.
 
-DHCP - Bring this interface up with DHCP on the given subnet. Only one
-subnet can be set to DHCP. If the subnet is managed this interface will
-pull from the dynamic IP range.
+DHCP - Bring this interface up with DHCP on the given subnet. Only one subnet
+can be set to DHCP. If the subnet is managed this interface will pull from the
+dynamic IP range.
 
-STATIC - Bring this interface up with a STATIC IP address on the
-given subnet. Any number of STATIC links can exist on an interface.
+STATIC - Bring this interface up with a STATIC IP address on the given subnet.
+Any number of STATIC links can exist on an interface.
 
-LINK\_UP - Bring this interface up only on the given subnet. No IP address
+LINK_UP - Bring this interface up only on the given subnet. No IP address
 will be assigned to this interface. The interface cannot have any current
 AUTO, DHCP or STATIC links.
 
 Returns 404 if the node or interface is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=remove_tag`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=remove_tag`
 
 Remove a tag from interface on a node.
 
 - `param tag`
    The tag being removed.
 
-Returns 404 if the node or interface is not found. Returns 403 if the user
-is not allowed to update the interface.
+Returns 404 if the node or interface is not found. Returns 403 if the user is
+not allowed to update the interface.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=set_default_gateway`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=set_default_gateway`
 
 Set the node to use this interface as the default gateway.
 
-If this interface has more than one subnet with a gateway IP in the same
-IP address family then specifying the ID of the link on this interface
-is required.
+If this interface has more than one subnet with a gateway IP in the same IP
+address family then specifying the ID of the link on this interface is
+required.
 
-- `param link\_id`
-   ID of the link on this interface to select the default gateway IP
-    address from.
+- `param link_id`
+   ID of the link on this interface to select the
+       default gateway IP address from.
 
-Returns 400 if the interface has not AUTO or STATIC links. Returns 404 if
-the node or interface is not found.
+Returns 400 if the interface has not AUTO or STATIC links. Returns 404 if the
+node or interface is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/` `op=unlink_subnet`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/{id}/ op=unlink_subnet`
 
 Unlink interface to a subnet.
 
@@ -1835,49 +1888,49 @@ Unlink interface to a subnet.
 
 Returns 404 if the node or interface is not found.
 
-##### `PUT /api/2.0/nodes/{system_id}/interfaces/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/interfaces/{id}/`
 
 Update interface on node.
 
-Machines must has status of Ready or Broken to have access to all options.
-Machines with Deployed status can only have the name and/or mac\_address
+Machines must have a status of Ready or Broken to have access to all options.
+Machines with Deployed status can only have the name and/or mac_address
 updated for an interface. This is intented to allow a bad interface to be
 replaced while the machine remains deployed.
 
-Fields for physical interface:
+Fields for physical interface- `
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
    Tags for the interface.
 
 - `param vlan`
-   Untagged VLAN the interface is connected to. If not set then the
-    interface is considered disconnected.
+   Untagged VLAN the interface is connected to. If not set
+       then the interface is considered disconnected.
 
-Fields for bond interface:
+Fields for bond interface- `
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
    Tags for the interface.
 
 - `param vlan`
-   Untagged VLAN the interface is connected to. If not set then the
-    interface is considered disconnected.
+   Untagged VLAN the interface is connected to. If not set
+       then the interface is considered disconnected.
 
 - `param parents`
    Parent interfaces that make this bond.
 
-Fields for VLAN interface:
+Fields for VLAN interface- `
 
 - `param tags`
    Tags for the interface.
@@ -1888,12 +1941,12 @@ Fields for VLAN interface:
 - `param parent`
    Parent interface for this VLAN interface.
 
-Fields for bridge interface:
+Fields for bridge interface- `
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
@@ -1905,78 +1958,81 @@ Fields for bridge interface:
 - `param parent`
    Parent interface for this bridge interface.
 
-Following are extra parameters that can be set on all interface types:
+Following are extra parameters that can be set on all interface types- `
 
 - `param mtu`
    Maximum transmission unit.
 
-- `param accept\_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
 - `param autoconf`
    Perform stateless autoconfiguration. (IPv6 only)
 
-Following are parameters specific to bonds:
+Following are parameters specific to bonds- `
 
-- `param bond-mode`
-   The operating mode of the bond. (Default: active-backup).
+- `param bond_mode`
+   The operating mode of the bond.
+       (Default- ` active-backup).
 
-- `param bond-miimon`
-   The link monitoring freqeuncy in milliseconds. (Default: 100).
+- `param bond_miimon`
+   The link monitoring freqeuncy in milliseconds.
+       (Default- ` 100).
 
-- `param bond-downdelay`
-   Specifies the time, in milliseconds, to wait before disabling a slave
-    after a link failure has been detected.
+- `param bond_downdelay`
+   Specifies the time, in milliseconds, to wait
+       before disabling a slave after a link failure has been detected.
 
-- `param bond-updelay`
-   Specifies the time, in milliseconds, to wait before enabling a slave
-    after a link recovery has been detected.
+- `param bond_updelay`
+   Specifies the time, in milliseconds, to wait
+       before enabling a slave after a link recovery has been detected.
 
-- `param bond-lacp\_rate`
-   Option specifying the rate in which we'll ask our link partner to
-    transmit LACPDU packets in 802.3ad mode. Available options are fast
-    or slow. (Default: slow).
+- `param bond_lacp_rate`
+   Option specifying the rate in which we'll ask
+       our link partner to transmit LACPDU packets in 802.3ad mode. Available
+        options are fast or slow. (Default- ` slow).
 
-- `param bond-xmit\_hash\_policy`
-   The transmit hash policy to use for slave selection in balance-xor,
-    802.3ad, and tlb modes.
+- `param bond_xmit_hash_policy`
+   The transmit hash policy to use for
+       slave selection in balance-xor, 802.3ad, and tlb modes.
 
-Supported bonding modes (bond-mode):
+Supported bonding modes (bond-mode)- `
 
 balance-rr - Transmit packets in sequential order from the first available
-slave through the last. This mode provides load balancing and
-fault tolerance.
+slave through the last. This mode provides load balancing and fault tolerance.
 
 active-backup - Only one slave in the bond is active. A different slave
-becomes active if, and only if, the active slave fails. The bond's MAC
-address is externally visible on only one port (network adapter) to avoid
-confusing the switch.
+becomes active if, and only if, the active slave fails. The bond's MAC address
+is externally visible on only one port (network adapter) to avoid confusing
+the switch.
 
-balance-xor - Transmit based on the selected transmit hash policy. The
-default policy is a simple \[(source MAC address XOR'd with destination
-MAC address XOR packet type ID) modulo slave count\].
+balance-xor - Transmit based on the selected transmit hash policy. The default
+policy is a simple \[(source MAC address XOR'd with destination MAC address
+XOR packet type ID) modulo slave count\].
 
-broadcast - Transmits everything on all slave interfaces. This mode
-provides fault tolerance.
+broadcast - Transmits everything on all slave interfaces. This mode provides
+fault tolerance.
 
-802.3ad - IEEE 802.3ad Dynamic link aggregation. Creates aggregation
-groups that share the same speed and duplex settings. Utilizes all slaves
-in the active aggregator according to the 802.3ad specification.
+802.3ad - IEEE 802.3ad Dynamic link aggregation. Creates aggregation groups
+that share the same speed and duplex settings. Utilizes all slaves in the
+active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing: channel bonding that does
+balance-tlb - Adaptive transmit load balancing- ` channel bonding that does
 not require any special switch support.
 
-balance-alb - Adaptive load balancing: includes balance-tlb plus receive
-load balancing (rlb) for IPV4 traffic, and does not require any special
-switch support. The receive load balancing is achieved by ARP negotiation.
+balance-alb - Adaptive load balancing- ` includes balance-tlb plus receive
+load balancing (rlb) for IPV4 traffic, and does not require any special switch
+support. The receive load balancing is achieved by ARP negotiation.
 
-Following are parameters specific to bridges:
+Following are parameters specific to bridges- `
 
-- `param bridge\_stp`
-   Turn spanning tree protocol on or off. (Default: False).
+- `param bridge_stp`
+   Turn spanning tree protocol on or off.
+       (Default- ` False).
 
-- `param bridge\_fd`
-   Set bridge forward delay to time seconds. (Default: 15).
+- `param bridge_fd`
+   Set bridge forward delay to time seconds.
+       (Default- ` 15).
 
 Returns 404 if the node or interface is not found.
 
@@ -1984,90 +2040,98 @@ Returns 404 if the node or interface is not found.
 
 Manage interfaces on a node.
 
-##### `GET /api/2.0/nodes/{system_id}/interfaces/`
+#### `GET /api/2.0/nodes/{system_id}/interfaces/`
 
 List all interfaces belonging to a machine, device, or rack controller.
 
 Returns 404 if the node is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/` `op=create_bond`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bond`
 
 Create a bond interface on a machine.
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
    Tags for the interface.
 
 - `param vlan`
-   VLAN the interface is connected to. If not provided then the interface
-    is considered disconnected.
+   VLAN the interface is connected to. If not
+       provided then the interface is considered disconnected.
 
 - `param parents`
    Parent interfaces that make this bond.
 
-Following are parameters specific to bonds:
+Following are parameters specific to bonds- `
 
-- `param bond\_mode`
-   The operating mode of the bond. (Default: active-backup).
+- `param bond_mode`
+   The operating mode of the bond.
+       (Default- ` active-backup).
 
-- `param bond\_miimon`
-   The link monitoring freqeuncy in milliseconds. (Default: 100).
+- `param bond_miimon`
+   The link monitoring freqeuncy in milliseconds.
+       (Default- ` 100).
 
-- `param bond\_downdelay`
-   Specifies the time, in milliseconds, to wait before disabling a slave
-    after a link failure has been detected.
+- `param bond_downdelay`
+   Specifies the time, in milliseconds, to wait
+       before disabling a slave after a link failure has been detected.
 
-- `param bond\_updelay`
-   Specifies the time, in milliseconds, to wait before enabling a slave
-    after a link recovery has been detected.
+- `param bond_updelay`
+   Specifies the time, in milliseconds, to wait
+       before enabling a slave after a link recovery has been detected.
 
-- `param bond\_lacp\_rate`
-   Option specifying the rate in which we'll ask our link partner to
-    transmit LACPDU packets in 802.3ad mode. Available options are fast
-    or slow. (Default: slow).
+- `param bond_lacp_rate`
+   Option specifying the rate in which we'll ask
+       our link partner to transmit LACPDU packets in 802.3ad mode. Available
+        options are fast or slow. (Default- ` slow).
 
-- `param bond\_xmit\_hash\_policy`
-   The transmit hash policy to use for slave selection in balance-xor,
-    802.3ad, and tlb modes. (Default: layer2)
+- `param bond_xmit_hash_policy`
+   The transmit hash policy to use for
+       slave selection in balance-xor, 802.3ad, and tlb modes. (Default- `
+        layer2)
 
-Supported bonding modes (bond-mode): balance-rr - Transmit packets in
-sequential order from the first available slave through the last. This
-mode provides load balancing and fault tolerance.
+- `param bond_num_grat_arp`
+   The number of peer notifications (IPv4 ARP
+       or IPv6 Neighbour Advertisements) to be issued after a failover.
+        (Default- ` 1)
+
+Supported bonding modes (bond-mode)- ` balance-rr - Transmit packets in
+sequential order from the first available slave through the last. This mode
+provides load balancing and fault tolerance.
 
 active-backup - Only one slave in the bond is active. A different slave
-becomes active if, and only if, the active slave fails. The bond's MAC
-address is externally visible on only one port (network adapter) to avoid
-confusing the switch.
+becomes active if, and only if, the active slave fails. The bond's MAC address
+is externally visible on only one port (network adapter) to avoid confusing
+the switch.
 
-balance-xor - Transmit based on the selected transmit hash policy. The
-default policy is a simple \[(source MAC address XOR'd with destination
-MAC address XOR packet type ID) modulo slave count\].
+balance-xor - Transmit based on the selected transmit hash policy. The default
+policy is a simple \[(source MAC address XOR'd with destination MAC address
+XOR packet type ID) modulo slave count\].
 
-broadcast - Transmits everything on all slave interfaces. This mode
-provides fault tolerance.
+broadcast - Transmits everything on all slave interfaces. This mode provides
+fault tolerance.
 
-802.3ad - IEEE 802.3ad Dynamic link aggregation. Creates aggregation
-groups that share the same speed and duplex settings. Utilizes all slaves
-in the active aggregator according to the 802.3ad specification.
+802.3ad - IEEE 802.3ad Dynamic link aggregation. Creates aggregation groups
+that share the same speed and duplex settings. Utilizes all slaves in the
+active aggregator according to the 802.3ad specification.
 
-balance-tlb - Adaptive transmit load balancing: channel bonding that does
+balance-tlb - Adaptive transmit load balancing- ` channel bonding that does
 not require any special switch support.
 
-balance-alb - Adaptive load balancing: includes balance-tlb plus receive
-load balancing (rlb) for IPV4 traffic, and does not require any special
-switch support. The receive load balancing is achieved by ARP negotiation.
+balance-alb - Adaptive load balancing- ` includes balance-tlb plus receive
+load balancing (rlb) for IPV4 traffic, and does not require any special switch
+support. The receive load balancing is achieved by ARP negotiation.
 
-Following are extra parameters that can be set on the interface:
+Following are extra parameters that can be set on the interface- `
 
 - `param mtu`
    Maximum transmission unit.
 
-- `param accept\_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
 - `param autoconf`
@@ -2075,14 +2139,14 @@ Following are extra parameters that can be set on the interface:
 
 Returns 404 if the node is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/` `op=create_bridge`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_bridge`
 
 Create a bridge interface on a machine.
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
@@ -2094,20 +2158,22 @@ Create a bridge interface on a machine.
 - `param parent`
    Parent interface for this bridge interface.
 
-Following are parameters specific to bridges:
+Following are parameters specific to bridges- `
 
-- `param bridge\_stp`
-   Turn spanning tree protocol on or off. (Default: False).
+- `param bridge_stp`
+   Turn spanning tree protocol on or off.
+       (Default- ` False).
 
-- `param bridge\_fd`
-   Set bridge forward delay to time seconds. (Default: 15).
+- `param bridge_fd`
+   Set bridge forward delay to time seconds.
+       (Default- ` 15).
 
-Following are extra parameters that can be set on the interface:
+Following are extra parameters that can be set on the interface- `
 
 - `param mtu`
    Maximum transmission unit.
 
-- `param accept\_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
 - `param autoconf`
@@ -2115,29 +2181,29 @@ Following are extra parameters that can be set on the interface:
 
 Returns 404 if the node is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/` `op=create_physical`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_physical`
 
 Create a physical interface on a machine and device.
 
 - `param name`
    Name of the interface.
 
-- `param mac\_address`
+- `param mac_address`
    MAC address of the interface.
 
 - `param tags`
    Tags for the interface.
 
 - `param vlan`
-   Untagged VLAN the interface is connected to. If not provided then the
-    interface is considered disconnected.
+   Untagged VLAN the interface is connected to. If not
+       provided then the interface is considered disconnected.
 
-Following are extra parameters that can be set on the interface:
+Following are extra parameters that can be set on the interface- `
 
 - `param mtu`
    Maximum transmission unit.
 
-- `param accept\_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
 - `param autoconf`
@@ -2145,7 +2211,7 @@ Following are extra parameters that can be set on the interface:
 
 Returns 404 if the node is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/interfaces/` `op=create_vlan`
+#### `POST /api/2.0/nodes/{system_id}/interfaces/ op=create_vlan`
 
 Create a VLAN interface on a machine.
 
@@ -2158,12 +2224,12 @@ Create a VLAN interface on a machine.
 - `param parent`
    Parent interface for this VLAN interface.
 
-Following are extra parameters that can be set on the interface:
+Following are extra parameters that can be set on the interface- `
 
 - `param mtu`
    Maximum transmission unit.
 
-- `param accept\_ra`
+- `param accept_ra`
    Accept router advertisements. (IPv6 only)
 
 - `param autoconf`
@@ -2175,173 +2241,196 @@ Returns 404 if the node is not found.
 
 Manage a license key.
 
-##### `DELETE /api/2.0/license-key/{osystem}/{distro_series}`
+#### `DELETE /api/2.0/license-key/{osystem}/{distro_series}`
 
 Delete license key.
 
-##### `GET /api/2.0/license-key/{osystem}/{distro_series}`
+#### `GET /api/2.0/license-key/{osystem}/{distro_series}`
 
 Read license key.
 
-##### `PUT /api/2.0/license-key/{osystem}/{distro_series}`
+#### `PUT /api/2.0/license-key/{osystem}/{distro_series}`
 
 Update license key.
 
 - `param osystem`
    Operating system that the key belongs to.
 
-- `param distro\_series`
+- `param distro_series`
    OS release that the key belongs to.
 
-- `param license\_key`
-   License key for osystem/distro\_series combo.
+- `param license_key`
+   License key for osystem/distro_series combo.
 
 ### License Keys
 
 Manage the license keys.
 
-##### `GET /api/2.0/license-keys/`
+#### `GET /api/2.0/license-keys/`
 
 List license keys.
 
-##### `POST /api/2.0/license-keys/`
+#### `POST /api/2.0/license-keys/`
 
 Define a license key.
 
 - `param osystem`
    Operating system that the key belongs to.
 
-- `param distro\_series`
+- `param distro_series`
    OS release that the key belongs to.
 
-- `param license\_key`
-   License key for osystem/distro\_series combo.
+- `param license_key`
+   License key for osystem/distro_series combo.
 
 ### MAAS server
 
 Manage the MAAS server.
 
-##### `GET /api/2.0/maas/` `op=get_config`
+#### `GET /api/2.0/maas/ op=get_config`
 
 Get a config value.
 
 - `param name`
    The name of the config item to be retrieved.
 
-Available configuration items:
+Available configuration items- `
 
-active\_discovery\_interval
-   Active subnet mapping interval. When enabled, each rack will scan
-    subnets enabled for active mapping. This helps ensure discovery
-    information is accurate and complete.
+- `active_discovery_interval`
+   Active subnet mapping interval. When enabled, each rack will scan subnets
+    enabled for active mapping. This helps ensure discovery information is
+    accurate and complete.
 
-boot\_images\_auto\_import
+- `boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-commissioning\_distro\_series
+- `commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-completed\_intro
-   Marks if the initial intro has been completed..
+- `completed_intro`
+   Marks if the initial intro has been completed.
 
-curtin\_verbose
+- `curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
-    detail in the installation logs..
+    detail in the installation logs.
 
-default\_distro\_series
+- `default_distro_series`
    Default OS release used for deployment.
 
-default\_dns\_ttl
-   Default Time-To-Live for the DNS.. If no TTL value is specified at a
-    more specific point this is how long DNS responses are valid,
-    in seconds.
+- `default_dns_ttl`
+   Default Time-To-Live for the DNS. If no TTL value is specified at a more
+    specific point this is how long DNS responses are valid, in seconds.
 
-default\_min\_hwe\_kernel
-   Default Minimum Kernel Version. The default minimum kernel version
-    used on all new and commissioned nodes.
+- `default_min_hwe_kernel`
+   Default Minimum Kernel Version. The default minimum kernel version used on
+    all new and commissioned nodes.
 
-default\_osystem
+- `default_osystem`
    Default operating system used for deployment.
 
-default\_storage\_layout
-   Default storage layout. Storage layout that is applied to a node when
-    it is commissioned. Available choices are: 'bcache' (Bcache layout),
+- `default_storage_layout`
+   Default storage layout. Storage layout that is applied to a node when it
+    is commissioned. Available choices are- ` 'bcache' (Bcache layout),
     'flat' (Flat layout), 'lvm' (LVM layout).
 
-disk\_erase\_with\_quick\_erase
+- `disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
     erase; it wipes only the beginning and end of each disk.
 
-disk\_erase\_with\_secure\_erase
-   Use secure erase by default when erasing disks.. Will only be used on
-    devices that support secure erase. Other devices will fall back to
-    full wipe or quick erase depending on the selected options.
+- `disk_erase_with_secure_erase`
+   Use secure erase by default when erasing disks. Will only be used on
+    devices that support secure erase. Other devices will fall back to full
+    wipe or quick erase depending on the selected options.
 
-dnssec\_validation
-   Enable DNSSEC validation of upstream zones. Only used when MAAS is
-    running its own DNS server. This value is used as the value of
-    'dnssec\_validation' in the DNS server config.
+- `dnssec_validation`
+   Enable DNSSEC validation of upstream zones. Only used when MAAS is running
+    its own DNS server. This value is used as the value of
+    'dnssec_validation' in the DNS server config.
 
-enable\_analytics
-   Enable MAAS UI usage of Google Analytics. This helps the developers of
-    MAAS to identify usage statistics to further development..
+- `enable_analytics`
+   Enable Google Analytics in MAAS UI to shape improvements in user
+    experience.
 
-enable\_disk\_erasing\_on\_release
-   Erase nodes' disks prior to releasing.. Forces users to always erase
-    disks when releasing.
+- `enable_disk_erasing_on_release`
+   Erase nodes' disks prior to releasing. Forces users to always erase disks
+    when releasing.
 
-enable\_http\_proxy
-   Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use
-    the built-in HTTP proxy (or user specified proxy) for APT. MAAS also
-    uses the proxy for downloading boot images.
+- `enable_http_proxy`
+   Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
+    built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
+    proxy for downloading boot images.
 
-enable\_third\_party\_drivers
+- `enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-http\_proxy
-   Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned
-    nodes to use as a proxy for APT traffic. MAAS also uses the proxy for
-    downloading boot images. If no URL is provided, the built-in MAAS
-    proxy will be used.
+- `http_proxy`
+   Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
+    to use as a proxy for APT traffic. MAAS also uses the proxy for
+    downloading boot images. If no URL is provided, the built-in MAAS proxy
+    will be used.
 
-kernel\_opts
+- `kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-maas\_name
+- `maas_name`
    MAAS name.
 
-network\_discovery
-   . When enabled, MAAS will use passive techniques (such as listening to
-    ARP requests and mDNS advertisements) to observe networks attached to
-    rack controllers. Active subnet mapping will also be available to be
-    enabled on the configured subnets.
+- `max_node_commissioning_results`
+   The maximum number of commissioning results runs which are stored.
 
-ntp\_external\_only
-   Use external NTP servers only. Configure all region controller hosts,
-    rack controller hosts, and subsequently deployed machines to refer
-    directly to the configured external NTP servers. Otherwise only region
-    controller hosts will be configured to use those external NTP servers,
-    rack contoller hosts will in turn refer to the regions' NTP servers,
-    and deployed machines will refer to the racks' NTP servers.
+- `max_node_installation_results`
+   The maximum number of installation result runs which are stored.
 
-ntp\_servers
+- `max_node_testing_results`
+   The maximum number of testing results runs which are stored.
+
+- `network_discovery`
+   . When enabled, MAAS will use passive techniques (such as listening to ARP
+    requests and mDNS advertisements) to observe networks attached to rack
+    controllers. Active subnet mapping will also be available to be enabled on
+    the configured subnets.
+
+- `ntp_external_only`
+   Use external NTP servers only. Configure all region controller hosts, rack
+    controller hosts, and subsequently deployed machines to refer directly to
+    the configured external NTP servers. Otherwise only region controller
+    hosts will be configured to use those external NTP servers, rack contoller
+    hosts will in turn refer to the regions' NTP servers, and deployed
+    machines will refer to the racks' NTP servers.
+
+- `ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
-    hostnames delimited by commas and/or spaces, to be used as time
-    references for MAAS itself, the machines MAAS deploys, and devices
-    that make use of MAAS's DHCP services.
+    hostnames delimited by commas and/or spaces, to be used as time references
+    for MAAS itself, the machines MAAS deploys, and devices that make use of
+    MAAS's DHCP services.
 
-upstream\_dns
+- `prefer_v4_proxy`
+   Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
+    proxy will be set to prefer IPv4 DNS resolution before it attempts to
+    perform IPv6 DNS resolution.
+
+- `subnet_ip_exhaustion_threshold_count`
+   If the number of free IP addresses on a subnet becomes less than or equal
+    to this threshold, an IP exhaustion warning will appear for that subnet.
+
+- `upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
-    (space-separated IP addresses). Only used when MAAS is running its own
-    DNS server. This value is used as the value of 'forwarders' in the DNS
-    server config.
+    (space-separated IP addresses). Only used when MAAS is running its own DNS
+    server. This value is used as the value of 'forwarders' in the DNS server
+    config.
 
-windows\_kms\_host
-   Windows KMS activation host. FQDN or IP address of the host that
-    provides the KMS Windows activation service. (Only needed for Windows
-    deployments using KMS activation.)
+- `use_peer_proxy`
+   Use the built-in proxy with an external proxy as a peer. If
+    enable_http_proxy is set, the built-in proxy will be configured to use
+    http_proxy as a peer proxy. The deployed machines will be configured to
+    use the built-in proxy.
 
-##### `POST /api/2.0/maas/` `op=set_config`
+- `windows_kms_host`
+   Windows KMS activation host. FQDN or IP address of the host that provides
+    the KMS Windows activation service. (Only needed for Windows deployments
+    using KMS activation.)
+
+#### `POST /api/2.0/maas/ op=set_config`
 
 Set a config value.
 
@@ -2351,194 +2440,218 @@ Set a config value.
 - `param value`
    The value of the config item to be set.
 
-Available configuration items:
+Available configuration items- `
 
-active\_discovery\_interval
-   Active subnet mapping interval. When enabled, each rack will scan
-    subnets enabled for active mapping. This helps ensure discovery
-    information is accurate and complete.
+- `active_discovery_interval`
+   Active subnet mapping interval. When enabled, each rack will scan subnets
+    enabled for active mapping. This helps ensure discovery information is
+    accurate and complete.
 
-boot\_images\_auto\_import
+- `boot_images_auto_import`
    Automatically import/refresh the boot images every 60 minutes.
 
-commissioning\_distro\_series
+- `commissioning_distro_series`
    Default Ubuntu release used for commissioning.
 
-completed\_intro
-   Marks if the initial intro has been completed..
+- `completed_intro`
+   Marks if the initial intro has been completed.
 
-curtin\_verbose
+- `curtin_verbose`
    Run the fast-path installer with higher verbosity. This provides more
-    detail in the installation logs..
+    detail in the installation logs.
 
-default\_distro\_series
+- `default_distro_series`
    Default OS release used for deployment.
 
-default\_dns\_ttl
-   Default Time-To-Live for the DNS.. If no TTL value is specified at a
-    more specific point this is how long DNS responses are valid,
-    in seconds.
+- `default_dns_ttl`
+   Default Time-To-Live for the DNS. If no TTL value is specified at a more
+    specific point this is how long DNS responses are valid, in seconds.
 
-default\_min\_hwe\_kernel
-   Default Minimum Kernel Version. The default minimum kernel version
-    used on all new and commissioned nodes.
+- `default_min_hwe_kernel`
+   Default Minimum Kernel Version. The default minimum kernel version used on
+    all new and commissioned nodes.
 
-default\_osystem
+- `default_osystem`
    Default operating system used for deployment.
 
-default\_storage\_layout
-   Default storage layout. Storage layout that is applied to a node when
-    it is commissioned. Available choices are: 'bcache' (Bcache layout),
+- `default_storage_layout`
+   Default storage layout. Storage layout that is applied to a node when it
+    is commissioned. Available choices are- ` 'bcache' (Bcache layout),
     'flat' (Flat layout), 'lvm' (LVM layout).
 
-disk\_erase\_with\_quick\_erase
+- `disk_erase_with_quick_erase`
    Use quick erase by default when erasing disks.. This is not a secure
     erase; it wipes only the beginning and end of each disk.
 
-disk\_erase\_with\_secure\_erase
-   Use secure erase by default when erasing disks.. Will only be used on
-    devices that support secure erase. Other devices will fall back to
-    full wipe or quick erase depending on the selected options.
+- `disk_erase_with_secure_erase`
+   Use secure erase by default when erasing disks. Will only be used on
+    devices that support secure erase. Other devices will fall back to full
+    wipe or quick erase depending on the selected options.
 
-dnssec\_validation
-   Enable DNSSEC validation of upstream zones. Only used when MAAS is
-    running its own DNS server. This value is used as the value of
-    'dnssec\_validation' in the DNS server config.
+- `dnssec_validation`
+   Enable DNSSEC validation of upstream zones. Only used when MAAS is running
+    its own DNS server. This value is used as the value of
+    'dnssec_validation' in the DNS server config.
 
-enable\_analytics
-   Enable MAAS UI usage of Google Analytics. This helps the developers of
-    MAAS to identify usage statistics to further development..
+- `enable_analytics`
+   Enable Google Analytics in MAAS UI to shape improvements in user
+    experience.
 
-enable\_disk\_erasing\_on\_release
-   Erase nodes' disks prior to releasing.. Forces users to always erase
-    disks when releasing.
+- `enable_disk_erasing_on_release`
+   Erase nodes' disks prior to releasing. Forces users to always erase disks
+    when releasing.
 
-enable\_http\_proxy
-   Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use
-    the built-in HTTP proxy (or user specified proxy) for APT. MAAS also
-    uses the proxy for downloading boot images.
+- `enable_http_proxy`
+   Enable the use of an APT and HTTP/HTTPS proxy. Provision nodes to use the
+    built-in HTTP proxy (or user specified proxy) for APT. MAAS also uses the
+    proxy for downloading boot images.
 
-enable\_third\_party\_drivers
+- `enable_third_party_drivers`
    Enable the installation of proprietary drivers (i.e. HPVSA).
 
-http\_proxy
-   Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned
-    nodes to use as a proxy for APT traffic. MAAS also uses the proxy for
-    downloading boot images. If no URL is provided, the built-in MAAS
-    proxy will be used.
+- `http_proxy`
+   Proxy for APT and HTTP/HTTPS. This will be passed onto provisioned nodes
+    to use as a proxy for APT traffic. MAAS also uses the proxy for
+    downloading boot images. If no URL is provided, the built-in MAAS proxy
+    will be used.
 
-kernel\_opts
+- `kernel_opts`
    Boot parameters to pass to the kernel by default.
 
-maas\_name
+- `maas_name`
    MAAS name.
 
-network\_discovery
-   . When enabled, MAAS will use passive techniques (such as listening to
-    ARP requests and mDNS advertisements) to observe networks attached to
-    rack controllers. Active subnet mapping will also be available to be
-    enabled on the configured subnets.
+- `max_node_commissioning_results`
+   The maximum number of commissioning results runs which are stored.
 
-ntp\_external\_only
-   Use external NTP servers only. Configure all region controller hosts,
-    rack controller hosts, and subsequently deployed machines to refer
-    directly to the configured external NTP servers. Otherwise only region
-    controller hosts will be configured to use those external NTP servers,
-    rack contoller hosts will in turn refer to the regions' NTP servers,
-    and deployed machines will refer to the racks' NTP servers.
+- `max_node_installation_results`
+   The maximum number of installation result runs which are stored.
 
-ntp\_servers
+- `max_node_testing_results`
+   The maximum number of testing results runs which are stored.
+
+- `network_discovery`
+   . When enabled, MAAS will use passive techniques (such as listening to ARP
+    requests and mDNS advertisements) to observe networks attached to rack
+    controllers. Active subnet mapping will also be available to be enabled on
+    the configured subnets.
+
+- `ntp_external_only`
+   Use external NTP servers only. Configure all region controller hosts, rack
+    controller hosts, and subsequently deployed machines to refer directly to
+    the configured external NTP servers. Otherwise only region controller
+    hosts will be configured to use those external NTP servers, rack contoller
+    hosts will in turn refer to the regions' NTP servers, and deployed
+    machines will refer to the racks' NTP servers.
+
+- `ntp_servers`
    Addresses of NTP servers. NTP servers, specified as IP addresses or
-    hostnames delimited by commas and/or spaces, to be used as time
-    references for MAAS itself, the machines MAAS deploys, and devices
-    that make use of MAAS's DHCP services.
+    hostnames delimited by commas and/or spaces, to be used as time references
+    for MAAS itself, the machines MAAS deploys, and devices that make use of
+    MAAS's DHCP services.
 
-upstream\_dns
+- `prefer_v4_proxy`
+   Sets IPv4 DNS resolution before IPv6. If prefer_v4_proxy is set, the
+    proxy will be set to prefer IPv4 DNS resolution before it attempts to
+    perform IPv6 DNS resolution.
+
+- `subnet_ip_exhaustion_threshold_count`
+   If the number of free IP addresses on a subnet becomes less than or equal
+    to this threshold, an IP exhaustion warning will appear for that subnet.
+
+- `upstream_dns`
    Upstream DNS used to resolve domains not managed by this MAAS
-    (space-separated IP addresses). Only used when MAAS is running its own
-    DNS server. This value is used as the value of 'forwarders' in the DNS
-    server config.
+    (space-separated IP addresses). Only used when MAAS is running its own DNS
+    server. This value is used as the value of 'forwarders' in the DNS server
+    config.
 
-windows\_kms\_host
-   Windows KMS activation host. FQDN or IP address of the host that
-    provides the KMS Windows activation service. (Only needed for Windows
-    deployments using KMS activation.)
+- `use_peer_proxy`
+   Use the built-in proxy with an external proxy as a peer. If
+    enable_http_proxy is set, the built-in proxy will be configured to use
+    http_proxy as a peer proxy. The deployed machines will be configured to
+    use the built-in proxy.
+
+- `windows_kms_host`
+   Windows KMS activation host. FQDN or IP address of the host that provides
+    the KMS Windows activation service. (Only needed for Windows deployments
+    using KMS activation.)
 
 ### Machine
 
 Manage an individual Machine.
 
-> The Machine is identified by its system\_id.
+> The Machine is identified by its system_id.
 
-##### `DELETE /api/2.0/machines/{system_id}/`
+#### `DELETE /api/2.0/machines/{system_id}/`
 
 Delete a specific Node.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to delete the node. Returns 204 if the node is
-successfully deleted.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to delete the node. Returns 204 if the node is successfully
+deleted.
 
-##### `GET /api/2.0/machines/{system_id}/`
+#### `GET /api/2.0/machines/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/machines/{system_id}/` `op=details`
+#### `GET /api/2.0/machines/{system_id}/ op=details`
 
 Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
-Note that this is returned as BSON and not JSON. This is for efficiency,
-but mainly because JSON can't do binary content without applying
-additional encoding like base-64.
+Note that this is returned as BSON and not JSON. This is for efficiency, but
+mainly because JSON can't do binary content without applying additional
+encoding like base-64.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/machines/{system_id}/` `op=get_curtin_config`
+#### `GET /api/2.0/machines/{system_id}/ op=get_curtin_config`
 
 Return the rendered curtin configuration for the machine.
 
-Returns 404 if the machine could not be found. Returns 403 if the user
-does not have permission to get the curtin configuration.
+Returns 404 if the machine could not be found. Returns 403 if the user does
+not have permission to get the curtin configuration.
 
-##### `GET /api/2.0/machines/{system_id}/` `op=power_parameters`
+#### `GET /api/2.0/machines/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
-This method is reserved for admin users and returns a 403 if the user is
-not one.
+This method is reserved for admin users and returns a 403 if the user is not
+one.
 
 This returns the power parameters, if any, configured for a node. For some
-types of power control this will include private information such as
-passwords and secret keys.
+types of power control this will include private information such as passwords
+and secret keys.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/machines/{system_id}/` `op=query_power_state`
+#### `GET /api/2.0/machines/{system_id}/ op=query_power_state`
 
 Query the power state of a node.
 
-Send a request to the node's power controller which asks it about the
-node's state. The reply to this could be delayed by up to 30 seconds while
-waiting for the power controller to respond. Use this method sparingly as
-it ties up an appserver thread while waiting.
+Send a request to the node's power controller which asks it about the node's
+state. The reply to this could be delayed by up to 30 seconds while waiting
+for the power controller to respond. Use this method sparingly as it ties up
+an appserver thread while waiting.
 
-- `param system\_id`
+- `param system_id`
    The node to query.
 
 - `return`
-   a dict whose key is "state" with a value of one of 'on' or 'off'.
+   a dict whose key is "state" with a value of one of
+       'on' or 'off'.
 
 Returns 404 if the node is not found. Returns node's power state.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=abort`
+#### `POST /api/2.0/machines/{system_id}/ op=abort`
 
-Abort a machine's current operation.
+Abort a node's current operation.
 
 - `param comment`
    Optional comment for the event log.
@@ -2546,18 +2659,16 @@ Abort a machine's current operation.
 - `type comment`
    unicode
 
-This currently only supports aborting of the 'Disk Erasing' operation.
+Returns 404 if the node could not be found. Returns 403 if the user does not
+have permission to abort the current operation.
 
-Returns 404 if the machine could not be found. Returns 403 if the user
-does not have permission to abort the current operation.
-
-##### `POST /api/2.0/machines/{system_id}/` `op=clear_default_gateways`
+#### `POST /api/2.0/machines/{system_id}/ op=clear_default_gateways`
 
 Clear any set default gateways on the machine.
 
 This will clear both IPv4 and IPv6 gateways on the machine. This will
 transition the logic of identifing the best gateway to MAAS. This logic is
-determined based the following criteria:
+determined based the following criteria- `
 
 1.  Managed subnets over unmanaged subnets.
 2.  Bond interfaces over physical interfaces.
@@ -2566,70 +2677,118 @@ determined based the following criteria:
 5.  Sticky IP links over user reserved IP links.
 6.  User reserved IP links over auto IP links.
 
-If the default gateways need to be specific for this machine you can set
-which interface and subnet's gateway to use when this machine is deployed
-with the interfaces set-default-gateway API.
+If the default gateways need to be specific for this machine you can set which
+interface and subnet's gateway to use when this machine is deployed with the
+interfaces set-default-gateway API.
 
-Returns 404 if the machine could not be found. Returns 403 if the user
-does not have permission to clear the default gateways.
+Returns 404 if the machine could not be found. Returns 403 if the user does
+not have permission to clear the default gateways.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=commission`
+#### `POST /api/2.0/machines/{system_id}/ op=commission`
 
 Begin commissioning process for a machine.
 
-- `param enable\_ssh`
-   Whether to enable SSH for the commissioning environment using the
-    user's SSH key(s).
+- `param enable_ssh`
+   Whether to enable SSH for the commissioning
+       environment using the user's SSH key(s).
 
-- `type enable\_ssh`
+- `type enable_ssh`
    bool ('0' for False, '1' for True)
 
-- `param skip\_networking`
-   Whether to skip re-configuring the networking on the machine after the
-    commissioning has completed.
+- `param skip_networking`
+   Whether to skip re-configuring the networking
+       on the machine after the commissioning has completed.
 
-- `type skip\_networking`
+- `type skip_networking`
    bool ('0' for False, '1' for True)
 
-- `param skip\_storage`
-   Whether to skip re-configuring the storage on the machine after the
-    commissioning has completed.
+- `param skip_storage`
+   Whether to skip re-configuring the storage
+       on the machine after the commissioning has completed.
 
-- `type skip\_storage`
+- `type skip_storage`
    bool ('0' for False, '1' for True)
+
+- `param commissioning_scripts`
+   A comma seperated list of commissioning
+       script names and tags to be run. By default all custom commissioning
+        scripts are run. Builtin commissioning scripts always run. Selecting
+        'update_firmware' or 'configure_hba' will run firmware updates or
+        configure HBA's on matching machines.
+
+- `type commissioning_scripts`
+   string
+
+- `param testing_scripts`
+   A comma seperated list of testing script names
+       and tags to be run. By default all tests tagged 'commissioning' will
+        be run. Set to 'none' to disable running tests.
+
+- `type testing_scripts`
+   string
 
 A machine in the 'ready', 'declared' or 'failed test' state may initiate a
 commissioning cycle where it is checked out and tested in preparation for
-transitioning to the 'ready' state. If it is already in the 'ready' state
-this is considered a re-commissioning process which is useful if
-commissioning tests were changed after it previously commissioned.
+transitioning to the 'ready' state. If it is already in the 'ready' state this
+is considered a re-commissioning process which is useful if commissioning
+tests were changed after it previously commissioned.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=deploy`
+#### `POST /api/2.0/machines/{system_id}/ op=deploy`
 
 Deploy an operating system to a machine.
 
-- `param user\_data`
-   If present, this blob of user-data to be made available to the
-    machines through the metadata service.
+- `param user_data`
+   If present, this blob of user-data to be made
+       available to the machines through the metadata service.
 
-- `type user\_data`
+- `type user_data`
    base64-encoded unicode
 
-- `param distro\_series`
-   If present, this parameter specifies the OS release the machine
-    will use.
+- `param distro_series`
+   If present, this parameter specifies the
+       OS release the machine will use.
 
-- `type distro\_series`
+- `type distro_series`
    unicode
 
-- `param hwe\_kernel`
-   If present, this parameter specified the kernel to be used on the
-    machine
+- `param hwe_kernel`
+   If present, this parameter specified the kernel to
+       be used on the machine
 
-- `type hwe\_kernel`
+- `type hwe_kernel`
    unicode
+
+- `param agent_name`
+   An optional agent name to attach to the
+       acquired machine.
+
+- `type agent_name`
+   unicode
+
+- `param bridge_all`
+   Optionally create a bridge interface for every
+       configured interface on the machine. The created bridges will be
+        removed once the machine is released. (Default- ` False)
+
+- `type bridge_all`
+   boolean
+
+- `param bridge_stp`
+   Optionally turn spanning tree protocol on or off
+       for the bridges created on every configured interface. (Default- `
+        off)
+
+- `type bridge_stp`
+   boolean
+
+- `param bridge_fd`
+   Optionally adjust the forward delay to time seconds.
+       (Default- ` 15)
+
+- `type bridge_fd`
+   integer
 
 - `param comment`
    Optional comment for the event log.
@@ -2637,41 +2796,63 @@ Deploy an operating system to a machine.
 - `type comment`
    unicode
 
-Ideally we'd have MIME multipart and content-transfer-encoding etc. deal
-with the encapsulation of binary data, but couldn't make it work with the
-framework in reasonable time so went for a dumb, manual encoding instead.
+- `param install_rackd`
+   If True, the Rack Controller will be installed on
+       this machine.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to start the machine. Returns 503 if the start-up
-attempted to allocate an IP address, and there were no IP addresses
-available on the relevant cluster interface.
+- `type install_rackd`
+   boolean
 
-##### `POST /api/2.0/machines/{system_id}/` `op=exit_rescue_mode`
+Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
+the encapsulation of binary data, but couldn't make it work with the framework
+in reasonable time so went for a dumb, manual encoding instead.
+
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to start the machine. Returns 503 if the start-up attempted to
+allocate an IP address, and there were no IP addresses available on the
+relevant cluster interface.
+
+#### `POST /api/2.0/machines/{system_id}/ op=exit_rescue_mode`
 
 Exit rescue mode process for a machine.
 
 A machine in the 'rescue mode' state may exit the rescue mode process.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to exit the rescue mode process for this machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to exit the rescue mode process for this machine.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=mark_broken`
+#### `POST /api/2.0/machines/{system_id}/ op=lock`
+
+Mark a deployed machine as locked, to prevent changes.
+
+A locked machine cannot be released or modified.
+
+- `param comment`
+   Optional comment for the event log.
+
+- `type comment`
+   unicode
+
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission lock the machine.
+
+#### `POST /api/2.0/machines/{system_id}/ op=mark_broken`
 
 Mark a node as 'broken'.
 
 If the node is allocated, release it first.
 
 - `param comment`
-   Optional comment for the event log. Will be displayed on the node as
-    an error description until marked fixed.
+   Optional comment for the event log. Will be
+       displayed on the node as an error description until marked fixed.
 
 - `type comment`
    unicode
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to mark the node broken.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to mark the node broken.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=mark_fixed`
+#### `POST /api/2.0/machines/{system_id}/ op=mark_fixed`
 
 Mark a broken node as fixed and set its status as 'ready'.
 
@@ -2681,38 +2862,52 @@ Mark a broken node as fixed and set its status as 'ready'.
 - `type comment`
    unicode
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to mark the machine fixed.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to mark the machine fixed.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=mount_special`
+#### `POST /api/2.0/machines/{system_id}/ op=mount_special`
 
 Mount a special-purpose filesystem, like tmpfs.
 
 - `param fstype`
-   The filesystem type. This must be a filesystem that does not require a
-    block special device.
+   The filesystem type. This must be a filesystem that
+       does not require a block special device.
 
-- `param mount\_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-- `param mount\_option`
+- `param mount_option`
    Options to pass to mount(8).
 
 Returns 403 when the user is not permitted to mount the partition.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=power_off`
+#### `POST /api/2.0/machines/{system_id}/ op=override_failed_testing`
+
+Ignore failed tests and put node back into a usable state.
+
+- `param comment`
+   Optional comment for the event log.
+
+- `type comment`
+   unicode
+
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to ignore tests for the node.
+
+#### `POST /api/2.0/machines/{system_id}/ op=power_off`
 
 Power off a node.
 
-- `param stop\_mode`
-   An optional power off mode. If 'soft', perform a soft power down if
-    the node's power type supports it, otherwise perform a hard power off.
-    For all values other than 'soft', and by default, perform a hard
-    power off. A soft power off generally asks the OS to shutdown the
-    system gracefully before powering off, while a hard power off occurs
-    immediately without any warning to the OS.
+- `param stop_mode`
+   An optional power off mode. If 'soft',
+       perform a soft power down if the node's power type supports it,
+        otherwise perform a hard power off. For all values other than 'soft',
+        and by default, perform a hard power off. A soft power off generally
+        asks the OS to shutdown the system gracefully before powering off,
+        while a hard power off occurs immediately without any warning to the
+        OS.
 
-- `type stop\_mode`
+- `type stop_mode`
    unicode
 
 - `param comment`
@@ -2721,18 +2916,18 @@ Power off a node.
 - `type comment`
    unicode
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to stop the node.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to stop the node.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=power_on`
+#### `POST /api/2.0/machines/{system_id}/ op=power_on`
 
 Turn on a node.
 
-- `param user\_data`
-   If present, this blob of user-data to be made available to the nodes
-    through the metadata service.
+- `param user_data`
+   If present, this blob of user-data to be made
+       available to the nodes through the metadata service.
 
-- `type user\_data`
+- `type user_data`
    base64-encoded unicode
 
 - `param comment`
@@ -2741,16 +2936,16 @@ Turn on a node.
 - `type comment`
    unicode
 
-Ideally we'd have MIME multipart and content-transfer-encoding etc. deal
-with the encapsulation of binary data, but couldn't make it work with the
-framework in reasonable time so went for a dumb, manual encoding instead.
+Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
+the encapsulation of binary data, but couldn't make it work with the framework
+in reasonable time so went for a dumb, manual encoding instead.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to start the machine. Returns 503 if the start-up
-attempted to allocate an IP address, and there were no IP addresses
-available on the relevant cluster interface.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to start the machine. Returns 503 if the start-up attempted to
+allocate an IP address, and there were no IP addresses available on the
+relevant cluster interface.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=release`
+#### `POST /api/2.0/machines/{system_id}/ op=release`
 
 Release a machine. Opposite of Machines.allocate.
 
@@ -2766,146 +2961,190 @@ Release a machine. Opposite of Machines.allocate.
 - `type erase`
    boolean
 
-- `param secure\_erase`
-   Use the drive's secure erase feature if available. In some cases this
-    can be much faster than overwriting the drive. Some drives implement
-    secure erasure by overwriting themselves so this could still be slow.
+- `param secure_erase`
+   Use the drive's secure erase feature if available.
+       In some cases this can be much faster than overwriting the drive. Some
+        drives implement secure erasure by overwriting themselves so this
+        could still be slow.
 
-- `type secure\_erase`
+- `type secure_erase`
    boolean
 
-- `param quick\_erase`
-   Wipe 1MiB at the start and at the end of the drive to make data
-    recovery inconvenient and unlikely to happen by accident. This is
-    not secure.
+- `param quick_erase`
+   Wipe 2MiB at the start and at the end of the drive
+       to make data recovery inconvenient and unlikely to happen by accident.
+        This is not secure.
 
-- `type quick\_erase`
+- `type quick_erase`
    boolean
 
-If neither secure\_erase nor quick\_erase are specified, MAAS will
-overwrite the whole disk with null bytes. This can be very slow.
+If neither secure_erase nor quick_erase are specified, MAAS will overwrite
+the whole disk with null bytes. This can be very slow.
 
-If both secure\_erase and quick\_erase are specified and the drive does
-NOT have a secure erase feature, MAAS will behave as if only quick\_erase
-was specified.
+If both secure_erase and quick_erase are specified and the drive does NOT
+have a secure erase feature, MAAS will behave as if only quick_erase was
+specified.
 
-If secure\_erase is specified and quick\_erase is NOT specified and the
-drive does NOT have a secure erase feature, MAAS will behave as if
-secure\_erase was NOT specified, i.e. will overwrite the whole disk with
-null bytes. This can be very slow.
+If secure_erase is specified and quick_erase is NOT specified and the drive
+does NOT have a secure erase feature, MAAS will behave as if secure_erase was
+NOT specified, i.e. will overwrite the whole disk with null bytes. This can be
+very slow.
 
-Returns 404 if the machine is not found. Returns 403 if the user doesn't
-have permission to release the machine. Returns 409 if the machine is in a
-state where it may not be released.
+Returns 404 if the machine is not found. Returns 403 if the user doesn't have
+permission to release the machine. Returns 409 if the machine is in a state
+where it may not be released.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=rescue_mode`
+#### `POST /api/2.0/machines/{system_id}/ op=rescue_mode`
 
 Begin rescue mode process for a machine.
 
-A machine in the 'deployed' or 'broken' state may initiate the rescue
-mode process.
+A machine in the 'deployed' or 'broken' state may initiate the rescue mode
+process.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to start the rescue mode process for this machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to start the rescue mode process for this machine.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=restore_default_configuration`
+#### `POST /api/2.0/machines/{system_id}/ op=restore_default_configuration`
 
 Reset a machine's configuration to its initial state.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to reset the machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to reset the machine.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=restore_networking_configuration`
+#### `POST /api/2.0/machines/{system_id}/ op=restore_networking_configuration`
 
 Reset a machine's networking options to its initial state.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to reset the machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to reset the machine.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=restore_storage_configuration`
+#### `POST /api/2.0/machines/{system_id}/ op=restore_storage_configuration`
 
 Reset a machine's storage options to its initial state.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to reset the machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to reset the machine.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=set_owner_data`
+#### `POST /api/2.0/machines/{system_id}/ op=set_owner_data`
 
 Set key/value data for the current owner.
 
 Pass any key/value data to this method to add, modify, or remove. A key is
 removed when the value for that key is set to an empty string.
 
-This operation will not remove any previous keys unless explicitly passed
-with an empty string. All owner data is removed when the machine is no
-longer allocated to a user.
+This operation will not remove any previous keys unless explicitly passed with
+an empty string. All owner data is removed when the machine is no longer
+allocated to a user.
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=set_storage_layout`
+#### `POST /api/2.0/machines/{system_id}/ op=set_storage_layout`
 
 Changes the storage layout on the machine.
 
-This can only be preformed on an allocated machine.
+This operation can only be performed on a machine with a status of 'Ready'.
 
-Note: This will clear the current storage layout and any extra
+Note- ` This will clear the current storage layout and any extra
 configuration and replace it will the new layout.
 
-- `param storage\_layout`
-   Storage layout for the machine. (flat, lvm, and bcache)
+- `param storage_layout`
+   Storage layout for the machine. (flat, lvm,
+       and bcache)
 
-The following are optional for all layouts:
+The following are optional for all layouts- `
 
-- `param boot\_size`
+- `param boot_size`
    Size of the boot partition.
 
-- `param root\_size`
+- `param root_size`
    Size of the root partition.
 
-- `param root\_device`
+- `param root_device`
    Physical block device to place the root partition.
 
-The following are optional for LVM:
+The following are optional for LVM- `
 
-- `param vg\_name`
+- `param vg_name`
    Name of created volume group.
 
-- `param lv\_name`
+- `param lv_name`
    Name of created logical volume.
 
-- `param lv\_size`
+- `param lv_size`
    Size of created logical volume.
 
-The following are optional for Bcache:
+The following are optional for Bcache- `
 
-- `param cache\_device`
+- `param cache_device`
    Physical block device to use as the cache device.
 
-- `param cache\_mode`
-   Cache mode for bcache device. (writeback, writethrough, writearound)
+- `param cache_mode`
+   Cache mode for bcache device. (writeback,
+       writethrough, writearound)
 
-- `param cache\_size`
-   Size of the cache partition to create on the cache device.
+- `param cache_size`
+   Size of the cache partition to create on the cache
+       device.
 
-- `param cache\_no\_part`
-   Don't create a partition on the cache device. Use the entire disk as
-    the cache device.
+- `param cache_no_part`
+   Don't create a partition on the cache device.
+       Use the entire disk as the cache device.
 
 Returns 400 if the machine is currently not allocated. Returns 404 if the
-machine could not be found. Returns 403 if the user does not have
-permission to set the storage layout.
+machine could not be found. Returns 403 if the user does not have permission
+to set the storage layout.
 
-##### `POST /api/2.0/machines/{system_id}/` `op=unmount_special`
+#### `POST /api/2.0/machines/{system_id}/ op=test`
+
+Begin testing process for a node.
+
+- `param enable_ssh`
+   Whether to enable SSH for the testing environment
+       using the user's SSH key(s).
+
+- `type enable_ssh`
+   bool ('0' for False, '1' for True)
+
+- `param testing_scripts`
+   A comma seperated list of testing script names
+       and tags to be run. By default all tests tagged 'commissioning' will
+        be run.
+
+- `type testing_scripts`
+   string
+
+A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
+may run tests. If testing is started and successfully passes from a 'broken',
+or any failed state besides 'failed commissioning' the node will be returned
+to a ready state. Otherwise the node will return to the state it was when
+testing started.
+
+Returns 404 if the node is not found.
+
+#### `POST /api/2.0/machines/{system_id}/ op=unlock`
+
+Mark a machine as unlocked, allowing changes.
+
+- `param comment`
+   Optional comment for the event log.
+
+- `type comment`
+   unicode
+
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission unlock the machine.
+
+#### `POST /api/2.0/machines/{system_id}/ op=unmount_special`
 
 Unmount a special-purpose filesystem, like tmpfs.
 
-- `param mount\_point`
+- `param mount_point`
    Path on the filesystem to unmount.
 
 Returns 403 when the user is not permitted to unmount the partition.
 
-##### `PUT /api/2.0/machines/{system_id}/`
+#### `PUT /api/2.0/machines/{system_id}/`
 
 Update a specific Machine.
 
@@ -2916,7 +3155,8 @@ Update a specific Machine.
    unicode
 
 - `param domain`
-   The domain for this machine. If not given the default domain is used.
+   The domain for this machine. If not given the default
+       domain is used.
 
 - `type domain`
    unicode
@@ -2927,64 +3167,66 @@ Update a specific Machine.
 - `type architecture`
    unicode
 
-- `param min\_hwe\_kernel`
-   A string containing the minimum kernel version allowed to be ran on
-    this machine.
+- `param min_hwe_kernel`
+   A string containing the minimum kernel version
+       allowed to be ran on this machine.
 
-- `type min\_hwe\_kernel`
+- `type min_hwe_kernel`
    unicode
 
-- `param power\_type`
-   The new power type for this machine. If you use the default value,
-    power\_parameters will be set to the empty string. Available to admin
-    users. See the Power types\_ section for a list of the available
-    power types.
+- `param power_type`
+   The new power type for this machine. If you use the
+       default value, power_parameters will be set to the empty string.
+        Available to admin users. See the [Power types]() section for a list
+        of the available power types.
 
-- `type power\_type`
+- `type power_type`
    unicode
 
-- `param power\_parameters\_{param1}`
-   The new value for the 'param1' power parameter. Note that this is
-    dynamic as the available parameters depend on the selected value of
-    the Machine's power\_type. Available to admin users. See the
-    Power types\_ section for a list of the available power parameters for
-    each power type.
+- `param [power_parameters](){param1}`
+   The new value for the 'param1'
+       power parameter. Note that this is dynamic as the available parameters
+        depend on the selected value of the Machine's power_type. Available
+        to admin users. See the [Power types]() section for a list of the
+        available power parameters for each power type.
 
-- `type power\_parameters\_{param1}`
+- `type [power_parameters](){param1}`
    unicode
 
-- `param power\_parameters\_skip\_check`
-   Whether or not the new power parameters for this machine should be
-    checked against the expected power parameters for the machine's power
-- `type ('true' or 'false'). The default is 'false'.`
+- `param power_parameters_skip_check`
+   Whether or not the new power
+       parameters for this machine should be checked against the expected
+        power parameters for the machine's power type ('true' or 'false'). The
+        default is 'false'.
 
-- `type power\_parameters\_skip\_check`
+- `type power_parameters_skip_check`
    unicode
 
 - `param zone`
-   Name of a valid physical zone in which to place this machine.
+   Name of a valid physical zone in which to place this
+       machine.
 
 - `type zone`
    unicode
 
-- `param swap\_size`
-   Specifies the size of the swap file, in bytes. Field accept K, M, G
-    and T suffixes for values expressed respectively in kilobytes,
-    megabytes, gigabytes and terabytes.
+- `param swap_size`
+   Specifies the size of the swap file, in bytes. Field
+       accept K, M, G and T suffixes for values expressed respectively in
+        kilobytes, megabytes, gigabytes and terabytes.
 
-- `type swap\_size`
+- `type swap_size`
    unicode
 
-- `param disable\_ipv4`
+- `param disable_ipv4`
    Deprecated. If specified, must be False.
 
-- `type disable\_ipv4`
+- `type disable_ipv4`
    boolean
 
-- `param cpu\_count`
+- `param cpu_count`
    The amount of CPU cores the machine has.
 
-- `type cpu\_count`
+- `type cpu_count`
    integer
 
 - `param memory`
@@ -2993,125 +3235,149 @@ Update a specific Machine.
 - `type memory`
    unicode
 
-Returns 404 if the machine is not found. Returns 403 if the user does not
-have permission to update the machine.
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to update the machine.
 
 ### Machines
 
 Manage the collection of all the machines in the MAAS.
 
-##### `GET /api/2.0/machines/`
+#### `GET /api/2.0/machines/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
 - `param hostname`
-   An optional hostname. Only nodes relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to see multiple nodes.
+   An optional hostname. Only nodes relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to see multiple nodes.
 
 - `type hostname`
    unicode
 
-- `param mac\_address`
-   An optional MAC address. Only nodes relating to the node owning the
-    specified MAC address will be returned. This can be specified multiple
-    times to see multiple nodes.
+- `param mac_address`
+   An optional MAC address. Only nodes relating to the
+       node owning the specified MAC address will be returned. This can be
+        specified multiple times to see multiple nodes.
 
-- `type mac\_address`
+- `type mac_address`
    unicode
 
 - `param id`
-   An optional list of system ids. Only nodes relating to the nodes with
-    matching system ids will be returned.
+   An optional list of system ids. Only nodes relating to the
+       nodes with matching system ids will be returned.
 
 - `type id`
    unicode
 
 - `param domain`
-   An optional name for a dns domain. Only nodes relating to the nodes in
-    the domain will be returned.
+   An optional name for a dns domain. Only nodes relating
+       to the nodes in the domain will be returned.
 
 - `type domain`
    unicode
 
 - `param zone`
-   An optional name for a physical zone. Only nodes relating to the nodes
-    in the zone will be returned.
+   An optional name for a physical zone. Only nodes relating
+       to the nodes in the zone will be returned.
 
 - `type zone`
    unicode
 
-- `param agent\_name`
-   An optional agent name. Only nodes relating to the nodes with matching
-    agent names will be returned.
+- `param agent_name`
+   An optional agent name. Only nodes relating to the
+       nodes with matching agent names will be returned.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
-##### `GET /api/2.0/machines/` `op=list_allocated`
+#### `GET /api/2.0/machines/ op=is_registered`
+
+Returns whether or not the given MAC address is registered within this MAAS
+(and attached to a non-retired node).
+
+- `param mac_address`
+   The mac address to be checked.
+
+- `type mac_address`
+   unicode
+
+- `return`
+   'true' or 'false'.
+
+- `rtype`
+   unicode
+
+Returns 400 if any mandatory parameters are missing.
+
+#### `GET /api/2.0/machines/ op=list_allocated`
 
 Fetch Machines that were allocated to the User/oauth token.
 
-##### `GET /api/2.0/machines/` `op=power_parameters`
+#### `GET /api/2.0/machines/ op=power_parameters`
 
 Retrieve power parameters for multiple machines.
 
 - `param id`
-   An optional list of system ids. Only machines with matching system ids
-    will be returned.
+   An optional list of system ids. Only machines with
+       matching system ids will be returned.
 
 - `type id`
    iterable
 
 - `return`
-   A dictionary of power parameters, keyed by machine system\_id.
+   A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
 
-##### `POST /api/2.0/machines/`
+#### `POST /api/2.0/machines/`
 
 Create a new Machine.
 
 Adding a server to MAAS puts it on a path that will wipe its disks and
-re-install its operating system, in the event that it PXE boots. In
-anonymous enlistment (and when the enlistment is done by a non-admin), the
-machine is held in the "New" state for approval by a MAAS admin.
+re-install its operating system, in the event that it PXE boots. In anonymous
+enlistment (and when the enlistment is done by a non-admin), the machine is
+held in the "New" state for approval by a MAAS admin.
 
-The minimum data required is: architecture=&lt;arch string&gt; (e.g.
-"i386/generic") mac\_addresses=&lt;value&gt; (e.g. "aa:bb:cc:dd:ee:ff")
+The minimum data required is- ` architecture=&lt;arch string&gt; (e.g.
+"i386/generic") mac_addresses=&lt;value&gt; (e.g. "aa- `bb`
+cc- `dd`ee`ff")
 
 - `param architecture`
-   A string containing the architecture type of the machine. (For
-    example, "i386", or "amd64".) To determine the supported
-    architectures, use the boot-resources endpoint.
+   A string containing the architecture type of
+       the machine. (For example, "i386", or "amd64".) To determine the
+        supported architectures, use the boot-resources endpoint.
 
 - `type architecture`
    unicode
 
-- `param min\_hwe\_kernel`
-   A string containing the minimum kernel version allowed to be ran on
-    this machine.
+- `param min_hwe_kernel`
+   A string containing the minimum kernel version
+       allowed to be ran on this machine.
 
-- `type min\_hwe\_kernel`
+- `type min_hwe_kernel`
    unicode
 
 - `param subarchitecture`
-   A string containing the subarchitecture type of the machine. (For
-    example, "generic" or "hwe-t".) To determine the supported
-    subarchitectures, use the boot-resources endpoint.
+   A string containing the subarchitecture type
+       of the machine. (For example, "generic" or "hwe-t".) To determine the
+        supported subarchitectures, use the boot-resources endpoint.
 
 - `type subarchitecture`
    unicode
 
-- `param mac\_addresses`
-   One or more MAC addresses for the machine. To specify more than one
-    MAC address, the parameter must be specified twice. (such as "machines
-    new
-    mac\_addresses=01:02:03:04:05:06 mac\_addresses=02:03:04:05:06:07")
+- `param mac_addresses`
+   One or more MAC addresses for the machine. To
+       specify more than one MAC address, the parameter must be specified
+        twice. (such as "machines new mac_addresses=01- `02`
 
-- `type mac\_addresses`
+03- `04`05`06
+   mac_addresses=02- `03`
+
+> 04- `05`06`07")
+
+- `type mac_addresses`
    unicode
 
 - `param hostname`
@@ -3121,104 +3387,109 @@ The minimum data required is: architecture=&lt;arch string&gt; (e.g.
    unicode
 
 - `param domain`
-   The domain of the machine. If not given the default domain is used.
+   The domain of the machine. If not given the default
+       domain is used.
 
 - `type domain`
    unicode
 
-- `param power\_type`
-   A power management type, if applicable (e.g. "virsh", "ipmi").
+- `param power_type`
+   A power management type, if applicable (e.g.
+       "virsh", "ipmi").
 
-- `type power\_type`
+- `type power_type`
    unicode
 
-##### `POST /api/2.0/machines/` `op=accept`
+#### `POST /api/2.0/machines/ op=accept`
 
 Accept declared machines into the MAAS.
 
 Machines can be enlisted in the MAAS anonymously or by non-admin users, as
-opposed to by an admin. These machines are held in the New state; a MAAS
-admin must first verify the authenticity of these enlistments, and
-accept them.
+opposed to by an admin. These machines are held in the New state; a MAAS admin
+must first verify the authenticity of these enlistments, and accept them.
 
-Enlistments can be accepted en masse, by passing multiple machines to
-this call. Accepting an already accepted machine is not an error, but
-accepting one that is already allocated, broken, etc. is.
+Enlistments can be accepted en masse, by passing multiple machines to this
+call. Accepting an already accepted machine is not an error, but accepting one
+that is already allocated, broken, etc. is.
 
 - `param machines`
-   system\_ids of the machines whose enlistment is to be accepted. (An
-    empty list is acceptable).
+   system_ids of the machines whose enlistment is to be
+       accepted. (An empty list is acceptable).
 
 - `return`
-   The system\_ids of any machines that have their status changed by
-    this call. Thus, machines that were already accepted are excluded from
-    the result.
+   The system_ids of any machines that have their status changed
+       by this call. Thus, machines that were already accepted are excluded
+        from the result.
 
-Returns 400 if any of the machines do not exist. Returns 403 if the user
-is not an admin.
+Returns 400 if any of the machines do not exist. Returns 403 if the user is
+not an admin.
 
-##### `POST /api/2.0/machines/` `op=accept_all`
+#### `POST /api/2.0/machines/ op=accept_all`
 
 Accept all declared machines into the MAAS.
 
 Machines can be enlisted in the MAAS anonymously or by non-admin users, as
-opposed to by an admin. These machines are held in the New state; a MAAS
-admin must first verify the authenticity of these enlistments, and
-accept them.
+opposed to by an admin. These machines are held in the New state; a MAAS admin
+must first verify the authenticity of these enlistments, and accept them.
 
 - `return`
-   Representations of any machines that have their status changed by
-    this call. Thus, machines that were already accepted are excluded from
-    the result.
+   Representations of any machines that have their status changed
+       by this call. Thus, machines that were already accepted are excluded
+        from the result.
 
-##### `POST /api/2.0/machines/` `op=add_chassis`
+#### `POST /api/2.0/machines/ op=add_chassis`
 
 Add special hardware types.
 
-- `param chassis\_type`
-   The type of hardware. mscm is the type for the Moonshot Chassis
-    Manager. msftocs is the type for the Microsoft OCS Chassis Manager.
-    powerkvm is the type for Virtual Machines on Power KVM, managed by
-    Virsh. seamicro15k is the type for the Seamicro 1500 Chassis. ucsm is
-    the type for the Cisco UCS Manager. virsh is the type for virtual
-    machines managed by Virsh. vmware is the type for virtual machines
-    managed by VMware.
+- `param chassis_type`
+   The type of hardware.
+       mscm is the type for the Moonshot Chassis Manager. msftocs is the type
+        for the Microsoft OCS Chassis Manager. powerkvm is the type for
+        Virtual Machines on Power KVM, managed by Virsh. recs_box is the type
+        for the christmann RECS|Box servers. seamicro15k is the type for the
+        Seamicro 1500 Chassis. ucsm is the type for the Cisco UCS Manager.
+        virsh is the type for virtual machines managed by Virsh. vmware is the
+    - `type for virtual machines managed by VMware.`
 
-- `type chassis\_type`
+- `type chassis_type`
    unicode
 
 - `param hostname`
-   The URL, hostname, or IP address to access the chassis.
+   The URL, hostname, or IP address to access the
+       chassis.
 
 - `type url`
    unicode
 
 - `param username`
-   The username used to access the chassis. This field is required for
-    the seamicro15k, vmware, mscm, msftocs, and ucsm chassis types.
+   The username used to access the chassis. This field
+       is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
+        ucsm chassis types.
 
 - `type username`
    unicode
 
 - `param password`
-   The password used to access the chassis. This field is required for
-    the seamicro15k, vmware, mscm, msftocs, and ucsm chassis types.
+   The password used to access the chassis. This field
+       is required for the recs_box, seamicro15k, vmware, mscm, msftocs, and
+        ucsm chassis types.
 
 - `type password`
    unicode
 
-- `param accept\_all`
-   If true, all enlisted machines will be commissioned.
+- `param accept_all`
+   If true, all enlisted machines will be
+       commissioned.
 
-- `type accept\_all`
+- `type accept_all`
    unicode
 
-- `param rack\_controller`
-   The system\_id of the rack controller to send the add chassis
-    command through. If none is specifed MAAS will automatically determine
-    the rack controller to use.
+- `param rack_controller`
+   The system_id of the rack controller to send
+       the add chassis command through. If none is specifed MAAS will
+        automatically determine the rack controller to use.
 
-- `type rack\_controller`
+- `type rack_controller`
    unicode
 
 - `param domain`
@@ -3228,24 +3499,25 @@ Add special hardware types.
    unicode
 
 The following are optional if you are adding a virsh, vmware, or powerkvm
-chassis:
+chassis- `
 
-- `param prefix\_filter`
+- `param prefix_filter`
    Filter machines with supplied prefix.
 
-- `type prefix\_filter`
+- `type prefix_filter`
    unicode
 
-The following are optional if you are adding a seamicro15k chassis:
+The following are optional if you are adding a seamicro15k chassis- `
 
-- `param power\_control`
-   The power\_control to use, either ipmi (default), restapi,
-    or restapi2.
+- `param power_control`
+   The power_control to use, either ipmi (default),
+       restapi, or restapi2.
 
-- `type power\_control`
+- `type power_control`
    unicode
 
-The following are optional if you are adding a vmware or msftocs chassis.
+The following are optional if you are adding a recs_box, vmware or msftocs
+chassis.
 
 - `param port`
    The port to use when accessing the chassis.
@@ -3253,70 +3525,70 @@ The following are optional if you are adding a vmware or msftocs chassis.
 - `type port`
    integer
 
-The following are optioanl if you are adding a vmware chassis:
+The following are optioanl if you are adding a vmware chassis- `
 
 - `param protocol`
-   The protocol to use when accessing the VMware chassis
-    (default: https).
+   The protocol to use when accessing the VMware
+       chassis (default- ` https).
 
 - `type protocol`
    unicode
 
 - `return`
-   A string containing the chassis powered on by which rack controller.
+   A string containing the chassis powered on by which rack
+       controller.
 
-Returns 404 if no rack controller can be found which has access to the
-given URL. Returns 403 if the user does not have access to the rack
-controller. Returns 400 if the required parameters were not passed.
+Returns 404 if no rack controller can be found which has access to the given
+URL. Returns 403 if the user does not have access to the rack controller.
+Returns 400 if the required parameters were not passed.
 
-##### `POST /api/2.0/machines/` `op=allocate`
+#### `POST /api/2.0/machines/ op=allocate`
 
 Allocate an available machine for deployment.
 
 Constraints parameters can be used to allocate a machine that possesses
-certain characteristics. All the constraints are optional and when
-multiple constraints are provided, they are combined using
-'AND' semantics.
+certain characteristics. All the constraints are optional and when multiple
+constraints are provided, they are combined using 'AND' semantics.
 
 - `param name`
-   Hostname or FQDN of the desired machine. If a FQDN is specified, both
-    the domain and the hostname portions must match.
+   Hostname or FQDN of the desired machine. If a FQDN is
+       specified, both the domain and the hostname portions must match.
 
 - `type name`
    unicode
 
-- `param system\_id`
-   system\_id of the desired machine.
+- `param system_id`
+   system_id of the desired machine.
 
-- `type system\_id`
+- `type system_id`
    unicode
 
 - `param arch`
-   Architecture of the returned machine (e.g. 'i386/generic', 'amd64',
-    'armhf/highbank', etc.).
+   Architecture of the returned machine (e.g. 'i386/generic',
+       'amd64', 'armhf/highbank', etc.).
 
-    If multiple architectures are specified, the machine to acquire may
-    match any of the given architectures. To request multiple
-    architectures, this parameter must be repeated in the request with
-    each value.
+        If multiple architectures are specified, the machine to acquire may
+        match any of the given architectures. To request multiple
+        architectures, this parameter must be repeated in the request with
+        each value.
 
 - `type arch`
    unicode (accepts multiple)
 
-- `param cpu\_count`
+- `param cpu_count`
    Minimum number of CPUs a returned machine must have.
 
-> A machine with additional CPUs may be allocated if there is no exact
-> match, or if the 'mem' constraint is not also specified.
+    > A machine with additional CPUs may be allocated if there is no exact
+    > match, or if the 'mem' constraint is not also specified.
 
-- `type cpu\_count`
+- `type cpu_count`
    positive integer
 
 - `param mem`
-   The minimum amount of memory (expressed in MB) the returned machine
-    must have. A machine with additional memory may be allocated if there
-    is no exact match, or the 'cpu\_count' constraint is not
-    also specified.
+   The minimum amount of memory (expressed in MB) the
+   - `return`ed machine must have. A machine with additional memory may be
+        allocated if there is no exact match, or the 'cpu_count' constraint
+        is not also specified.
 
 - `type mem`
    positive integer
@@ -3324,19 +3596,19 @@ multiple constraints are provided, they are combined using
 - `param tags`
    Tags the machine must match in order to be acquired.
 
-> If multiple tag names are specified, the machine must be tagged with all
-> of them. To request multiple tags, this parameter must be repeated in
-> the request with each value.
+    > If multiple tag names are specified, the machine must be tagged with all
+    > of them. To request multiple tags, this parameter must be repeated in
+    > the request with each value.
 
 - `type tags`
    unicode (accepts multiple)
 
-- `param not\_tags`
+- `param not_tags`
    Tags the machine must NOT match.
 
-> If multiple tag names are specified, the machine must NOT be tagged with
-> ANY of them. To request exclusion of multiple tags, this parameter must
-> be repeated in the request with each value.
+    > If multiple tag names are specified, the machine must NOT be tagged with
+    > ANY of them. To request exclusion of multiple tags, this parameter must
+    > be repeated in the request with each value.
 
 - `type tags`
    unicode (accepts multiple)
@@ -3347,161 +3619,205 @@ multiple constraints are provided, they are combined using
 - `type zone`
    unicode
 
-- `type not\_in\_zone`
-   List of physical zones from which the machine must not be acquired.
+- `param not_in_zone`
+   List of physical zones from which the machine must
+       not be acquired.
 
-    If multiple zones are specified, the machine must NOT be associated
-    with ANY of them. To request multiple zones to exclude, this parameter
-    must be repeated in the request with each value.
+        If multiple zones are specified, the machine must NOT be associated
+        with ANY of them. To request multiple zones to exclude, this parameter
+        must be repeated in the request with each value.
 
-- `type not\_in\_zone`
+- `type not_in_zone`
    unicode (accepts multiple)
+
+- `param pod`
+   Pod the machine must be located in.
+
+- `type pod`
+   unicode
+
+- `param not_pod`
+   Pod the machine must not be located in.
+
+- `type not_pod`
+   unicode
+
+- `param pod_type`
+   Pod type the machine must be located in.
+
+- `type pod_type`
+   unicode
+
+- `param not_pod_type`
+   Pod type the machine must not be located in.
+
+- `type not_pod_type`
+   unicode
 
 - `param subnets`
    Subnets that must be linked to the machine.
 
-> "Linked to" means the node must be configured to acquire an address in
-> the specified subnet, have a static IP address in the specified subnet,
-> or have been observed to DHCP from the specified subnet during
-> commissioning time (which implies that it *could* have an address on the
-> specified subnet).
->
-> Subnets can be specified by one of the following criteria:
->
-> -   &lt;id&gt;: match the subnet by its 'id' field
-> -   fabric:&lt;fabric-spec&gt;: match all subnets in a given fabric.
-> -   ip:&lt;ip-address&gt;: Match the subnet containing
->     &lt;ip-address&gt; with the with the longest-prefix match.
-> -   name:&lt;subnet-name&gt;: Match a subnet with the given name.
-> -   space:&lt;space-spec&gt;: Match all subnets in a given space.
-> -   vid:&lt;vid-integer&gt;: Match a subnet on a VLAN with the
->     specified VID. Valid values range from 0 through 4094 (inclusive).
->     An untagged VLAN can be specified by using the value "0".
-> -   vlan:&lt;vlan-spec&gt;: Match all subnets on the given VLAN.
->
-> Note that (as of this writing), the 'fabric', 'space', 'vid', and 'vlan'
-> specifiers are only useful for the 'not\_spaces' version of this
-> constraint, because they will most likely force the query to match ALL
-> the subnets in each fabric, space, or VLAN, and thus not return
-> any nodes. (This is not a particularly useful behavior, so may be
-> changed in the future.)
->
-> If multiple subnets are specified, the machine must be associated with
-> all of them. To request multiple subnets, this parameter must be
-> repeated in the request with each value.
->
-> Note that this replaces the leagcy 'networks' constraint in MAAS 1.x.
+    > "Linked to" means the node must be configured to acquire an address in
+    > the specified subnet, have a static IP address in the specified subnet,
+    > or have been observed to DHCP from the specified subnet during
+    > commissioning time (which implies that it *could* have an address on the
+    > specified subnet).
+    >
+    > Subnets can be specified by one of the following criteria- `
+    >
+    > -   &lt;id&gt;- ` match the subnet by its 'id' field
+    > -   fabric- `&lt;fabric-spec&gt;`
+
+    match all subnets in a given fabric.
+       -   ip- `&lt;ip-address&gt;`
+
+    Match the subnet containing &lt;ip-address&gt; with
+       the with the longest-prefix match.
+
+    > -   name- `&lt;subnet-name&gt;`
+
+    Match a subnet with the given name.
+       -   space- `&lt;space-spec&gt;`
+
+    Match all subnets in a given space.
+       -   vid- `&lt;vid-integer&gt;`
+
+    Match a subnet on a VLAN with the specified
+       VID. Valid values range from 0 through 4094 (inclusive). An untagged
+        VLAN can be specified by using the value "0".
+
+    > -   vlan- `&lt;vlan-spec&gt;`
+
+    Match all subnets on the given VLAN.
+
+    > Note that (as of this writing), the 'fabric', 'space', 'vid', and 'vlan'
+    > specifiers are only useful for the 'not_spaces' version of this
+    > constraint, because they will most likely force the query to match ALL
+    > the subnets in each fabric, space, or VLAN, and thus not return any
+    > nodes. (This is not a particularly useful behavior, so may be changed in
+    > the future.)
+    >
+    > If multiple subnets are specified, the machine must be associated with
+    > all of them. To request multiple subnets, this parameter must be
+    > repeated in the request with each value.
+    >
+    > Note that this replaces the leagcy 'networks' constraint in MAAS 1.x.
 
 - `type subnets`
    unicode (accepts multiple)
 
-- `param not\_subnets`
+- `param not_subnets`
    Subnets that must NOT be linked to the machine.
 
-> See the 'subnets' constraint documentation above for more information
-> about how each subnet can be specified.
->
-> If multiple subnets are specified, the machine must NOT be associated
-> with ANY of them. To request multiple subnets to exclude, this parameter
-> must be repeated in the request with each value. (Or a fabric, space, or
-> VLAN specifier may be used to match multiple subnets).
->
-> Note that this replaces the leagcy 'not\_networks' constraint in
-> MAAS 1.x.
+    > See the 'subnets' constraint documentation above for more information
+    > about how each subnet can be specified.
+    >
+    > If multiple subnets are specified, the machine must NOT be associated
+    > with ANY of them. To request multiple subnets to exclude, this parameter
+    > must be repeated in the request with each value. (Or a fabric, space, or
+    > VLAN specifier may be used to match multiple subnets).
+    >
+    > Note that this replaces the leagcy 'not_networks' constraint in MAAS
+    > 1.x.
 
-- `type not\_subnets`
+- `type not_subnets`
    unicode (accepts multiple)
 
 - `param storage`
-   A list of storage constraint identifiers, in the form:
-    &lt;label&gt;:&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;:...\]
+   A list of storage constraint identifiers, in the form- `
+       &lt;label&gt;- `&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+
+> ...\]
 
 - `type storage`
    unicode
 
 - `param interfaces`
-   A labeled constraint map associating constraint labels with interface
-    properties that should be matched. Returned nodes must have one or
-    more interface matching the specified constraints. The labeled
-    constraint map must be in the format:
-    `<label>:<key>=<value>[,<key2>=<value2>[,...]]`
+   A labeled constraint map associating constraint
+       labels with interface properties that should be matched. Returned
+        nodes must have one or more interface matching the specified
+        constraints. The labeled constraint map must be in the format- `
+        `<label>- `<key>=<value>[,<key2>=<value2>[,...]]`
 
-    Each key can be one of the following:
+        Each key can be one of the following- `
 
--   id: Matches an interface with the specific id
--   fabric: Matches an interface attached to the specified fabric.
--   fabric\_class: Matches an interface attached to a fabric with the
-        specified class.
--   ip: Matches an interface with the specified IP address assigned
-        to it.
--   mode: Matches an interface with the specified mode. (Currently,
-        the only supported mode is "unconfigured".)
--   name: Matches an interface with the specified name. (For
-        example, "eth0".)
--   hostname: Matches an interface attached to the node with the
-        specified hostname.
--   subnet: Matches an interface attached to the specified subnet.
--   space: Matches an interface attached to the specified space.
--   subnet\_cidr: Matches an interface attached to the specified
-        subnet CIDR. (For example, "192.168.0.0/24".)
--   type: Matches an interface of the specified type. (Valid types:
-        "physical", "vlan", "bond", "bridge", or "unknown".)
--   vlan: Matches an interface on the specified VLAN.
--   vid: Matches an interface on a VLAN with the specified VID.
--   tag: Matches an interface tagged with the specified tag.
+        -   id- ` Matches an interface with the specific id
+        -   fabric- ` Matches an interface attached to the specified
+            fabric.
+        -   fabric_class- ` Matches an interface attached to a fabric with
+            the specified class.
+        -   ip- ` Matches an interface with the specified IP address
+            assigned to it.
+        -   mode- ` Matches an interface with the specified mode.
+            (Currently, the only supported mode is "unconfigured".)
+        -   name- ` Matches an interface with the specified name. (For
+            example, "eth0".)
+        -   hostname- ` Matches an interface attached to the node with the
+            specified hostname.
+        -   subnet- ` Matches an interface attached to the specified
+            subnet.
+        -   space- ` Matches an interface attached to the specified space.
+        -   subnet_cidr- ` Matches an interface attached to the specified
+            subnet CIDR. (For example, "192.168.0.0/24".)
+        -   type- ` Matches an interface of the specified type. (Valid
+            types- ` "physical", "vlan", "bond", "bridge", or "unknown".)
+        -   vlan- ` Matches an interface on the specified VLAN.
+        -   vid- ` Matches an interface on a VLAN with the specified VID.
+        -   tag- ` Matches an interface tagged with the specified tag.
 
 - `type interfaces`
    unicode
 
 - `param fabrics`
-   Set of fabrics that the machine must be associated with in order to
-    be acquired.
+   Set of fabrics that the machine must be associated with
+       in order to be acquired.
 
-    If multiple fabrics names are specified, the machine can be in any of
-    the specified fabrics. To request multiple possible fabrics to match,
-    this parameter must be repeated in the request with each value.
+        If multiple fabrics names are specified, the machine can be in any of
+        the specified fabrics. To request multiple possible fabrics to match,
+        this parameter must be repeated in the request with each value.
 
 - `type fabrics`
    unicode (accepts multiple)
 
-- `param not\_fabrics`
-   Fabrics the machine must NOT be associated with in order to
-    be acquired.
+- `param not_fabrics`
+   Fabrics the machine must NOT be associated with in
+       order to be acquired.
 
-    If multiple fabrics names are specified, the machine must NOT be in
-    ANY of them. To request exclusion of multiple fabrics, this parameter
-    must be repeated in the request with each value.
+        If multiple fabrics names are specified, the machine must NOT be in
+        ANY of them. To request exclusion of multiple fabrics, this parameter
+        must be repeated in the request with each value.
 
-- `type not\_fabrics`
+- `type not_fabrics`
    unicode (accepts multiple)
 
-- `param fabric\_classes`
-   Set of fabric class types whose fabrics the machine must be associated
-    with in order to be acquired.
+- `param fabric_classes`
+   Set of fabric class types whose fabrics the
+       machine must be associated with in order to be acquired.
 
-    If multiple fabrics class types are specified, the machine can be in
-    any matching fabric. To request multiple possible fabrics class types
-    to match, this parameter must be repeated in the request with
-    each value.
+        If multiple fabrics class types are specified, the machine can be in
+        any matching fabric. To request multiple possible fabrics class types
+        to match, this parameter must be repeated in the request with each
+        value.
 
-- `type fabric\_classes`
+- `type fabric_classes`
    unicode (accepts multiple)
 
-- `param not\_fabric\_classes`
-   Fabric class types whose fabrics the machine must NOT be associated
-    with in order to be acquired.
+- `param not_fabric_classes`
+   Fabric class types whose fabrics the machine
+       must NOT be associated with in order to be acquired.
 
-    If multiple fabrics names are specified, the machine must NOT be in
-    ANY of them. To request exclusion of multiple fabrics, this parameter
-    must be repeated in the request with each value.
+        If multiple fabrics names are specified, the machine must NOT be in
+        ANY of them. To request exclusion of multiple fabrics, this parameter
+        must be repeated in the request with each value.
 
-- `type not\_fabric\_classes`
+- `type not_fabric_classes`
    unicode (accepts multiple)
 
-- `param agent\_name`
-   An optional agent name to attach to the acquired machine.
+- `param agent_name`
+   An optional agent name to attach to the
+       acquired machine.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
 - `param comment`
@@ -3510,57 +3826,58 @@ multiple constraints are provided, they are combined using
 - `type comment`
    unicode
 
-- `param bridge\_all`
-   Optionally create a bridge interface for every configured interface on
-    the machine. The created bridges will be removed once the machine is
-    released. (Default: False)
+- `param bridge_all`
+   Optionally create a bridge interface for every
+       configured interface on the machine. The created bridges will be
+        removed once the machine is released. (Default- ` False)
 
-- `type bridge\_all`
+- `type bridge_all`
    boolean
 
-- `param bridge\_stp`
-   Optionally turn spanning tree protocol on or off for the bridges
-    created on every configured interface. (Default: off)
+- `param bridge_stp`
+   Optionally turn spanning tree protocol on or off
+       for the bridges created on every configured interface. (Default- `
+        off)
 
-- `type bridge\_stp`
+- `type bridge_stp`
    boolean
 
-- `param bridge\_fd`
-   Optionally adjust the forward delay to time seconds. (Default: 15)
+- `param bridge_fd`
+   Optionally adjust the forward delay to time seconds.
+       (Default- ` 15)
 
-- `type bridge\_fd`
+- `type bridge_fd`
    integer
 
-- `param dry\_run`
-   Optional boolean to indicate that the machine should not actually be
-    acquired (this is for support/troubleshooting, or users who want to
-    see which machine would match a constraint, without acquiring
-    a machine). Defaults to False.
+- `param dry_run`
+   Optional boolean to indicate that the machine should
+       not actually be acquired (this is for support/troubleshooting, or
+        users who want to see which machine would match a constraint, without
+        acquiring a machine). Defaults to False.
 
-- `type dry\_run`
+- `type dry_run`
    bool
 
 - `param verbose`
-   Optional boolean to indicate that the user would like additional
-    verbosity in the constraints\_by\_type field (each constraint will be
-    prefixed by verbose\_, and contain the full data structure that
-    indicates which machine(s) matched).
+   Optional boolean to indicate that the user would like
+       additional verbosity in the constraints_by_type field (each
+        constraint will be prefixed by verbose_, and contain the full data
+        structure that indicates which machine(s) matched).
 
 - `type verbose`
    bool
 
-Returns 409 if a suitable machine matching the constraints could not
-be found.
+Returns 409 if a suitable machine matching the constraints could not be found.
 
-##### `POST /api/2.0/machines/` `op=release`
+#### `POST /api/2.0/machines/ op=release`
 
 Release multiple machines.
 
 This places the machines back into the pool, ready to be reallocated.
 
 - `param machines`
-   system\_ids of the machines which are to be released. (An empty list
-    is acceptable).
+   system_ids of the machines which are to be released.
+       (An empty list is acceptable).
 
 - `param comment`
    Optional comment for the event log.
@@ -3569,26 +3886,25 @@ This places the machines back into the pool, ready to be reallocated.
    unicode
 
 - `return`
-   The system\_ids of any machines that have their status changed by
-    this call. Thus, machines that were already released are excluded from
-    the result.
+   The system_ids of any machines that have their status
+       changed by this call. Thus, machines that were already released are
+        excluded from the result.
 
-Returns 400 if any of the machines cannot be found. Returns 403 if the
-user does not have permission to release any of the machines. Returns a
-409 if any of the machines could not be released due to their
-current state.
+Returns 400 if any of the machines cannot be found. Returns 403 if the user
+does not have permission to release any of the machines. Returns a 409 if any
+of the machines could not be released due to their current state.
 
-##### `POST /api/2.0/machines/` `op=set_zone`
+#### `POST /api/2.0/machines/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
 - `param zone`
-   Zone name. If omitted, the zone is "none" and the nodes will be taken
-    out of their physical zones.
+   Zone name. If omitted, the zone is "none" and the nodes
+       will be taken out of their physical zones.
 
 - `param nodes`
-   system\_ids of the nodes whose zones are to be set. (An empty list
-    is acceptable).
+   system_ids of the nodes whose zones are to be set.
+       (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -3598,59 +3914,60 @@ Manage a network.
 
 > This endpoint is deprecated. Use the new 'subnet' endpoint instead.
 
-##### `DELETE /api/2.0/networks/{name}/`
+#### `DELETE /api/2.0/networks/{name}/`
 
 Delete network definition.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-##### `GET /api/2.0/networks/{name}/`
+#### `GET /api/2.0/networks/{name}/`
 
 Read network definition.
 
-##### `GET /api/2.0/networks/{name}/` `op=list_connected_macs`
+#### `GET /api/2.0/networks/{name}/ op=list_connected_macs`
 
 Returns the list of MAC addresses connected to this network.
 
 Only MAC addresses for nodes visible to the requesting user are returned.
 
-##### `POST /api/2.0/networks/{name}/` `op=connect_macs`
+#### `POST /api/2.0/networks/{name}/ op=connect_macs`
 
 Connect the given MAC addresses to this network.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-##### `POST /api/2.0/networks/{name}/` `op=disconnect_macs`
+#### `POST /api/2.0/networks/{name}/ op=disconnect_macs`
 
 Disconnect the given MAC addresses from this network.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
-##### `PUT /api/2.0/networks/{name}/`
+#### `PUT /api/2.0/networks/{name}/`
 
 Update network definition.
 
 This endpoint is no longer available. Use the 'subnet' endpoint instead.
 
 - `param name`
-   A simple name for the network, to make it easier to refer to. Must
-    consist only of letters, digits, dashes, and underscores.
+   A simple name for the network, to make it easier to
+       refer to. Must consist only of letters, digits, dashes, and
+        underscores.
 
 - `param ip`
-   Base IP address for the network, e.g. 10.1.0.0. The host bits will
-    be zeroed.
+   Base IP address for the network, e.g. 10.1.0.0. The host
+       bits will be zeroed.
 
 - `param netmask`
-   Subnet mask to indicate which parts of an IP address are part of the
-    network address. For example, 255.255.255.0.
+   Subnet mask to indicate which parts of an IP address
+       are part of the network address. For example, 255.255.255.0.
 
-- `param vlan\_tag`
-   Optional VLAN tag: a number between 1 and 0xffe (4094) inclusive, or
-    zero for an untagged network.
+- `param vlan_tag`
+   Optional VLAN tag- ` a number between 1 and 0xffe (4094)
+       inclusive, or zero for an untagged network.
 
 - `param description`
-   Detailed description of the network for the benefit of users
-    and administrators.
+   Detailed description of the network for the benefit
+       of users and administrators.
 
 ### Networks
 
@@ -3658,16 +3975,16 @@ Manage the networks.
 
 > This endpoint is deprecated. Use the new 'subnets' endpoint instead.
 
-##### `GET /api/2.0/networks/`
+#### `GET /api/2.0/networks/`
 
 List networks.
 
 - `param node`
-   Optionally, nodes which must be attached to any returned networks. If
-    more than one node is given, the result will be restricted to networks
-    that these nodes have in common.
+   Optionally, nodes which must be attached to any returned
+       networks. If more than one node is given, the result will be
+        restricted to networks that these nodes have in common.
 
-##### `POST /api/2.0/networks/`
+#### `POST /api/2.0/networks/`
 
 Define a network.
 
@@ -3677,47 +3994,47 @@ This endpoint is no longer available. Use the 'subnets' endpoint instead.
 
 Manage an individual Node.
 
-> The Node is identified by its system\_id.
+> The Node is identified by its system_id.
 
-##### `DELETE /api/2.0/nodes/{system_id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/`
 
 Delete a specific Node.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to delete the node. Returns 204 if the node is
-successfully deleted.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to delete the node. Returns 204 if the node is successfully
+deleted.
 
-##### `GET /api/2.0/nodes/{system_id}/`
+#### `GET /api/2.0/nodes/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/nodes/{system_id}/` `op=details`
+#### `GET /api/2.0/nodes/{system_id}/ op=details`
 
 Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
-Note that this is returned as BSON and not JSON. This is for efficiency,
-but mainly because JSON can't do binary content without applying
-additional encoding like base-64.
+Note that this is returned as BSON and not JSON. This is for efficiency, but
+mainly because JSON can't do binary content without applying additional
+encoding like base-64.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/nodes/{system_id}/` `op=power_parameters`
+#### `GET /api/2.0/nodes/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
-This method is reserved for admin users and returns a 403 if the user is
-not one.
+This method is reserved for admin users and returns a 403 if the user is not
+one.
 
 This returns the power parameters, if any, configured for a node. For some
-types of power control this will include private information such as
-passwords and secret keys.
+types of power control this will include private information such as passwords
+and secret keys.
 
 Returns 404 if the node is not found.
 
@@ -3725,108 +4042,627 @@ Returns 404 if the node is not found.
 
 Read the collection of NodeResult in the MAAS.
 
-##### `GET /api/2.0/installation-results/`
+#### `GET /api/2.0/installation-results/`
 
 List NodeResult visible to the user, optionally filtered.
 
-- `param system\_id`
-   An optional list of system ids. Only the results related to the nodes
-    with these system ids will be returned.
+- `param system_id`
+   An optional list of system ids. Only the
+       results related to the nodes with these system ids will be returned.
 
-- `type system\_id`
+- `type system_id`
    iterable
 
 - `param name`
-   An optional list of names. Only the results with the specified names
-    will be returned.
+   An optional list of names. Only the results
+       with the specified names will be returned.
 
 - `type name`
    iterable
 
-- `param result\_type`
-   An optional result\_type. Only the results with the specified
-    result\_type will be returned.
+- `param result_type`
+   An optional result_type. Only the results
+       with the specified result_type will be returned.
 
 - `type name`
    iterable
+
+### Node Script
+
+Manage or view a custom script.
+
+#### `DELETE /api/2.0/scripts/{name}`
+
+Delete a script.
+
+#### `GET /api/2.0/scripts/{name}`
+
+Return a script's metadata.
+
+- `param include_script`
+   Include the base64 encoded script content.
+
+- `type include_script`
+   bool
+
+#### `GET /api/2.0/scripts/{name} op=download`
+
+Download a script.
+
+- `param revision`
+   What revision to download, latest by default. Can use
+       rev as a shortcut.
+
+- `type revision`
+   integer
+
+#### `POST /api/2.0/scripts/{name} op=add_tag`
+
+Add a single tag to a script.
+
+- `param tag`
+   The tag being added.
+
+- `type tag`
+   unicode
+
+Returns 404 if the script is not found.
+
+#### `POST /api/2.0/scripts/{name} op=remove_tag`
+
+Remove a single tag to a script.
+
+- `param tag`
+   The tag being removed.
+
+- `type tag`
+   unicode
+
+Returns 404 if the script is not found.
+
+#### `POST /api/2.0/scripts/{name} op=revert`
+
+Revert a script to an earlier version.
+
+- `param to`
+   What revision in the script's history to revert to. This can
+       either be an ID or a negative number representing how far back to go.
+
+- `type to`
+   integer
+
+Returns 404 if the script is not found.
+
+#### `PUT /api/2.0/scripts/{name}`
+
+Update a commissioning script.
+
+- `param name`
+   The name of the script.
+
+- `type name`
+   unicode
+
+- `param title`
+   The title of the script.
+
+- `type title`
+   unicode
+
+- `param description`
+   A description of what the script does.
+
+- `type description`
+   unicode
+
+- `param tags`
+   A comma seperated list of tags for this script.
+
+- `type tags`
+   unicode
+
+- `param type`
+   The type defines when the script should be used. Can be
+       testing or commissioning, defaults to testing.
+
+- `type script_type`
+   unicode
+
+- `param hardware_type`
+   The hardware_type defines what type of hardware
+       the script is assoicated with. May be CPU, memory, storage, or node.
+
+- `type hardware_type`
+   unicode
+
+- `param parallel`
+   Whether the script may be run in parallel with other
+       scripts. May be disabled to run by itself, instance to run along
+        scripts with the same name, or any to run along any script.
+
+- `type parallel`
+   unicode
+
+- `param timeout`
+   How long the script is allowed to run before failing.
+       0 gives unlimited time, defaults to 0.
+
+- `type timeout`
+   unicode
+
+- `param timeout`
+   How long the script is allowed to run before failing.
+       0 gives unlimited time, defaults to 0.
+
+- `type timeout`
+   unicode
+
+- `param destructive`
+   Whether or not the script overwrites data on any
+       drive on the running system. Destructive scripts can not be run on
+        deployed systems. Defaults to false.
+
+- `type destructive`
+   boolean
+
+- `param script`
+   The content of the script to be uploaded in binary form.
+       note- ` this is not a normal parameter, but a file upload. Its
+        filename is ignored; MAAS will know it by the name you pass to the
+        request. Optionally you can ignore the name and script parameter in
+        favor of uploading a single file as part of the request.
+
+- `param comment`
+   A comment about what this change does.
+
+- `type comment`
+   unicode
+
+- `param for_hardware`
+   A list of modalias, PCI IDs, and/or USB IDs the
+       script will automatically run on. Must start with modalias- `,
+        pci- `
+
+,
+   or usb- `.
+
+- `type for_hardware`
+   unicode
+
+- `param may_reboot`
+   Whether or not the script may reboot the system
+       while running.
+
+- `type may_reboot`
+   boolean
+
+- `param recommission`
+   Whether builtin commissioning scripts should be
+       rerun after successfully running this scripts.
+
+- `type recommission`
+   boolean
+
+### Node Script Result
+
+Manage node script results.
+
+#### `DELETE /api/2.0/nodes/{system_id}/results/{id}/`
+
+Delete a set of results.
+
+id can either by the script set id, current-commissioning, current-testing, or
+current-installation.
+
+#### `GET /api/2.0/nodes/{system_id}/results/{id}/`
+
+View a specific set of results.
+
+id can either by the script set id, current-commissioning, current-testing, or
+current-installation.
+
+- `param hardware_type`
+   Only return scripts for the given hardware type.
+       Can be node, cpu, memory, or storage. Defaults to all.
+
+- `type script_type`
+   unicode
+
+- `param include_output`
+   Include base64 encoded output from the script.
+
+- `type include_output`
+   bool
+
+- `param filters`
+   A comma seperated list to show only results that ran
+       with a script name, tag, or id.
+
+- `type filters`
+   unicode
+
+#### `GET /api/2.0/nodes/{system_id}/results/{id}/ op=download`
+
+Download a compressed tar containing all results.
+
+id can either by the script set id, current-commissioning, current-testing, or
+current-installation.
+
+- `param hardware_type`
+   Only return scripts for the given hardware type.
+       Can be node, cpu, memory, or storage. Defaults to all.
+
+- `type script_type`
+   unicode
+
+- `param filters`
+   A comma seperated list to show only results that ran
+       with a script name or tag.
+
+- `type filters`
+   unicode
+
+- `param output`
+   Can be either combined, stdout, stderr, or all. By
+       default only the combined output is returned.
+
+- `type output`
+   unicode
+
+- `param filetype`
+   Filetype to output, can be txt or tar.xz
+
+- `type format`
+   unicode
+
+### Node Script Result
+
+Manage node script results.
+
+#### `GET /api/2.0/nodes/{system_id}/results/`
+
+Return a list of script results grouped by run.
+
+- `param type`
+   Only return scripts with the given type. This can be
+       commissioning, testing, or installion. Defaults to showing all.
+
+- `type type`
+   unicode
+
+- `param hardware_type`
+   Only return scripts for the given hardware type.
+       Can be node, cpu, memory, or storage. Defaults to all.
+
+- `type script_type`
+   unicode
+
+- `param include_output`
+   Include base64 encoded output from the script.
+
+- `type include_output`
+   bool
+
+- `param filters`
+   A comma seperated list to show only results
+       with a script name or tag.
+
+- `type filters`
+   unicode
+
+### Node Scripts
+
+Manage custom scripts.
+
+> This functionality is only available to administrators.
+
+#### `GET /api/2.0/scripts/`
+
+Return a list of stored scripts.
+
+- `param type`
+   Only return scripts with the given type. This can be
+       testing or commissioning. Defaults to showing both.
+
+- `type type`
+   unicode
+
+- `param hardware_type`
+   Only return scripts for the given hardware type.
+       Can be node, cpu, memory, or storage. Defaults to all.
+
+- `type hardware_type`
+   unicode
+
+- `param include_script`
+   Include the base64 encoded script content.
+
+- `type include_script`
+   bool
+
+- `param filters`
+   A comma seperated list to show only results
+       with a script name or tag.
+
+- `type filters`
+   unicode
+
+#### `POST /api/2.0/scripts/`
+
+Create a new script.
+
+- `param name`
+   The name of the script.
+
+- `type name`
+   unicode
+
+- `param title`
+   The title of the script.
+
+- `type title`
+   unicode
+
+- `param description`
+   A description of what the script does.
+
+- `type description`
+   unicode
+
+- `param tags`
+   A comma seperated list of tags for this script.
+
+- `type tags`
+   unicode
+
+- `param type`
+   The script_type defines when the script should be used.
+       Can be testing or commissioning, defaults to testing.
+
+- `type script_type`
+   unicode
+
+- `param hardware_type`
+   The hardware_type defines what type of hardware
+       the script is assoicated with. May be CPU, memory, storage, or node.
+
+- `type hardware_type`
+   unicode
+
+- `param parallel`
+   Whether the script may be run in parallel with other
+       scripts. May be disabled to run by itself, instance to run along
+        scripts with the same name, or any to run along any script.
+
+- `type parallel`
+   unicode
+
+- `param timeout`
+   How long the script is allowed to run before failing.
+       0 gives unlimited time, defaults to 0.
+
+- `type timeout`
+   unicode
+
+- `param destructive`
+   Whether or not the script overwrites data on any
+       drive on the running system. Destructive scripts can not be run on
+        deployed systems. Defaults to false.
+
+- `type destructive`
+   boolean
+
+- `param script`
+   The content of the script to be uploaded in binary form.
+       note- ` this is not a normal parameter, but a file upload. Its
+        filename is ignored; MAAS will know it by the name you pass to the
+        request. Optionally you can ignore the name and script parameter in
+        favor of uploading a single file as part of the request.
+
+- `type script`
+   unicode
+
+- `param comment`
+   A comment about what this change does.
+
+- `type comment`
+   unicode
+
+- `param for_hardware`
+   A list of modalias, PCI IDs, and/or USB IDs the
+       script will automatically run on. Must start with modalias- `,
+        pci- `
+
+,
+   or usb- `.
+
+- `type for_hardware`
+   unicode
+
+- `param may_reboot`
+   Whether or not the script may reboot the system
+       while running.
+
+- `type may_reboot`
+   boolean
+
+- `param recommission`
+   Whether builtin commissioning scripts should be
+       rerun after successfully running this scripts.
+
+- `type recommission`
+   boolean
 
 ### Nodes
 
 Manage the collection of all the nodes in the MAAS.
 
-##### `GET /api/2.0/nodes/`
+#### `GET /api/2.0/nodes/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
 - `param hostname`
-   An optional hostname. Only nodes relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to see multiple nodes.
+   An optional hostname. Only nodes relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to see multiple nodes.
 
 - `type hostname`
    unicode
 
-- `param mac\_address`
-   An optional MAC address. Only nodes relating to the node owning the
-    specified MAC address will be returned. This can be specified multiple
-    times to see multiple nodes.
+- `param mac_address`
+   An optional MAC address. Only nodes relating to the
+       node owning the specified MAC address will be returned. This can be
+        specified multiple times to see multiple nodes.
 
-- `type mac\_address`
+- `type mac_address`
    unicode
 
 - `param id`
-   An optional list of system ids. Only nodes relating to the nodes with
-    matching system ids will be returned.
+   An optional list of system ids. Only nodes relating to the
+       nodes with matching system ids will be returned.
 
 - `type id`
    unicode
 
 - `param domain`
-   An optional name for a dns domain. Only nodes relating to the nodes in
-    the domain will be returned.
+   An optional name for a dns domain. Only nodes relating
+       to the nodes in the domain will be returned.
 
 - `type domain`
    unicode
 
 - `param zone`
-   An optional name for a physical zone. Only nodes relating to the nodes
-    in the zone will be returned.
+   An optional name for a physical zone. Only nodes relating
+       to the nodes in the zone will be returned.
 
 - `type zone`
    unicode
 
-- `param agent\_name`
-   An optional agent name. Only nodes relating to the nodes with matching
-    agent names will be returned.
+- `param agent_name`
+   An optional agent name. Only nodes relating to the
+       nodes with matching agent names will be returned.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
-##### `POST /api/2.0/nodes/` `op=set_zone`
+#### `GET /api/2.0/nodes/ op=is_registered`
+
+Returns whether or not the given MAC address is registered within this MAAS
+(and attached to a non-retired node).
+
+- `param mac_address`
+   The mac address to be checked.
+
+- `type mac_address`
+   unicode
+
+- `return`
+   'true' or 'false'.
+
+- `rtype`
+   unicode
+
+Returns 400 if any mandatory parameters are missing.
+
+#### `POST /api/2.0/nodes/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
 - `param zone`
-   Zone name. If omitted, the zone is "none" and the nodes will be taken
-    out of their physical zones.
+   Zone name. If omitted, the zone is "none" and the nodes
+       will be taken out of their physical zones.
 
 - `param nodes`
-   system\_ids of the nodes whose zones are to be set. (An empty list
-    is acceptable).
+   system_ids of the nodes whose zones are to be set.
+       (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
+
+### Notification
+
+Manage an individual notification.
+
+#### `DELETE /api/2.0/notifications/{id}/`
+
+Delete a specific notification.
+
+#### `GET /api/2.0/notifications/{id}/`
+
+Read a specific notification.
+
+#### `POST /api/2.0/notifications/{id}/ op=dismiss`
+
+Dismiss a specific notification.
+
+Returns HTTP 403 FORBIDDEN if this notification is not relevant (targeted) to
+the invoking user.
+
+It is safe to call multiple times for the same notification.
+
+#### `PUT /api/2.0/notifications/{id}/`
+
+Update a specific notification.
+
+See NotificationsHandler.create for field information.
+
+### Notifications
+
+Manage the collection of all the notifications in MAAS.
+
+#### `GET /api/2.0/notifications/`
+
+List notifications relevant to the invoking user.
+
+Notifications that have been dismissed are *not* returned.
+
+#### `POST /api/2.0/notifications/`
+
+Create a notification.
+
+This is available to admins *only*.
+
+- `param message`
+   The message for this notification. May contain basic
+       HTML; this will be sanitised before display.
+
+- `param context`
+   Optional JSON context. The root object *must* be an
+       object (i.e. a mapping). The values herein can be referenced by
+        message with Python's "format" (not %) codes.
+
+- `param category`
+   Optional category. Choose from- ` error, warning,
+       success, or info. Defaults to info.
+
+- `param ident`
+   Optional unique identifier for this notification.
+
+- `param user`
+   Optional user ID this notification is intended for. By
+       default it will not be targeted to any individual user.
+
+- `param users`
+   Optional boolean, true to notify all users, defaults to
+       false, i.e. not targeted to all users.
+
+- `param admins`
+   Optional boolean, true to notify all admins, defaults to
+       false, i.e. not targeted to all admins.
+
+Note- ` if neither user nor users nor admins is set, the notification will
+not be seen by anyone.
 
 ### Package Repositories
 
 Manage the collection of all Package Repositories in MAAS.
 
-##### `GET /api/2.0/package-repositories/`
+#### `GET /api/2.0/package-repositories/`
 
 List all Package Repositories.
 
-##### `POST /api/2.0/package-repositories/`
+#### `POST /api/2.0/package-repositories/`
 
 Create a Package Repository.
 
@@ -3848,11 +4684,16 @@ Create a Package Repository.
 - `type distributions`
    unicode
 
-- `param disabled\_pockets`
+- `param disabled_pockets`
    The list of pockets to disable.
 
+- `param disabled_components`
+   The list of components to disable. Only
+       applicable to the default Ubuntu repositories.
+
 - `param components`
-   The list of components to enable.
+   The list of components to enable. Only applicable
+       to custom repositories.
 
 - `param arches`
    The list of supported architectures.
@@ -3875,19 +4716,19 @@ Manage an individual Package Repository.
 
 > The Package Repository is identified by its id.
 
-##### `DELETE /api/2.0/package-repositories/{id}/`
+#### `DELETE /api/2.0/package-repositories/{id}/`
 
 Delete a Package Repository.
 
 Returns 404 if the Package Repository is not found.
 
-##### `GET /api/2.0/package-repositories/{id}/`
+#### `GET /api/2.0/package-repositories/{id}/`
 
 Read Package Repository.
 
 Returns 404 if the repository is not found.
 
-##### `PUT /api/2.0/package-repositories/{id}/`
+#### `PUT /api/2.0/package-repositories/{id}/`
 
 Update a Package Repository.
 
@@ -3909,11 +4750,16 @@ Update a Package Repository.
 - `type distributions`
    unicode
 
-- `param disabled\_pockets`
+- `param disabled_pockets`
    The list of pockets to disable.
 
+- `param disabled_components`
+   The list of components to disable. Only
+       applicable to the default Ubuntu repositories.
+
 - `param components`
-   The list of components to enable.
+   The list of components to enable. Only applicable
+       to custom repositories.
 
 - `param arches`
    The list of supported architectures.
@@ -3936,19 +4782,19 @@ Returns 404 if the Package Repository is not found.
 
 Manage partition on a block device.
 
-##### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
+#### `DELETE /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
 
 Delete partition.
 
 Returns 404 if the node, block device, or partition are not found.
 
-##### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
+#### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}`
 
 Read partition.
 
 Returns 404 if the node, block device, or partition are not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}` `op=format`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=format`
 
 Format a partition.
 
@@ -3961,155 +4807,325 @@ Format a partition.
 - `param label`
    The label for the filesystem.
 
-Returns 403 when the user doesn't have the ability to format the
-partition. Returns 404 if the node, block device, or partition is
-not found.
+Returns 403 when the user doesn't have the ability to format the partition.
+Returns 404 if the node, block device, or partition is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}` `op=mount`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=mount`
 
 Mount the filesystem on partition.
 
-- `param mount\_point`
+- `param mount_point`
    Path on the filesystem to mount.
 
-- `param mount\_options`
+- `param mount_options`
    Options to pass to mount(8).
 
 Returns 403 when the user doesn't have the ability to mount the partition.
 Returns 404 if the node, block device, or partition is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}` `op=unformat`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unformat`
 
 Unformat a partition.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id}` `op=unmount`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partition/{id} op=unmount`
 
 Unmount the filesystem on partition.
 
 Returns 400 if the partition is not formatted or not currently mounted.
-Returns 403 when the user doesn't have the ability to unmount the
-partition. Returns 404 if the node, block device, or partition is
-not found.
+Returns 403 when the user doesn't have the ability to unmount the partition.
+Returns 404 if the node, block device, or partition is not found.
 
 ### Partitions
 
 Manage partitions on a block device.
 
-##### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
+#### `GET /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
 
 List all partitions on the block device.
 
 Returns 404 if the node or the block device are not found.
 
-##### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
+#### `POST /api/2.0/nodes/{system_id}/blockdevices/{device_id}/partitions/`
 
 Create a partition on the block device.
 
 - `param size`
-   The size of the partition.
+   The size of the partition. If not specified, all
+       available space will be used.
 
 - `param uuid`
-   UUID for the partition. Only used if the partition table type for the
-    block device is GPT.
+   UUID for the partition. Only used if the partition table
+   - `type for the block device is GPT.`
 
 - `param bootable`
    If the partition should be marked bootable.
 
 Returns 404 if the node or the block device are not found.
 
+### Pod
+
+Manage an individual pod.
+
+> The pod is identified by its id.
+
+#### `DELETE /api/2.0/pods/{id}/`
+
+Delete a specific Pod.
+
+Returns 404 if the pod is not found. Returns 403 if the user does not have
+permission to delete the pod. Returns 204 if the pod is successfully deleted.
+
+#### `GET /api/2.0/pods/{id}/`
+
+#### `GET /api/2.0/pods/{id}/ op=parameters`
+
+Obtain pod parameters.
+
+This method is reserved for admin users and returns a 403 if the user is not
+one.
+
+This returns the pod parameters, if any, configured for a pod. For some types
+of pod this will include private information such as passwords and secret
+keys.
+
+Returns 404 if the pod is not found.
+
+#### `POST /api/2.0/pods/{id}/ op=add_tag`
+
+Add a tag to Pod.
+
+- `param tag`
+   The tag being added.
+
+Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
+update the Pod.
+
+#### `POST /api/2.0/pods/{id}/ op=compose`
+
+Compose a machine from Pod.
+
+All fields below are optional- `
+
+- `param cores`
+   Minimum number of CPU cores.
+
+- `param memory`
+   Minimum amount of memory (MiB).
+
+- `param cpu_speed`
+   Minimum amount of CPU speed (MHz).
+
+- `param architecture`
+   Architecture for the machine. Must be an
+       architecture that the pod supports.
+
+- `param storage`
+   A list of storage constraint identifiers, in the form- `
+       &lt;label&gt;- `&lt;size&gt;(&lt;tag&gt;\[,&lt;tag&gt;\[,...\])\]\[,&lt;label&gt;`
+
+> ...\]
+
+- `type storage`
+   unicode
+
+- `param hostname`
+   Hostname for the newly composed machine.
+
+- `type hostname`
+   unicode
+
+- `param domain`
+   ID of domain to place the newly composed machine in.
+
+- `param zone`
+   ID of zone place the newly composed machine in.
+
+Returns 404 if the pod is not found. Returns 403 if the user does not have
+permission to compose machine.
+
+#### `POST /api/2.0/pods/{id}/ op=refresh`
+
+Refresh a specific Pod.
+
+Performs pod discovery and updates all discovered information and discovered
+machines.
+
+Returns 404 if the pod is not found. Returns 403 if the user does not have
+permission to refresh the pod.
+
+#### `POST /api/2.0/pods/{id}/ op=remove_tag`
+
+Remove a tag from Pod.
+
+- `param tag`
+   The tag being removed.
+
+Returns 404 if the Pod is not found. Returns 403 if the user is not allowed to
+update the Pod.
+
+#### `PUT /api/2.0/pods/{id}/`
+
+Update a specific Pod.
+
+- `param name`
+   Name for the pod (optional).
+
+Note- ` 'type' cannot be updated on a Pod. The Pod must be deleted and
+re-added to change the type.
+
+Returns 404 if the pod is not found. Returns 403 if the user does not have
+permission to update the pod.
+
+### Pods
+
+Manage the collection of all the pod in the MAAS.
+
+#### `GET /api/2.0/pods/`
+
+List pods.
+
+Get a listing of all the pods.
+
+#### `POST /api/2.0/pods/`
+
+Create a Pod.
+
+- `param type`
+   Type of pod to create (rsd, virsh).
+
+- `param name`
+   Name for the pod (optional).
+
+- `param zone`
+   Name of the zone for the pod (optional).
+
+- `param tags`
+   A tag or tags (separated by comma) for the pod.
+
+Returns 503 if the pod could not be discovered. Returns 404 if the pod is not
+found. Returns 403 if the user does not have permission to create a pod.
+
 ### RackController
 
 Manage an individual rack controller.
 
-> The rack controller is identified by its system\_id.
+> The rack controller is identified by its system_id.
 
-##### `DELETE /api/2.0/rackcontrollers/{system_id}/`
+#### `DELETE /api/2.0/rackcontrollers/{system_id}/`
 
 Delete a specific Node.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to delete the node. Returns 204 if the node is
-successfully deleted.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to delete the node. Returns 204 if the node is successfully
+deleted.
 
-##### `GET /api/2.0/rackcontrollers/{system_id}/`
+#### `GET /api/2.0/rackcontrollers/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/rackcontrollers/{system_id}/` `op=details`
+#### `GET /api/2.0/rackcontrollers/{system_id}/ op=details`
 
 Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
-Note that this is returned as BSON and not JSON. This is for efficiency,
-but mainly because JSON can't do binary content without applying
-additional encoding like base-64.
+Note that this is returned as BSON and not JSON. This is for efficiency, but
+mainly because JSON can't do binary content without applying additional
+encoding like base-64.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/rackcontrollers/{system_id}/` `op=list_boot_images`
+#### `GET /api/2.0/rackcontrollers/{system_id}/ op=list_boot_images`
 
 List all available boot images.
 
-Shows all available boot images and lists whether they are in sync with
-the region.
+Shows all available boot images and lists whether they are in sync with the
+region.
 
 Returns 404 if the rack controller is not found.
 
-##### `GET /api/2.0/rackcontrollers/{system_id}/` `op=power_parameters`
+#### `GET /api/2.0/rackcontrollers/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
-This method is reserved for admin users and returns a 403 if the user is
-not one.
+This method is reserved for admin users and returns a 403 if the user is not
+one.
 
 This returns the power parameters, if any, configured for a node. For some
-types of power control this will include private information such as
-passwords and secret keys.
+types of power control this will include private information such as passwords
+and secret keys.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/rackcontrollers/{system_id}/` `op=query_power_state`
+#### `GET /api/2.0/rackcontrollers/{system_id}/ op=query_power_state`
 
 Query the power state of a node.
 
-Send a request to the node's power controller which asks it about the
-node's state. The reply to this could be delayed by up to 30 seconds while
-waiting for the power controller to respond. Use this method sparingly as
-it ties up an appserver thread while waiting.
+Send a request to the node's power controller which asks it about the node's
+state. The reply to this could be delayed by up to 30 seconds while waiting
+for the power controller to respond. Use this method sparingly as it ties up
+an appserver thread while waiting.
 
-- `param system\_id`
+- `param system_id`
    The node to query.
 
 - `return`
-   a dict whose key is "state" with a value of one of 'on' or 'off'.
+   a dict whose key is "state" with a value of one of
+       'on' or 'off'.
 
 Returns 404 if the node is not found. Returns node's power state.
 
-##### `POST /api/2.0/rackcontrollers/{system_id}/` `op=import_boot_images`
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=abort`
+
+Abort a node's current operation.
+
+- `param comment`
+   Optional comment for the event log.
+
+- `type comment`
+   unicode
+
+Returns 404 if the node could not be found. Returns 403 if the user does not
+have permission to abort the current operation.
+
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=import_boot_images`
 
 Import the boot images on this rack controller.
 
 Returns 404 if the rack controller is not found.
 
-##### `POST /api/2.0/rackcontrollers/{system_id}/` `op=power_off`
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=override_failed_testing`
+
+Ignore failed tests and put node back into a usable state.
+
+- `param comment`
+   Optional comment for the event log.
+
+- `type comment`
+   unicode
+
+Returns 404 if the machine is not found. Returns 403 if the user does not have
+permission to ignore tests for the node.
+
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_off`
 
 Power off a node.
 
-- `param stop\_mode`
-   An optional power off mode. If 'soft', perform a soft power down if
-    the node's power type supports it, otherwise perform a hard power off.
-    For all values other than 'soft', and by default, perform a hard
-    power off. A soft power off generally asks the OS to shutdown the
-    system gracefully before powering off, while a hard power off occurs
-    immediately without any warning to the OS.
+- `param stop_mode`
+   An optional power off mode. If 'soft',
+       perform a soft power down if the node's power type supports it,
+        otherwise perform a hard power off. For all values other than 'soft',
+        and by default, perform a hard power off. A soft power off generally
+        asks the OS to shutdown the system gracefully before powering off,
+        while a hard power off occurs immediately without any warning to the
+        OS.
 
-- `type stop\_mode`
+- `type stop_mode`
    unicode
 
 - `param comment`
@@ -4118,18 +5134,18 @@ Power off a node.
 - `type comment`
    unicode
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to stop the node.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to stop the node.
 
-##### `POST /api/2.0/rackcontrollers/{system_id}/` `op=power_on`
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=power_on`
 
 Turn on a node.
 
-- `param user\_data`
-   If present, this blob of user-data to be made available to the nodes
-    through the metadata service.
+- `param user_data`
+   If present, this blob of user-data to be made
+       available to the nodes through the metadata service.
 
-- `type user\_data`
+- `type user_data`
    base64-encoded unicode
 
 - `param comment`
@@ -4138,147 +5154,195 @@ Turn on a node.
 - `type comment`
    unicode
 
-Ideally we'd have MIME multipart and content-transfer-encoding etc. deal
-with the encapsulation of binary data, but couldn't make it work with the
-framework in reasonable time so went for a dumb, manual encoding instead.
+Ideally we'd have MIME multipart and content-transfer-encoding etc. deal with
+the encapsulation of binary data, but couldn't make it work with the framework
+in reasonable time so went for a dumb, manual encoding instead.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to start the machine. Returns 503 if the start-up
-attempted to allocate an IP address, and there were no IP addresses
-available on the relevant cluster interface.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to start the machine. Returns 503 if the start-up attempted to
+allocate an IP address, and there were no IP addresses available on the
+relevant cluster interface.
 
-##### `PUT /api/2.0/rackcontrollers/{system_id}/`
+#### `POST /api/2.0/rackcontrollers/{system_id}/ op=test`
+
+Begin testing process for a node.
+
+- `param enable_ssh`
+   Whether to enable SSH for the testing environment
+       using the user's SSH key(s).
+
+- `type enable_ssh`
+   bool ('0' for False, '1' for True)
+
+- `param testing_scripts`
+   A comma seperated list of testing script names
+       and tags to be run. By default all tests tagged 'commissioning' will
+        be run.
+
+- `type testing_scripts`
+   string
+
+A node in the 'ready', 'allocated', 'deployed', 'broken', or any failed state
+may run tests. If testing is started and successfully passes from a 'broken',
+or any failed state besides 'failed commissioning' the node will be returned
+to a ready state. Otherwise the node will return to the state it was when
+testing started.
+
+Returns 404 if the node is not found.
+
+#### `PUT /api/2.0/rackcontrollers/{system_id}/`
 
 Update a specific Rack controller.
 
-- `param power\_type`
-   The new power type for this rack controller. If you use the default
-    value, power\_parameters will be set to the empty string. Available to
-    admin users. See the Power types\_ section for a list of the available
-    power types.
+- `param power_type`
+   The new power type for this rack controller. If you
+       use the default value, power_parameters will be set to the empty
+        string. Available to admin users. See the [Power types]() section for
+        a list of the available power types.
 
-- `type power\_type`
+- `type power_type`
    unicode
 
-- `param power\_parameters\_{param1}`
-   The new value for the 'param1' power parameter. Note that this is
-    dynamic as the available parameters depend on the selected value of
-    the rack controller's power\_type. Available to admin users. See the
-    Power types\_ section for a list of the available power parameters for
-    each power type.
+- `param [power_parameters](){param1}`
+   The new value for the 'param1'
+       power parameter. Note that this is dynamic as the available parameters
+        depend on the selected value of the rack controller's power_type.
+        Available to admin users. See the [Power types]() section for a list
+        of the available power parameters for each power type.
 
-- `type power\_parameters\_{param1}`
+- `type [power_parameters](){param1}`
    unicode
 
-- `param power\_parameters\_skip\_check`
-   Whether or not the new power parameters for this rack controller
-    should be checked against the expected power parameters for the rack
-    controller's power type ('true' or 'false'). The default is 'false'.
+- `param power_parameters_skip_check`
+   Whether or not the new power
+       parameters for this rack controller should be checked against the
+        expected power parameters for the rack controller's power type ('true'
+        or 'false'). The default is 'false'.
 
-- `type power\_parameters\_skip\_check`
+- `type power_parameters_skip_check`
    unicode
 
 - `param zone`
-   Name of a valid physical zone in which to place this rack controller.
+   Name of a valid physical zone in which to place this
+       rack controller.
 
 - `type zone`
    unicode
 
-Returns 404 if the rack controller is not found. Returns 403 if the user
-does not have permission to update the rack controller.
+Returns 404 if the rack controller is not found. Returns 403 if the user does
+not have permission to update the rack controller.
 
 ### RackControllers
 
 Manage the collection of all rack controllers in MAAS.
 
-##### `GET /api/2.0/rackcontrollers/`
+#### `GET /api/2.0/rackcontrollers/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
 - `param hostname`
-   An optional hostname. Only nodes relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to see multiple nodes.
+   An optional hostname. Only nodes relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to see multiple nodes.
 
 - `type hostname`
    unicode
 
-- `param mac\_address`
-   An optional MAC address. Only nodes relating to the node owning the
-    specified MAC address will be returned. This can be specified multiple
-    times to see multiple nodes.
+- `param mac_address`
+   An optional MAC address. Only nodes relating to the
+       node owning the specified MAC address will be returned. This can be
+        specified multiple times to see multiple nodes.
 
-- `type mac\_address`
+- `type mac_address`
    unicode
 
 - `param id`
-   An optional list of system ids. Only nodes relating to the nodes with
-    matching system ids will be returned.
+   An optional list of system ids. Only nodes relating to the
+       nodes with matching system ids will be returned.
 
 - `type id`
    unicode
 
 - `param domain`
-   An optional name for a dns domain. Only nodes relating to the nodes in
-    the domain will be returned.
+   An optional name for a dns domain. Only nodes relating
+       to the nodes in the domain will be returned.
 
 - `type domain`
    unicode
 
 - `param zone`
-   An optional name for a physical zone. Only nodes relating to the nodes
-    in the zone will be returned.
+   An optional name for a physical zone. Only nodes relating
+       to the nodes in the zone will be returned.
 
 - `type zone`
    unicode
 
-- `param agent\_name`
-   An optional agent name. Only nodes relating to the nodes with matching
-    agent names will be returned.
+- `param agent_name`
+   An optional agent name. Only nodes relating to the
+       nodes with matching agent names will be returned.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
-##### `GET /api/2.0/rackcontrollers/` `op=describe_power_types`
+#### `GET /api/2.0/rackcontrollers/ op=describe_power_types`
 
 Query all of the rack controllers for power information.
 
 - `return`
    a list of dicts that describe the power types in this format.
 
-##### `GET /api/2.0/rackcontrollers/` `op=power_parameters`
+#### `GET /api/2.0/rackcontrollers/ op=is_registered`
+
+Returns whether or not the given MAC address is registered within this MAAS
+(and attached to a non-retired node).
+
+- `param mac_address`
+   The mac address to be checked.
+
+- `type mac_address`
+   unicode
+
+- `return`
+   'true' or 'false'.
+
+- `rtype`
+   unicode
+
+Returns 400 if any mandatory parameters are missing.
+
+#### `GET /api/2.0/rackcontrollers/ op=power_parameters`
 
 Retrieve power parameters for multiple machines.
 
 - `param id`
-   An optional list of system ids. Only machines with matching system ids
-    will be returned.
+   An optional list of system ids. Only machines with
+       matching system ids will be returned.
 
 - `type id`
    iterable
 
 - `return`
-   A dictionary of power parameters, keyed by machine system\_id.
+   A dictionary of power parameters, keyed by machine system_id.
 
 Raises 403 if the user is not an admin.
 
-##### `POST /api/2.0/rackcontrollers/` `op=import_boot_images`
+#### `POST /api/2.0/rackcontrollers/ op=import_boot_images`
 
 Import the boot images on all rack controllers.
 
-##### `POST /api/2.0/rackcontrollers/` `op=set_zone`
+#### `POST /api/2.0/rackcontrollers/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
 - `param zone`
-   Zone name. If omitted, the zone is "none" and the nodes will be taken
-    out of their physical zones.
+   Zone name. If omitted, the zone is "none" and the nodes
+       will be taken out of their physical zones.
 
 - `param nodes`
-   system\_ids of the nodes whose zones are to be set. (An empty list
-    is acceptable).
+   system_ids of the nodes whose zones are to be set.
+       (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -4286,20 +5350,20 @@ Raises 403 if the user is not an admin.
 
 Manage a specific RAID device on a machine.
 
-##### `DELETE /api/2.0/nodes/{system_id}/raid/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Delete RAID on a machine.
 
-Returns 404 if the machine or RAID is not found. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or RAID is not found. Returns 409 if the machine is
+not Ready.
 
-##### `GET /api/2.0/nodes/{system_id}/raid/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Read RAID device on a machine.
 
 Returns 404 if the machine or RAID is not found.
 
-##### `PUT /api/2.0/nodes/{system_id}/raid/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/raid/{id}/`
 
 Update RAID on a machine.
 
@@ -4309,44 +5373,46 @@ Update RAID on a machine.
 - `param uuid`
    UUID of the RAID.
 
-- `param add\_block\_devices`
+- `param add_block_devices`
    Block devices to add to the RAID.
 
-- `param remove\_block\_devices`
+- `param remove_block_devices`
    Block devices to remove from the RAID.
 
-- `param add\_spare\_devices`
+- `param add_spare_devices`
    Spare block devices to add to the RAID.
 
-- `param remove\_spare\_devices`
-   Spare block devices to remove from the RAID.
+- `param remove_spare_devices`
+   Spare block devices to remove
+       from the RAID.
 
-- `param add\_partitions`
+- `param add_partitions`
    Partitions to add to the RAID.
 
-- `param remove\_partitions`
+- `param remove_partitions`
    Partitions to remove from the RAID.
 
-- `param add\_spare\_partitions`
+- `param add_spare_partitions`
    Spare partitions to add to the RAID.
 
-- `param remove\_spare\_partitions`
-   Spare partitions to remove from the RAID.
+- `param remove_spare_partitions`
+   Spare partitions to remove from the
+       RAID.
 
-Returns 404 if the machine or RAID is not found. Returns 409 if the
-machine is not Ready.
+Returns 404 if the machine or RAID is not found. Returns 409 if the machine is
+not Ready.
 
 ### RAID Devices
 
 Manage all RAID devices on a machine.
 
-##### `GET /api/2.0/nodes/{system_id}/raids/`
+#### `GET /api/2.0/nodes/{system_id}/raids/`
 
 List all RAID devices belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/raids/`
+#### `POST /api/2.0/nodes/{system_id}/raids/`
 
 Creates a RAID
 
@@ -4359,103 +5425,104 @@ Creates a RAID
 - `param level`
    RAID level.
 
-- `param block\_devices`
+- `param block_devices`
    Block devices to add to the RAID.
 
-- `param spare\_devices`
+- `param spare_devices`
    Spare block devices to add to the RAID.
 
 - `param partitions`
    Partitions to add to the RAID.
 
-- `param spare\_partitions`
+- `param spare_partitions`
    Spare partitions to add to the RAID.
 
-Returns 404 if the machine is not found. Returns 409 if the machine is
-not Ready.
+Returns 404 if the machine is not found. Returns 409 if the machine is not
+Ready.
 
 ### RegionController
 
 Manage an individual region controller.
 
-> The region controller is identified by its system\_id.
+> The region controller is identified by its system_id.
 
-##### `DELETE /api/2.0/regioncontrollers/{system_id}/`
+#### `DELETE /api/2.0/regioncontrollers/{system_id}/`
 
 Delete a specific Node.
 
-Returns 404 if the node is not found. Returns 403 if the user does not
-have permission to delete the node. Returns 204 if the node is
-successfully deleted.
+Returns 404 if the node is not found. Returns 403 if the user does not have
+permission to delete the node. Returns 204 if the node is successfully
+deleted.
 
-##### `GET /api/2.0/regioncontrollers/{system_id}/`
+#### `GET /api/2.0/regioncontrollers/{system_id}/`
 
 Read a specific Node.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/regioncontrollers/{system_id}/` `op=details`
+#### `GET /api/2.0/regioncontrollers/{system_id}/ op=details`
 
 Obtain various system details.
 
 For example, LLDP and `lshw` XML dumps.
 
-Returns a `{detail_type: xml, ...}` map, where `detail_type` is something
+Returns a `{detail_type- ` xml, ...}` map, where `detail_type` is something
 like "lldp" or "lshw".
 
-Note that this is returned as BSON and not JSON. This is for efficiency,
-but mainly because JSON can't do binary content without applying
-additional encoding like base-64.
+Note that this is returned as BSON and not JSON. This is for efficiency, but
+mainly because JSON can't do binary content without applying additional
+encoding like base-64.
 
 Returns 404 if the node is not found.
 
-##### `GET /api/2.0/regioncontrollers/{system_id}/` `op=power_parameters`
+#### `GET /api/2.0/regioncontrollers/{system_id}/ op=power_parameters`
 
 Obtain power parameters.
 
-This method is reserved for admin users and returns a 403 if the user is
-not one.
+This method is reserved for admin users and returns a 403 if the user is not
+one.
 
 This returns the power parameters, if any, configured for a node. For some
-types of power control this will include private information such as
-passwords and secret keys.
+types of power control this will include private information such as passwords
+and secret keys.
 
 Returns 404 if the node is not found.
 
-##### `PUT /api/2.0/regioncontrollers/{system_id}/`
+#### `PUT /api/2.0/regioncontrollers/{system_id}/`
 
 Update a specific Region controller.
 
-- `param power\_type`
-   The new power type for this region controller. If you use the default
-    value, power\_parameters will be set to the empty string. Available to
-    admin users. See the Power types\_ section for a list of the available
-    power types.
+- `param power_type`
+   The new power type for this region controller. If
+       you use the default value, power_parameters will be set to the empty
+        string. Available to admin users. See the [Power types]() section for
+        a list of the available power types.
 
-- `type power\_type`
+- `type power_type`
    unicode
 
-- `param power\_parameters\_{param1}`
-   The new value for the 'param1' power parameter. Note that this is
-    dynamic as the available parameters depend on the selected value of
-    the region controller's power\_type. Available to admin users. See the
-    Power types\_ section for a list of the available power parameters for
-    each power type.
+- `param [power_parameters](){param1}`
+   The new value for the 'param1'
+       power parameter. Note that this is dynamic as the available parameters
+        depend on the selected value of the region controller's power_type.
+        Available to admin users. See the [Power types]() section for a list
+        of the available power parameters for each power type.
 
-- `type power\_parameters\_{param1}`
+- `type [power_parameters](){param1}`
    unicode
 
-- `param power\_parameters\_skip\_check`
-   Whether or not the new power parameters for this region controller
-    should be checked against the expected power parameters for the region
-    controller's power type ('true' or 'false'). The default is 'false'.
+- `param power_parameters_skip_check`
+   Whether or not the new power
+       parameters for this region controller should be checked against the
+        expected power parameters for the region controller's power type
+        ('true' or 'false'). The default is 'false'.
 
-- `type power\_parameters\_skip\_check`
+- `type power_parameters_skip_check`
    unicode
 
 - `param zone`
    Name of a valid physical zone in which to place this
-    region controller.
+       region controller.
 
 - `type zone`
    unicode
@@ -4467,67 +5534,86 @@ does not have permission to update the region controller.
 
 Manage the collection of all region controllers in MAAS.
 
-##### `GET /api/2.0/regioncontrollers/`
+#### `GET /api/2.0/regioncontrollers/`
 
 List Nodes visible to the user, optionally filtered by criteria.
 
 Nodes are sorted by id (i.e. most recent last) and grouped by type.
 
 - `param hostname`
-   An optional hostname. Only nodes relating to the node with the
-    matching hostname will be returned. This can be specified multiple
-    times to see multiple nodes.
+   An optional hostname. Only nodes relating to the node
+       with the matching hostname will be returned. This can be specified
+        multiple times to see multiple nodes.
 
 - `type hostname`
    unicode
 
-- `param mac\_address`
-   An optional MAC address. Only nodes relating to the node owning the
-    specified MAC address will be returned. This can be specified multiple
-    times to see multiple nodes.
+- `param mac_address`
+   An optional MAC address. Only nodes relating to the
+       node owning the specified MAC address will be returned. This can be
+        specified multiple times to see multiple nodes.
 
-- `type mac\_address`
+- `type mac_address`
    unicode
 
 - `param id`
-   An optional list of system ids. Only nodes relating to the nodes with
-    matching system ids will be returned.
+   An optional list of system ids. Only nodes relating to the
+       nodes with matching system ids will be returned.
 
 - `type id`
    unicode
 
 - `param domain`
-   An optional name for a dns domain. Only nodes relating to the nodes in
-    the domain will be returned.
+   An optional name for a dns domain. Only nodes relating
+       to the nodes in the domain will be returned.
 
 - `type domain`
    unicode
 
 - `param zone`
-   An optional name for a physical zone. Only nodes relating to the nodes
-    in the zone will be returned.
+   An optional name for a physical zone. Only nodes relating
+       to the nodes in the zone will be returned.
 
 - `type zone`
    unicode
 
-- `param agent\_name`
-   An optional agent name. Only nodes relating to the nodes with matching
-    agent names will be returned.
+- `param agent_name`
+   An optional agent name. Only nodes relating to the
+       nodes with matching agent names will be returned.
 
-- `type agent\_name`
+- `type agent_name`
    unicode
 
-##### `POST /api/2.0/regioncontrollers/` `op=set_zone`
+#### `GET /api/2.0/regioncontrollers/ op=is_registered`
+
+Returns whether or not the given MAC address is registered within this MAAS
+(and attached to a non-retired node).
+
+- `param mac_address`
+   The mac address to be checked.
+
+- `type mac_address`
+   unicode
+
+- `return`
+   'true' or 'false'.
+
+- `rtype`
+   unicode
+
+Returns 400 if any mandatory parameters are missing.
+
+#### `POST /api/2.0/regioncontrollers/ op=set_zone`
 
 Assign multiple nodes to a physical zone at once.
 
 - `param zone`
-   Zone name. If omitted, the zone is "none" and the nodes will be taken
-    out of their physical zones.
+   Zone name. If omitted, the zone is "none" and the nodes
+       will be taken out of their physical zones.
 
 - `param nodes`
-   system\_ids of the nodes whose zones are to be set. (An empty list
-    is acceptable).
+   system_ids of the nodes whose zones are to be set.
+       (An empty list is acceptable).
 
 Raises 403 if the user is not an admin.
 
@@ -4537,14 +5623,14 @@ Manage an SSH key.
 
 > SSH keys can be retrieved or deleted.
 
-##### `DELETE /api/2.0/account/prefs/sshkeys/{id}/`
+#### `DELETE /api/2.0/account/prefs/sshkeys/{id}/`
 
 DELETE an SSH key.
 
-Returns 404 if the key does not exist. Returns 401 if the key does not
-belong to the calling user.
+Returns 404 if the key does not exist. Returns 401 if the key does not belong
+to the calling user.
 
-##### `GET /api/2.0/account/prefs/sshkeys/{id}/`
+#### `GET /api/2.0/account/prefs/sshkeys/{id}/`
 
 GET an SSH key.
 
@@ -4554,23 +5640,23 @@ Returns 404 if the key does not exist.
 
 Manage the collection of all the SSH keys in this MAAS.
 
-##### `GET /api/2.0/account/prefs/sshkeys/`
+#### `GET /api/2.0/account/prefs/sshkeys/`
 
 List all keys belonging to the requesting user.
 
-##### `POST /api/2.0/account/prefs/sshkeys/`
+#### `POST /api/2.0/account/prefs/sshkeys/`
 
 Add a new SSH key to the requesting user's account.
 
-The request payload should contain the public SSH key data in form data
-whose name is "key".
+The request payload should contain the public SSH key data in form data whose
+name is "key".
 
-##### `POST /api/2.0/account/prefs/sshkeys/` `op=import`
+#### `POST /api/2.0/account/prefs/sshkeys/ op=import`
 
 Import the requesting user's SSH keys.
 
 Import SSH keys for a given protocol and authorization ID in
-protocol:auth\_id format.
+protocol- `auth_id format.
 
 ### SSL Key
 
@@ -4578,52 +5664,52 @@ Manage an SSL key.
 
 > SSL keys can be retrieved or deleted.
 
-##### `DELETE /api/2.0/account/prefs/sslkeys/{id}/`
+#### `DELETE /api/2.0/account/prefs/sslkeys/{id}/`
 
 DELETE an SSL key.
 
-Returns 401 if the key does not belong to the requesting user. Returns 204
-if the key is successfully deleted.
+Returns 401 if the key does not belong to the requesting user. Returns 204 if
+the key is successfully deleted.
 
-##### `GET /api/2.0/account/prefs/sslkeys/{id}/`
+#### `GET /api/2.0/account/prefs/sslkeys/{id}/`
 
 GET an SSL key.
 
-Returns 404 if the key with id is not found. Returns 401 if the key does
-not belong to the requesting user.
+Returns 404 if the key with id is not found. Returns 401 if the key does not
+belong to the requesting user.
 
 ### SSL Keys
 
 Operations on multiple keys.
 
-##### `GET /api/2.0/account/prefs/sslkeys/`
+#### `GET /api/2.0/account/prefs/sslkeys/`
 
 List all keys belonging to the requesting user.
 
-##### `POST /api/2.0/account/prefs/sslkeys/`
+#### `POST /api/2.0/account/prefs/sslkeys/`
 
 Add a new SSL key to the requesting user's account.
 
-The request payload should contain the SSL key data in form data whose
-name is "key".
+The request payload should contain the SSL key data in form data whose name is
+"key".
 
 ### Space
 
 Manage space.
 
-##### `DELETE /api/2.0/spaces/{id}/`
+#### `DELETE /api/2.0/spaces/{id}/`
 
 Delete space.
 
 Returns 404 if the space is not found.
 
-##### `GET /api/2.0/spaces/{id}/`
+#### `GET /api/2.0/spaces/{id}/`
 
 Read space.
 
 Returns 404 if the space is not found.
 
-##### `PUT /api/2.0/spaces/{id}/`
+#### `PUT /api/2.0/spaces/{id}/`
 
 Update space.
 
@@ -4639,11 +5725,11 @@ Returns 404 if the space is not found.
 
 Manage spaces.
 
-##### `GET /api/2.0/spaces/`
+#### `GET /api/2.0/spaces/`
 
 List all spaces.
 
-##### `POST /api/2.0/spaces/`
+#### `POST /api/2.0/spaces/`
 
 Create a space.
 
@@ -4657,19 +5743,19 @@ Create a space.
 
 Manage static route.
 
-##### `DELETE /api/2.0/static-routes/{id}/`
+#### `DELETE /api/2.0/static-routes/{id}/`
 
 Delete static route.
 
 Returns 404 if the static route is not found.
 
-##### `GET /api/2.0/static-routes/{id}/`
+#### `GET /api/2.0/static-routes/{id}/`
 
 Read static route.
 
 Returns 404 if the static route is not found.
 
-##### `PUT /api/2.0/static-routes/{id}/`
+#### `PUT /api/2.0/static-routes/{id}/`
 
 Update static route.
 
@@ -4679,7 +5765,7 @@ Update static route.
 - `param destination`
    Destination subnet for the route.
 
-- `param gateway\_ip`
+- `param gateway_ip`
    IP address of the gateway on the source subnet.
 
 - `param metric`
@@ -4691,11 +5777,11 @@ Returns 404 if the static route is not found.
 
 Manage static routes.
 
-##### `GET /api/2.0/static-routes/`
+#### `GET /api/2.0/static-routes/`
 
 List all static routes.
 
-##### `POST /api/2.0/static-routes/`
+#### `POST /api/2.0/static-routes/`
 
 Create a static route.
 
@@ -4705,7 +5791,7 @@ Create a static route.
 - `param destination`
    Destination subnet for the route.
 
-- `param gateway\_ip`
+- `param gateway_ip`
    IP address of the gateway on the source subnet.
 
 - `param metric`
@@ -4715,88 +5801,108 @@ Create a static route.
 
 Manage subnet.
 
-##### `DELETE /api/2.0/subnets/{id}/`
+#### `DELETE /api/2.0/subnets/{id}/`
 
 Delete subnet.
 
 Returns 404 if the subnet is not found.
 
-##### `GET /api/2.0/subnets/{id}/`
+#### `GET /api/2.0/subnets/{id}/`
 
 Read subnet.
 
 Returns 404 if the subnet is not found.
 
-##### `GET /api/2.0/subnets/{id}/` `op=ip_addresses`
+#### `GET /api/2.0/subnets/{id}/ op=ip_addresses`
 
 Returns a summary of IP addresses assigned to this subnet.
 
-Optional arguments: with\_username: (default=True) if False, suppresses
-the display of usernames associated with each address.
-with\_node\_summary: (default=True) if False, suppresses the display of
-any node associated with each address.
+##### Optional parameters
 
-##### `GET /api/2.0/subnets/{id}/` `op=reserved_ip_ranges`
+with_username
+   If False, suppresses the display of usernames associated with each
+    address. (Default- ` True)
+
+with_summary
+   If False, suppresses the display of nodes, BMCs, and and DNS records
+    associated with each address. (Default- ` True)
+
+with_node_summary
+   Deprecated form of with_summary.
+
+#### `GET /api/2.0/subnets/{id}/ op=reserved_ip_ranges`
 
 Lists IP ranges currently reserved in the subnet.
 
 Returns 404 if the subnet is not found.
 
-##### `GET /api/2.0/subnets/{id}/` `op=statistics`
+#### `GET /api/2.0/subnets/{id}/ op=statistics`
 
-Returns statistics for the specified subnet, including:
+Returns statistics for the specified subnet, including- `
 
-num\_available - the number of available IP addresses largest\_available -
-the largest number of contiguous free IP addresses num\_unavailable - the
-number of unavailable IP addresses total\_addresses - the sum of the
-available plus unavailable addresses usage - the (floating point) usage
-percentage of this subnet usage\_string - the (formatted unicode) usage
-percentage of this subnet ranges - the specific IP ranges present in ths
-subnet (if specified)
+num_available- ` the number of available IP addresses
+largest_available- ` the largest number of contiguous free IP addresses
+num_unavailable- ` the number of unavailable IP addresses
+total_addresses- ` the sum of the available plus unavailable addresses
+usage- ` the (floating point) usage percentage of this subnet
+usage_string- ` the (formatted unicode) usage percentage of this subnet
+ranges- ` the specific IP ranges present in ths subnet (if specified)
 
-Optional arguments: include\_ranges: if True, includes detailed
-information about the usage of this range. include\_suggestions: if True,
-includes the suggested gateway and dynamic range for this subnet, if it
-were to be configured.
+##### Optional parameters
+
+include_ranges
+   If True, includes detailed information about the usage of this range.
+
+include_suggestions
+   If True, includes the suggested gateway and dynamic range for this subnet,
+    if it were to be configured.
 
 Returns 404 if the subnet is not found.
 
-##### `GET /api/2.0/subnets/{id}/` `op=unreserved_ip_ranges`
+#### `GET /api/2.0/subnets/{id}/ op=unreserved_ip_ranges`
 
 Lists IP ranges currently unreserved in the subnet.
 
 Returns 404 if the subnet is not found.
 
-##### `PUT /api/2.0/subnets/{id}/`
+#### `PUT /api/2.0/subnets/{id}/`
 
-Update subnet.
+Update the specified subnet.
 
-- `param name`
+Please see the documentation for the 'create' operation for detailed
+descriptions of each parameter.
+
+##### Optional parameters
+
+name
    Name of the subnet.
 
-- `param description`
+description
    Description of the subnet.
 
-- `param vlan`
+vlan
    VLAN this subnet belongs to.
 
-- `param space`
+space
    Space this subnet is in.
 
-- `param cidr`
+cidr
    The network CIDR for this subnet.
 
-- `param gateway\_ip`
+gateway_ip
    The gateway IP address for this subnet.
 
-- `param rdns\_mode`
+rdns_mode
    How reverse DNS is handled for this subnet.
 
-- `param allow\_proxy`
+allow_proxy
    Configure maas-proxy to allow requests from this subnet.
 
-- `param dns\_servers`
+dns_servers
    Comma-seperated list of DNS servers for this subnet.
+
+managed
+   If False, MAAS should not manage this subnet. (Default- ` True)
 
 Returns 404 if the subnet is not found.
 
@@ -4804,55 +5910,74 @@ Returns 404 if the subnet is not found.
 
 Manage subnets.
 
-##### `GET /api/2.0/subnets/`
+#### `GET /api/2.0/subnets/`
 
 List all subnets.
 
-##### `POST /api/2.0/subnets/`
+#### `POST /api/2.0/subnets/`
 
 Create a subnet.
 
-- `param name`
-   Name of the subnet.
+##### Required parameters
 
-- `param description`
-   Description of the subnet.
-
-- `param fabric`
-   Fabric for the subnet. Defaults to the fabric the provided VLAN
-    belongs to or defaults to the default fabric.
-
-- `param vlan`
-   VLAN this subnet belongs to. Defaults to the default VLAN for the
-    provided fabric or defaults to the default VLAN in the default fabric.
-
-- `param vid`
-   VID of the VLAN this subnet belongs to. Only used when vlan is
-    not provided. Picks the VLAN with this VID in the provided fabric or
-    the default fabric if one is not given.
-
-- `param space`
-   Space this subnet is in. Defaults to the default space.
-
-- `param cidr`
+cidr
    The network CIDR for this subnet.
 
-- `param gateway\_ip`
+##### Optional parameters
+
+name
+   Name of the subnet.
+
+description
+   Description of the subnet.
+
+vlan
+   VLAN this subnet belongs to. Defaults to the default VLAN for the provided
+    fabric or defaults to the default VLAN in the default fabric (if
+    unspecified).
+
+fabric
+   Fabric for the subnet. Defaults to the fabric the provided VLAN belongs
+    to, or defaults to the default fabric.
+
+vid
+   VID of the VLAN this subnet belongs to. Only used when vlan is not
+    provided. Picks the VLAN with this VID in the provided fabric or the
+    default fabric if one is not given.
+
+space
+   Space this subnet is in. Defaults to the default space.
+
+gateway_ip
    The gateway IP address for this subnet.
 
-- `param rdns\_mode`
-   How reverse DNS is handled for this subnet. One of: 0 (Disabled), 1
+rdns_mode
+   How reverse DNS is handled for this subnet. One of- ` 0 (Disabled), 1
     (Enabled), or 2 (RFC2317). Disabled means no reverse zone is created;
-    Enabled means generate the reverse zone; RFC2317 extends Enabled to
-    create the necessary parent zone with the appropriate CNAME resource
-    records for the network, if the network is small enough to require the
-    support described in RFC2317.
+    Enabled means generate the reverse zone; RFC2317 extends Enabled to create
+    the necessary parent zone with the appropriate CNAME resource records for
+    the network, if the network is small enough to require the support
+    described in RFC2317.
 
-- `param allow\_proxy`
+allow_proxy
    Configure maas-proxy to allow requests from this subnet.
 
-- `param dns\_servers`
+dns_servers
    Comma-seperated list of DNS servers for this subnet.
+
+managed
+   In MAAS 2.0+, all subnets are assumed to be managed by default.
+
+    Only managed subnets allow DHCP to be enabled on their related dynamic
+    ranges. (Thus, dynamic ranges become "informational only"; an indication
+    that another DHCP server is currently handling them, or that MAAS will
+    handle them when the subnet is enabled for management.)
+
+    Managed subnets do not allow IP allocation by default. The meaning of a
+    "reserved" IP range is reversed for an unmanaged subnet. (That is, for
+    managed subnets, "reserved" means "MAAS cannot allocate any IP address
+    within this reserved block". For unmanaged subnets, "reserved" means "MAAS
+    must allocate IP addresses only from reserved IP ranges".
 
 ### Tag
 
@@ -4863,99 +5988,100 @@ Manage a Tag.
 >
 > A Tag is identified by its name.
 
-##### `DELETE /api/2.0/tags/{name}/`
+#### `DELETE /api/2.0/tags/{name}/`
 
 Delete a specific Tag.
 
-Returns 404 if the tag is not found. Returns 204 if the tag is
-successfully deleted.
+Returns 404 if the tag is not found. Returns 204 if the tag is successfully
+deleted.
 
-##### `GET /api/2.0/tags/{name}/`
+#### `GET /api/2.0/tags/{name}/`
 
 Read a specific Tag.
 
 Returns 404 if the tag is not found.
 
-##### `GET /api/2.0/tags/{name}/` `op=devices`
+#### `GET /api/2.0/tags/{name}/ op=devices`
 
 Get the list of devices that have this tag.
 
 Returns 404 if the tag is not found.
 
-##### `GET /api/2.0/tags/{name}/` `op=machines`
+#### `GET /api/2.0/tags/{name}/ op=machines`
 
 Get the list of machines that have this tag.
 
 Returns 404 if the tag is not found.
 
-##### `GET /api/2.0/tags/{name}/` `op=nodes`
+#### `GET /api/2.0/tags/{name}/ op=nodes`
 
 Get the list of nodes that have this tag.
 
 Returns 404 if the tag is not found.
 
-##### `GET /api/2.0/tags/{name}/` `op=rack_controllers`
+#### `GET /api/2.0/tags/{name}/ op=rack_controllers`
 
 Get the list of rack controllers that have this tag.
 
 Returns 404 if the tag is not found.
 
-##### `GET /api/2.0/tags/{name}/` `op=region_controllers`
+#### `GET /api/2.0/tags/{name}/ op=region_controllers`
 
 Get the list of region controllers that have this tag.
 
 Returns 404 if the tag is not found.
 
-##### `POST /api/2.0/tags/{name}/` `op=rebuild`
+#### `POST /api/2.0/tags/{name}/ op=rebuild`
 
 Manually trigger a rebuild the tag &lt;=&gt; node mapping.
 
-This is considered a maintenance operation, which should normally not
-be necessary. Adding nodes or updating a tag's definition should
-automatically trigger the appropriate changes.
+This is considered a maintenance operation, which should normally not be
+necessary. Adding nodes or updating a tag's definition should automatically
+trigger the appropriate changes.
 
 Returns 404 if the tag is not found.
 
-##### `POST /api/2.0/tags/{name}/` `op=update_nodes`
+#### `POST /api/2.0/tags/{name}/ op=update_nodes`
 
 Add or remove nodes being associated with this tag.
 
 - `param add`
-   system\_ids of nodes to add to this tag.
+   system_ids of nodes to add to this tag.
 
 - `param remove`
-   system\_ids of nodes to remove from this tag.
+   system_ids of nodes to remove from this tag.
 
 - `param definition`
-   (optional) If supplied, the definition will be validated against the
-    current definition of the tag. If the value does not match, then the
-    update will be dropped (assuming this was just a case of a worker
-    being out-of-date)
+   (optional) If supplied, the definition will be
+       validated against the current definition of the tag. If the value does
+        not match, then the update will be dropped (assuming this was just a
+        case of a worker being out-of-date)
 
-- `param rack\_controller`
-   A system ID of a rack controller that did the processing. This value
-    is optional. If not supplied, the requester must be a superuser. If
-    supplied, then the requester must be the rack controller.
+- `param rack_controller`
+   A system ID of a rack controller that did the
+       processing. This value is optional. If not supplied, the requester
+        must be a superuser. If supplied, then the requester must be the rack
+        controller.
 
 Returns 404 if the tag is not found. Returns 401 if the user does not have
-permission to update the nodes. Returns 409 if 'definition' doesn't match
-the current definition.
+permission to update the nodes. Returns 409 if 'definition' doesn't match the
+current definition.
 
-##### `PUT /api/2.0/tags/{name}/`
+#### `PUT /api/2.0/tags/{name}/`
 
 Update a specific Tag.
 
 - `param name`
-   The name of the Tag to be created. This should be a short name, and
-    will be used in the URL of the tag.
+   The name of the Tag to be created. This should be a short
+       name, and will be used in the URL of the tag.
 
 - `param comment`
-   A long form description of what the tag is meant for. It is meant as a
-    human readable description of the tag.
+   A long form description of what the tag is meant for.
+       It is meant as a human readable description of the tag.
 
 - `param definition`
-   An XPATH query that will be evaluated against the hardware\_details
-    stored for all nodes (output of lshw -xml).
+   An XPATH query that will be evaluated against the
+       hardware_details stored for all nodes (output of lshw -xml).
 
 Returns 404 if the tag is not found.
 
@@ -4963,34 +6089,34 @@ Returns 404 if the tag is not found.
 
 Manage the collection of all the Tags in this MAAS.
 
-##### `GET /api/2.0/tags/`
+#### `GET /api/2.0/tags/`
 
 List Tags.
 
 Get a listing of all tags that are currently defined.
 
-##### `POST /api/2.0/tags/`
+#### `POST /api/2.0/tags/`
 
 Create a new Tag.
 
 - `param name`
-   The name of the Tag to be created. This should be a short name, and
-    will be used in the URL of the tag.
+   The name of the Tag to be created. This should be a short
+       name, and will be used in the URL of the tag.
 
 - `param comment`
-   A long form description of what the tag is meant for. It is meant as a
-    human readable description of the tag.
+   A long form description of what the tag is meant for.
+       It is meant as a human readable description of the tag.
 
 - `param definition`
-   An XPATH query that will be evaluated against the hardware\_details
-    stored for all nodes (output of lshw -xml).
+   An XPATH query that will be evaluated against the
+       hardware_details stored for all nodes (output of lshw -xml).
 
-- `param kernel\_opts`
-   Can be None. If set, nodes associated with this tag will add this
-    string to their kernel options when booting. The value overrides the
-    global 'kernel\_opts' setting. If more than one tag is associated with
-    a node, the one with the lowest alphabetical name will be picked (eg
-    01-my-tag will be taken over 99-tag-name).
+- `param kernel_opts`
+   Can be None. If set, nodes associated with this tag
+       will add this string to their kernel options when booting. The value
+        overrides the global 'kernel_opts' setting. If more than one tag is
+        associated with a node, the one with the lowest alphabetical name will
+        be picked (eg 01-my-tag will be taken over 99-tag-name).
 
 Returns 401 if the user is not an admin.
 
@@ -4998,28 +6124,31 @@ Returns 401 if the user is not an admin.
 
 Manage a user account.
 
-##### `DELETE /api/2.0/users/{username}/`
+#### `DELETE /api/2.0/users/{username}/`
 
 Deletes a user
 
-`GET /api/2.0/users/{username}/` Users ===== Manage the user accounts of this
-MAAS.
+#### `GET /api/2.0/users/{username}/`
 
-##### `GET /api/2.0/users/`
+### Users
+
+Manage the user accounts of this MAAS.
+
+#### `GET /api/2.0/users/`
 
 List users.
 
-##### `GET /api/2.0/users/` `op=whoami`
+#### `GET /api/2.0/users/ op=whoami`
 
 Returns the currently logged in user.
 
-##### `POST /api/2.0/users/`
+#### `POST /api/2.0/users/`
 
 Create a MAAS user account.
 
-This is not safe: the password is sent in plaintext. Avoid it for
-production, unless you are confident that you can prevent eavesdroppers
-from observing the request.
+This is not safe- ` the password is sent in plaintext. Avoid it for
+production, unless you are confident that you can prevent eavesdroppers from
+observing the request.
 
 - `param username`
    Identifier-style username for the new user.
@@ -5039,10 +6168,10 @@ from observing the request.
 - `type password`
    unicode
 
-- `param is\_superuser`
+- `param is_superuser`
    Whether the new user is to be an administrator.
 
-- `type is\_superuser`
+- `type is_superuser`
    bool ('0' for False, '1' for True)
 
 Returns 400 if any mandatory parameters are missing.
@@ -5051,15 +6180,16 @@ Returns 400 if any mandatory parameters are missing.
 
 Information about this MAAS instance.
 
-> This returns a JSON dictionary with information about this MAAS instance:
+> This returns a JSON dictionary with information about this MAAS
+> instance- ``
 >
->     {
->         'version': '1.8.0',
->         'subversion': 'alpha10+bzr3750',
->         'capabilities': ['capability1', 'capability2', ...]
->     }
+> > {
+> >    'version'- ` '1.8.0', 'subversion'` 'alpha10+bzr3750',
+> >     'capabilities'- ` \['capability1', 'capability2', ...\]
+> >
+> > }
 
-##### `GET /api/2.0/version/`
+#### `GET /api/2.0/version/`
 
 Version and capabilities of this MAAS instance.
 
@@ -5067,19 +6197,19 @@ Version and capabilities of this MAAS instance.
 
 Manage VLAN on a fabric.
 
-##### `DELETE /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+#### `DELETE /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Delete VLAN on fabric.
 
 Returns 404 if the fabric or VLAN is not found.
 
-##### `GET /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+#### `GET /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Read VLAN on fabric.
 
 Returns 404 if the fabric or VLAN is not found.
 
-##### `PUT /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
+#### `PUT /api/2.0/fabrics/{fabric_id}/vlans/{vid}/`
 
 Update VLAN.
 
@@ -5107,23 +6237,41 @@ Update VLAN.
 - `type mtu`
    integer
 
-Param dhcp\_on
+- `param dhcp_on`
    Whether or not DHCP should be managed on the VLAN.
 
-- `type dhcp\_on`
+- `type dhcp_on`
    boolean
 
-- `param primary\_rack`
+- `param primary_rack`
    The primary rack controller managing the VLAN.
 
-- `type primary\_rack`
-   system\_id
+- `type primary_rack`
+   system_id
 
-- `param secondary\_rack`
+- `param secondary_rack`
    The secondary rack controller manging the VLAN.
 
-- `type secondary\_rack`
-   system\_id
+- `type secondary_rack`
+   system_id
+
+- `param relay_vlan`
+   Only set when this VLAN will be using a DHCP relay
+       to forward DHCP requests to another VLAN that MAAS is or will run the
+        DHCP server. MAAS will not run the DHCP relay itself, it must be
+        configured to proxy reqests to the primary and/or secondary rack
+        controller interfaces for the VLAN specified in this field.
+
+- `type relay_vlan`
+   ID of VLAN
+
+- `param space`
+   The space this VLAN should be placed in. Passing in an
+       empty string (or the string 'undefined') will cause the VLAN to be
+        placed in the 'undefined' space.
+
+- `type space`
+   unicode
 
 Returns 404 if the fabric or VLAN is not found.
 
@@ -5131,43 +6279,66 @@ Returns 404 if the fabric or VLAN is not found.
 
 Manage VLANs on a fabric.
 
-##### `GET /api/2.0/fabrics/{fabric_id}/vlans/`
+#### `GET /api/2.0/fabrics/{fabric_id}/vlans/`
 
 List all VLANs belonging to fabric.
 
 Returns 404 if the fabric is not found.
 
-##### `POST /api/2.0/fabrics/{fabric_id}/vlans/`
+#### `POST /api/2.0/fabrics/{fabric_id}/vlans/`
 
 Create a VLAN.
 
 - `param name`
    Name of the VLAN.
 
+- `type name`
+   unicode
+
 - `param description`
    Description of the VLAN.
 
+- `type description`
+   unicode
+
 - `param vid`
    VLAN ID of the VLAN.
+
+- `type vid`
+   integer
+
+- `param mtu`
+   The MTU to use on the VLAN.
+
+- `type mtu`
+   integer
+
+- `param space`
+   The space this VLAN should be placed in. Passing in an
+       empty string (or the string 'undefined') will cause the VLAN to be
+        placed in the 'undefined' space.
+
+- `type space`
+   unicode
 
 ### Volume group
 
 Manage volume group on a machine.
 
-##### `DELETE /api/2.0/nodes/{system_id}/volume-group/{id}/`
+#### `DELETE /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Delete volume group on a machine.
 
-Returns 404 if the machine or volume group is not found. Returns 409 if
-the machine is not Ready.
+Returns 404 if the machine or volume group is not found. Returns 409 if the
+machine is not Ready.
 
-##### `GET /api/2.0/nodes/{system_id}/volume-group/{id}/`
+#### `GET /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Read volume group on a machine.
 
 Returns 404 if the machine or volume group is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/` `op=create_logical_volume`
+#### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=create_logical_volume`
 
 Create a logical volume in the volume group.
 
@@ -5180,20 +6351,20 @@ Create a logical volume in the volume group.
 - `param size`
    Size of the logical volume.
 
-Returns 404 if the machine or volume group is not found. Returns 409 if
-the machine is not Ready.
+Returns 404 if the machine or volume group is not found. Returns 409 if the
+machine is not Ready.
 
-##### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/` `op=delete_logical_volume`
+#### `POST /api/2.0/nodes/{system_id}/volume-group/{id}/ op=delete_logical_volume`
 
 Delete a logical volume in the volume group.
 
 - `param id`
    ID of the logical volume.
 
-Returns 403 if no logical volume with id. Returns 404 if the machine or
-volume group is not found. Returns 409 if the machine is not Ready.
+Returns 403 if no logical volume with id. Returns 404 if the machine or volume
+group is not found. Returns 409 if the machine is not Ready.
 
-##### `PUT /api/2.0/nodes/{system_id}/volume-group/{id}/`
+#### `PUT /api/2.0/nodes/{system_id}/volume-group/{id}/`
 
 Read volume group on a machine.
 
@@ -5203,32 +6374,33 @@ Read volume group on a machine.
 - `param uuid`
    UUID of the volume group.
 
-- `param add\_block\_devices`
+- `param add_block_devices`
    Block devices to add to the volume group.
 
-- `param remove\_block\_devices`
-   Block devices to remove from the volume group.
+- `param remove_block_devices`
+   Block devices to remove from the
+       volume group.
 
-- `param add\_partitions`
+- `param add_partitions`
    Partitions to add to the volume group.
 
-- `param remove\_partitions`
+- `param remove_partitions`
    Partitions to remove from the volume group.
 
-Returns 404 if the machine or volume group is not found. Returns 409 if
-the machine is not Ready.
+Returns 404 if the machine or volume group is not found. Returns 409 if the
+machine is not Ready.
 
 ### Volume groups
 
 Manage volume groups on a machine.
 
-##### `GET /api/2.0/nodes/{system_id}/volume-groups/`
+#### `GET /api/2.0/nodes/{system_id}/volume-groups/`
 
 List all volume groups belonging to a machine.
 
 Returns 404 if the machine is not found.
 
-##### `POST /api/2.0/nodes/{system_id}/volume-groups/`
+#### `POST /api/2.0/nodes/{system_id}/volume-groups/`
 
 Create a volume group belonging to machine.
 
@@ -5238,41 +6410,41 @@ Create a volume group belonging to machine.
 - `param uuid`
    (optional) UUID of the volume group.
 
-- `param block\_devices`
+- `param block_devices`
    Block devices to add to the volume group.
 
 - `param partitions`
    Partitions to add to the volume group.
 
-Returns 404 if the machine is not found. Returns 409 if the machine is
-not Ready.
+Returns 404 if the machine is not found. Returns 409 if the machine is not
+Ready.
 
 ### Zone
 
 Manage a physical zone.
 
 > Any node is in a physical zone, or "zone" for short. The meaning of a
-> physical zone is up to you: it could identify e.g. a server rack, a network,
-> or a data centre. Users can then allocate nodes from specific physical
-> zones, to suit their redundancy or performance requirements.
+> physical zone is up to you- ` it could identify e.g. a server rack, a
+> network, or a data centre. Users can then allocate nodes from specific
+> physical zones, to suit their redundancy or performance requirements.
 >
 > This functionality is only available to administrators. Other users can view
 > physical zones, but not modify them.
 
-##### `DELETE /api/2.0/zones/{name}/`
+#### `DELETE /api/2.0/zones/{name}/`
 
 DELETE request. Delete zone.
 
-Returns 404 if the zone is not found. Returns 204 if the zone is
-successfully deleted.
+Returns 404 if the zone is not found. Returns 204 if the zone is successfully
+deleted.
 
-##### `GET /api/2.0/zones/{name}/`
+#### `GET /api/2.0/zones/{name}/`
 
 GET request. Return zone.
 
 Returns 404 if the zone is not found.
 
-##### `PUT /api/2.0/zones/{name}/`
+#### `PUT /api/2.0/zones/{name}/`
 
 PUT request. Update zone.
 
@@ -5282,13 +6454,13 @@ Returns 404 if the zone is not found.
 
 Manage physical zones.
 
-##### `GET /api/2.0/zones/`
+#### `GET /api/2.0/zones/`
 
 List zones.
 
 Get a listing of all the physical zones.
 
-##### `POST /api/2.0/zones/`
+#### `POST /api/2.0/zones/`
 
 Create a new physical zone.
 
@@ -5307,152 +6479,196 @@ Create a new physical zone.
 ## Power types
 
 This is the list of the supported power types and their associated power
-parameters. Note that the list of usable power types for a particular cluster
-might be a subset of this list if the cluster in question is from an older
-version of MAAS.
-
-### manual (Manual)
-
-Power parameters:
-
-### virsh (Virsh (virtual systems))
-
-Power parameters:
-
--   power\_address (Power address).
--   power\_id (Power ID).
--   power\_pass (Power password (optional)).
-
-### vmware (VMWare)
-
-Power parameters:
-
--   power\_vm\_name (VM Name (if UUID unknown)).
--   power\_uuid (VM UUID (if known)).
--   power\_address (VMware hostname).
--   power\_user (VMware username).
--   power\_pass (VMware password).
--   power\_port (VMware API port (optional)).
--   power\_protocol (VMware API protocol (optional)).
-
-### fence\_cdu (Sentry Switch CDU)
-
-Power parameters:
-
--   power\_address (Power address).
--   power\_id (Power ID).
--   power\_user (Power user).
--   power\_pass (Power password).
-
-### ipmi (IPMI)
-
-Power parameters:
-
--   power\_driver (Power driver). Choices: 'LAN' (LAN \[IPMI 1.5\]),
-'LAN\_2\_0' (LAN\_2\_0 \[IPMI 2.0\]) Default: 'LAN\_2\_0'.
--   power\_address (IP address).
--   power\_user (Power user).
--   power\_pass (Power password).
--   mac\_address (Power MAC).
-
-### moonshot (HP Moonshot - iLO4 (IPMI))
-
-Power parameters:
-
--   power\_address (Power address).
--   power\_user (Power user).
--   power\_pass (Power password).
--   power\_hwaddress (Power hardware address).
-
-### sm15k (SeaMicro 15000)
-
-Power parameters:
-
--   system\_id (System ID).
--   power\_address (Power address).
--   power\_user (Power user).
--   power\_pass (Power password).
--   power\_control (Power control type). Choices: 'ipmi' (IPMI), 'restapi'
-(REST API v0.9), 'restapi2' (REST API v2.0) Default: 'ipmi'.
+parameters. Note that the list of usable power types for a particular rack
+controller might be a subset of this list if the rack controller in question
+is from an older version of MAAS.
 
 ### amt (Intel AMT)
 
-Power parameters:
+Power parameters- `
 
--   power\_pass (Power password).
--   power\_address (Power address).
-
-### dli (Digital Loggers, Inc. PDU)
-
-Power parameters:
-
--   outlet\_id (Outlet ID).
--   power\_address (Power address).
--   power\_user (Power user).
--   power\_pass (Power password).
-
-### wedge (Facebook's Wedge)
-
-Power parameters:
-
--   power\_address (IP address).
--   power\_user (Power user).
--   power\_pass (Power password).
-
-### ucsm (Cisco UCS Manager)
-
-Power parameters:
-
--   uuid (Server UUID).
--   power\_address (URL for XML API).
--   power\_user (API user).
--   power\_pass (API password).
-
-### mscm (HP Moonshot - iLO Chassis Manager)
-
-Power parameters:
-
--   power\_address (IP for MSCM CLI API).
--   power\_user (MSCM CLI API user).
--   power\_pass (MSCM CLI API password).
--   node\_id (Node ID - Must adhere to cXnY format (X=cartridge number,
-Y=node number).).
-
-### msftocs (Microsoft OCS - Chassis Manager)
-
-Power parameters:
-
--   power\_address (Power address).
--   power\_port (Power port).
--   power\_user (Power user).
--   power\_pass (Power password).
--   blade\_id (Blade ID (Typically 1-24)).
+-   power_pass (Power password).
+-   power_address (Power address).
 
 ### apc (American Power Conversion (APC) PDU)
 
-Power parameters:
+Power parameters- `
 
--   power\_address (IP for APC PDU).
--   node\_outlet (APC PDU node outlet number (1-16)).
--   power\_on\_delay (Power ON outlet delay (seconds)). Default: '5'.
+-   power_address (IP for APC PDU).
+-   node_outlet (APC PDU node outlet number (1-16)).
+-   power_on_delay (Power ON outlet delay (seconds)). Default- ` '5'.
+
+### dli (Digital Loggers, Inc. PDU)
+
+Power parameters- `
+
+-   outlet_id (Outlet ID).
+-   power_address (Power address).
+-   power_user (Power user).
+-   power_pass (Power password).
+
+### fence_cdu (Sentry Switch CDU)
+
+Power parameters- `
+
+-   power_address (Power address).
+-   power_id (Power ID).
+-   power_user (Power user).
+-   power_pass (Power password).
 
 ### hmc (IBM Hardware Management Console (HMC))
 
-Power parameters:
+Power parameters- `
 
--   power\_address (IP for HMC).
--   power\_user (HMC username).
--   power\_pass (HMC password).
--   server\_name (HMC Managed System server name).
+-   power_address (IP for HMC).
+-   power_user (HMC username).
+-   power_pass (HMC password).
+-   server_name (HMC Managed System server name).
 -   lpar (HMC logical partition).
+
+### ipmi (IPMI)
+
+Power parameters- `
+
+-   power_driver (Power driver). Choices- ` 'LAN' (LAN \[IPMI 1.5\]),
+    'LAN_2_0' (LAN_2_0 \[IPMI 2.0\]) Default- ` 'LAN_2_0'.
+-   power_address (IP address).
+-   power_user (Power user).
+-   power_pass (Power password).
+-   mac_address (Power MAC).
+
+### manual (Manual)
+
+Power parameters- `
+
+### moonshot (HP Moonshot - iLO4 (IPMI))
+
+Power parameters- `
+
+-   power_address (Power address).
+-   power_user (Power user).
+-   power_pass (Power password).
+-   power_hwaddress (Power hardware address).
+
+### mscm (HP Moonshot - iLO Chassis Manager)
+
+Power parameters- `
+
+-   power_address (IP for MSCM CLI API).
+-   power_user (MSCM CLI API user).
+-   power_pass (MSCM CLI API password).
+-   node_id (Node ID - Must adhere to cXnY format (X=cartridge number, Y=node
+    number).).
+
+### msftocs (Microsoft OCS - Chassis Manager)
+
+Power parameters- `
+
+-   power_address (Power address).
+-   power_port (Power port).
+-   power_user (Power user).
+-   power_pass (Power password).
+-   blade_id (Blade ID (Typically 1-24)).
 
 ### nova (OpenStack Nova)
 
-Power parameters:
+Power parameters- `
 
--   nova\_id (Host UUID).
--   os\_tenantname (Tenant name).
--   os\_username (Username).
--   os\_password (Password).
--   os\_authurl (Auth URL).
+-   nova_id (Host UUID).
+-   os_tenantname (Tenant name).
+-   os_username (Username).
+-   os_password (Password).
+-   os_authurl (Auth URL).
+
+### recs_box (Christmann RECS|Box Power Driver)
+
+Power parameters- `
+
+-   node_id (Node ID).
+-   power_address (Power address).
+-   power_port (Power port).
+-   power_user (Power user).
+-   power_pass (Power password).
+
+### sm15k (SeaMicro 15000)
+
+Power parameters- `
+
+-   system_id (System ID).
+-   power_address (Power address).
+-   power_user (Power user).
+-   power_pass (Power password).
+-   power_control (Power control type). Choices- ` 'ipmi' (IPMI),
+    'restapi' (REST API v0.9), 'restapi2' (REST API v2.0) Default- `
+    'ipmi'.
+
+### ucsm (Cisco UCS Manager)
+
+Power parameters- `
+
+-   uuid (Server UUID).
+-   power_address (URL for XML API).
+-   power_user (API user).
+-   power_pass (API password).
+
+### virsh (Virsh (virtual systems))
+
+Power parameters- `
+
+-   power_address (Virsh address).
+-   power_pass (Virsh password (optional)).
+-   power_id (Virsh VM ID).
+
+### vmware (VMware)
+
+Power parameters- `
+
+-   power_vm_name (VM Name (if UUID unknown)).
+-   power_uuid (VM UUID (if known)).
+-   power_address (VMware hostname).
+-   power_user (VMware username).
+-   power_pass (VMware password).
+-   power_port (VMware API port (optional)).
+-   power_protocol (VMware API protocol (optional)).
+
+### wedge (Facebook's Wedge)
+
+Power parameters- `
+
+-   power_address (IP address).
+-   power_user (Power user).
+-   power_pass (Power password).
+
+### rsd (Rack Scale Design)
+
+Power parameters- `
+
+-   power_address (Pod address).
+-   power_user (Pod user).
+-   power_pass (Pod password).
+-   node_id (Node ID).
+
+## Pod types
+
+This is the list of the supported pod types and their associated parameters.
+Note that the list of usable pod types for a particular rack controller might
+be a subset of this list if the rack controller in question is from an older
+version of MAAS.
+
+### rsd (Rack Scale Design)
+
+Parameters- `
+
+-   power_address (Pod address).
+-   power_user (Pod user).
+-   power_pass (Pod password).
+-   node_id (Node ID).
+
+### virsh (Virsh (virtual systems))
+
+Parameters- `
+
+-   power_address (Virsh address).
+-   power_pass (Virsh password (optional)).
+-   power_id (Virsh VM ID).
 


### PR DESCRIPTION
fixes #834  (will fix others after this is merged).

Commands to generate this document:

```bash
git clone git://git.launchpad.net/maas
cd maas
make install dependencies
sudo apt install python-django-piston
# maybe needed:
make
make docs/api.rst
```
Command to convert *api.rst* to markdown *api.md* for documentation:

```bash
printf "Title: API | MAAS\ntable_of_contents: True\n\n" > api.md; cat api.rst | sed -n '/========/,$p' | sed 's/:/:\n / 2' | sed 's/^:\([a-z0-9 _{}]*\):/MDSTARTDEF\1MDENDDEF/g' | sed 's/_{/MDCURLYFIX/g' | pandoc --from=rst --to=markdown+backtick_code_blocks+pipe_tables+definition_lists+compact_definition_lists --column=78 --atx-headers | sed 's/MDSTARTDEF/- `/1' | sed 's/MDENDDEF/`/g' | sed 's/MDCURLYFIX/_{/g'| sed 's/:   /   /g'| sed 's/\\_/_/g'| sed 's/#### /##### /g'| sed 's/^       /   /g' | sed 's/^    /   /g' >> api.md
```