### PR TITLE
Update documentation-builder to 1.6.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -1,2 +1,35 @@
 site_title: MAAS documentation
-site_logo_url: https://assets.ubuntu.com/v1/5f3d3c45-maas-logo-cropped.svg
+site_logo_url: 'https://assets.ubuntu.com/v1/4fac1d52-MAAS-Logo.svg'
+site_favicon: 'https://assets.ubuntu.com/v1/5922a009-maas-favicon-32px.png'
+site_remove_navigation_title: true
+
+site_navigation:
+  - title: Install
+    location: https://maas.io/install
+
+  - title: Architecture
+    location: https://maas.io/how-it-works
+
+  - title: Tour
+    location: https://maas.io/tour
+
+  - title: Docs
+    location: /
+    selected: true
+
+  - title: Contact us
+    location: https://maas.io/contact-us
+
+site_navigation_colors:
+  active: '#e95420'
+  background: '#000'
+  border: '#666'
+  hover: '#e95420'
+  text: '#fff'
+
+site_footer_links:
+  - title: 'Legal information'
+    location: https://www.ubuntu.com/legal
+    
+  - title: 'Report a bug on this site'
+    location: https://github.com/CanonicalLtd/maas-docs/issues/new

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "scripts": {
       "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite build/ .extra templates",
       "watch": "watch -p './**/*.md' -c 'yarn run build-css'",
-      "build": "documentation-builder --base-directory . --output-path templates --output-media-path 'static/media' --media-url '/static/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.maas.io' --search-url 'https://docs.ubuntu.com/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches",
+      "build": "documentation-builder --base-directory . --output-path templates --output-media-path 'static/media' --media-url '/static/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.maas.io' --search-url 'https://docs.ubuntu.com/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/",
       "test": "",
       "serve": "cd dist && FLASK_DEBUG=true FLASK_APP=app.py flask run -h 0.0.0.0 -p $PORT"
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==0.12.2
 PyYAML==3.12
 pycountry==17.9.23
 yamlordereddictloader==0.4.0
-ubuntudesign.documentation-builder==1.5.1
+ubuntudesign.documentation-builder==1.6.0


### PR DESCRIPTION
## Done

- Updated documentation-builder to 1.6.0, which includes Vanilla 1.7.1 styling + some slight adjustments for docs (tighter spacing, wider text max-width etc)
- Updated `metadata.yaml` with favicon, logo url, and MAAS navigation styles
- Added `--site-root` option to build script so nav logo links to maas.io

## QA

- Pull code
- Add the name of this branch to `versions`
- Run `./run`
- Go to http://0.0.0.0:8203
- Select the name of the branch from the version dropdown
- Check the styling has been applied on this branch
- Check that the other versions still work properly

## Screenshot

![0 0 0 0_8203_devel_en_ 4](https://user-images.githubusercontent.com/25733845/42313197-08fff3dc-803a-11e8-8b50-4c147ba26a55.png)
