### PR TITLE
Update manage-ha.md

### DIFF
--- a/en/manage-ha.md
+++ b/en/manage-ha.md
@@ -127,7 +127,7 @@ sudo scp ubuntu@$PRIMARY_API_SERVER:regiond.conf /etc/maas/regiond.conf
 sudo chown root:maas /etc/maas/regiond.conf
 sudo chmod 640 /etc/maas/regiond.conf
 sudo maas-region local_config_set --database-host $PRIMARY_PG_SERVER
-sudo maas-region edit_named_options --migrate-conflicting-options
+sudo maas-region edit_named_options
 sudo systemctl restart bind9
 sudo systemctl start maas-regiond
 ```


### PR DESCRIPTION
--migrate-conflicting-options is not required on secondary region controllers.