### PR TITLE
Update documentation homepage

### DIFF
--- a/en/index.md
+++ b/en/index.md
@@ -1,138 +1,72 @@
-Title: What is MAAS?
-table_of_contents: True
+---
+title: Home
+homepage: true
+---
 
-
-# What is MAAS?
-
-MAAS is *Metal As A Service*. It lets you treat physical servers like virtual
-machines (instances) in the cloud. Rather than having to manage each server
-individually, MAAS turns your bare metal into an elastic cloud-like resource.
-
-Machines can be quickly provisioned and then destroyed again as easily as you
-can with instances in a public cloud like Amazon AWS, Google GCE, and Microsoft
-Azure, among others.
-
-MAAS can act as a standalone PXE/preseed service or it can be integrated with
-other technologies. In particular, it is designed to work especially well with
-[Juju][about-juju], the service and model management service. It's a perfect
-arrangement: MAAS manages the machines and Juju manages the services running on
-those machines.
-
-!!! Note: 
-    KVM guests can also act as MAAS nodes as long as they are set to boot 
-    from the network (PXE).
-
-
-## What MAAS offers
-
-MAAS provides management of a large number of physical machines by creating a
-single resource pool out of them. Participating machines can then be
-provisioned automatically and used as normal. When those machines are no longer
-required they are "released" back into the pool. MAAS integrates all the tools
-you require in one smooth experience. It includes:
-
-- web UI (optimised for mobile devices)
-- Ubuntu, CentOS, Windows, and RHEL installation support
-- open source IP address management (IPAM)
-- full API/CLI support
-- high availability (optional)
-- IPv6 support
-- inventory of components
-- DHCP and DNS for other devices on the network
-- DHCP relay integration
-- VLAN and fabric support
-- NTP for the entire infrastructure
-- hardware testing
-- composable hardware support
-
-MAAS works with any configuration system, and is recommended by the teams
-behind both [Chef][about-chef] and [Juju][about-juju] as a physical
-provisioning system.
-
-The [web UI][webui] provides a responsive interface to the majority of MAAS
-functionality, while the [CLI][manage-cli] and [REST API][api] facilitate
-configuration and large-scale automation.
-
-![web UI showing node view][img__webui]
-
-!!! Note: 
-    Windows and RHEL images require
-    [Ubuntu Advantage][ubuntu-advantage] to work properly with MAAS. 
-
-
-## Key components and colocation of all services
-
-The key components of a MAAS installation are the region controller and the
-rack controller. See [Concepts and terms][concepts-controllers] for how each
-are defined.
-
-Unless there is specific reason not to, it is recommended to have both
-controllers residing on the same system. A no-fuss way to achieve this is by
-installing the `maas` metapackage, or by installing from the Ubuntu Server ISO.
-
-Multiple region and rack controllers are required if
-[high availability][manage-ha] and/or load balancing (see HA page) is desired.
-
-It's important to note that the all-in-one solution will provide a DHCP
-service. Review your existing network design in order to determine whether this
-will cause problems. See [DHCP][dhcp] for more on this subject.
-
-![intro-arch-overview][img__arch-overview]
-
-## How MAAS works
-
-MAAS manages a pool of nodes. After registering ("Enlisting" state) a new
-system and preparing it for service ("Commissioning" state), the system joins
-the pool and is available for use ("Ready" state).
-
-MAAS controls machines through IPMI (or another BMC) or converged chassis
-controller such as Cisco UCS.
-
-!!! Negative "Warning":
-    A machine destined for MAAS will have its disk space overwritten.
-    A node in the pool is under MAAS's sole control and should not be provisioned
-    using other methods.
-
-Users of the MAAS then allocate them for their own use ("Acquire") when they go
-into use. Any subsequently installed operating system will contain the user's
-SSH public key for remote access (the user's MAAS account first needs to import
-the key). The web UI also allows for manual allocation in the sense of reserving
-hardware to specific users for later use.
-
-When allocating from the API/CLI, you can specify requirements ("constraints")
-for a machine. Common constraints are: memory, CPU cores, connected networks,
-and what physical zone they should be in.
-
-An allocated MAAS node is not like a virtual instance in a cloud: you get
-complete control, including hardware drivers and root access. To upgrade a
-BIOS, for example, an administrator could allocate a node to themselves, and
-run a vendor-supplied upgrade utility.
-
-Once you are done with a node you have allocated you send it back to the pool
-for re-use.
-
-Note that [Juju][about-juju] is designed to work with MAAS. In this case, MAAS
-becomes a sort of backend (resource pool) for Juju, or a "cloud provider" in
-Juju terminology. However, everything that was stated earlier still applies.
-For instance, if Juju removes a machine then MAAS will, in turn, release that
-machine to the pool.
-
-<!-- LINKS -->
-
-[about-chef]: https://www.chef.io/chef
-[about-juju]: https://jujucharms.com/docs/stable/about-juju
-[controllers]: intro-concepts.md#controllers
-[ubuntu-advantage]: https://www.ubuntu.com/support
-[concepts-controllers]: intro-concepts.md#controllers
-[manage-ha]: manage-ha.md
-[dhcp]: installconfig-network-dhcp.md
-[power-types]: nodes-power-types.md
-[load-balancing]: manage-ha.md#load-balancing-(optional)
-[mirror]: installconfig-images-mirror.md
-[webui]: installconfig-webui.md
-[manage-cli]: manage-cli.md
-[api]: api.md
-
-<!-- IMAGES -->
-[img__webui]: ../media/intro__2.4_webui.png
-[img__arch-overview]: ../media/intro-arch-overview.png
+<div class="p-strip--image is-dark" style="background-image: url('https://assets.ubuntu.com/v1/a328d904-MAAS-background-desktop-large-screen.png')">
+    <div class="p-content__row">
+        <div class="col-8">
+            <h1>MAAS Documentation</h1>
+            <p>MAAS is Metal As A Service. It lets you treat physical servers like virtual machines (instances) in the cloud. Rather than having to manage each server individually, MAAS turns your bare metal into an elastic cloud-like resource.</p>
+        </div>
+    </div>
+</div>
+<div class="p-strip">
+    <div class="p-content__row" style="max-width: 80em">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting started</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a href="/en/intro-what-is-maas">What is MAAS?&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/intro-what-is-maas#what-maas-offers">What MAAS offers&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/intro-what-is-maas#how-maas-works">How MAAS works&nbsp;&rsaquo;</a></li>
+                    <li class="p-list__item"><a href="/en/installconfig-snap-install">Install MAAS&nbsp;&rsaquo;</a></li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <img style="max-height: 20rem;" src="https://assets.ubuntu.com/v1/be6bd70c-Keep+an+eye+on+your+hardware+-+hardware+tests+list.jpg">
+            </div>
+        </div>
+        <hr class="is-deep">
+        <div>
+            <h2>What's new</h2>
+            <ul class="p-list">
+                <li class="p-list__item"><a href="/en/release-notes">MAAS 2.4 release notes&nbsp;&rsaquo;</a></li>
+                <li class="p-list__item"><a href="https://blog.ubuntu.com/2018/03/06/maas-for-the-home">MAAS for the home</a></li>
+                <li class="p-list__item"><a href="https://tutorials.ubuntu.com/tutorial/create-kvm-pods-with-maas#0">Create KVM pods with MAAS</a></li>
+                <li class="p-list__item"><a href="/en/intro-explore">Explore MAAS&nbsp;&rsaquo;</a></li>
+            </ul>
+        </div>
+        <hr class="is-deep">
+        <div class="u-equal-height">
+            <div class="col-6">
+                <h2>Getting support</h2>
+                <ul class="p-list">
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/fa38eb81-picto-business-midaubergine.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="https://maas.io/contact-us">Professional support</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/c5cb0f8e-picto-ubuntu.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="http://askubuntu.com/questions/tagged/maas">Ask a question</a>
+                    </li>
+                    <li class="p-list__item">
+                        <i class="p-icon" style="background-image:url('https://assets.ubuntu.com/v1/d3ae9c8e-irc-icon-circle.svg');
+                        height:1.5rem;width: 1.5rem;top: 2px;margin-right:.5rem;"></i>
+                        <a class="p-link--external" href="http://webchat.freenode.net/?channels=maas">IRC</a>
+                    </li>
+                </ul>
+            </div>
+            <div class="col-6">
+                <h2>Contribute</h2>
+                <ul class="p-list">
+                    <li class="p-list__item"><a class="p-link--external" href="/en/contributing-writing">Contributing guides</a></li>
+                    <li class="p-list__item--deep"><a class="p-link--external" href="https://launchpad.net/maas">Push some code</a></li>
+                    <li class="p-list__item"><a class="p-link--external" href="https://bugs.launchpad.net/maas/+filebug">File an issue</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/en/intro-what-is-maas.md
+++ b/en/intro-what-is-maas.md
@@ -1,0 +1,138 @@
+Title: What is MAAS?
+table_of_contents: True
+
+
+# What is MAAS?
+
+MAAS is *Metal As A Service*. It lets you treat physical servers like virtual
+machines (instances) in the cloud. Rather than having to manage each server
+individually, MAAS turns your bare metal into an elastic cloud-like resource.
+
+Machines can be quickly provisioned and then destroyed again as easily as you
+can with instances in a public cloud like Amazon AWS, Google GCE, and Microsoft
+Azure, among others.
+
+MAAS can act as a standalone PXE/preseed service or it can be integrated with
+other technologies. In particular, it is designed to work especially well with
+[Juju][about-juju], the service and model management service. It's a perfect
+arrangement: MAAS manages the machines and Juju manages the services running on
+those machines.
+
+!!! Note: 
+    KVM guests can also act as MAAS nodes as long as they are set to boot 
+    from the network (PXE).
+
+
+## What MAAS offers
+
+MAAS provides management of a large number of physical machines by creating a
+single resource pool out of them. Participating machines can then be
+provisioned automatically and used as normal. When those machines are no longer
+required they are "released" back into the pool. MAAS integrates all the tools
+you require in one smooth experience. It includes:
+
+- web UI (optimised for mobile devices)
+- Ubuntu, CentOS, Windows, and RHEL installation support
+- open source IP address management (IPAM)
+- full API/CLI support
+- high availability (optional)
+- IPv6 support
+- inventory of components
+- DHCP and DNS for other devices on the network
+- DHCP relay integration
+- VLAN and fabric support
+- NTP for the entire infrastructure
+- hardware testing
+- composable hardware support
+
+MAAS works with any configuration system, and is recommended by the teams
+behind both [Chef][about-chef] and [Juju][about-juju] as a physical
+provisioning system.
+
+The [web UI][webui] provides a responsive interface to the majority of MAAS
+functionality, while the [CLI][manage-cli] and [REST API][api] facilitate
+configuration and large-scale automation.
+
+![web UI showing node view][img__webui]
+
+!!! Note: 
+    Windows and RHEL images require
+    [Ubuntu Advantage][ubuntu-advantage] to work properly with MAAS. 
+
+
+## Key components and colocation of all services
+
+The key components of a MAAS installation are the region controller and the
+rack controller. See [Concepts and terms][concepts-controllers] for how each
+are defined.
+
+Unless there is specific reason not to, it is recommended to have both
+controllers residing on the same system. A no-fuss way to achieve this is by
+installing the `maas` metapackage, or by installing from the Ubuntu Server ISO.
+
+Multiple region and rack controllers are required if
+[high availability][manage-ha] and/or load balancing (see HA page) is desired.
+
+It's important to note that the all-in-one solution will provide a DHCP
+service. Review your existing network design in order to determine whether this
+will cause problems. See [DHCP][dhcp] for more on this subject.
+
+![intro-arch-overview][img__arch-overview]
+
+## How MAAS works
+
+MAAS manages a pool of nodes. After registering ("Enlisting" state) a new
+system and preparing it for service ("Commissioning" state), the system joins
+the pool and is available for use ("Ready" state).
+
+MAAS controls machines through IPMI (or another BMC) or converged chassis
+controller such as Cisco UCS.
+
+!!! Negative "Warning":
+    A machine destined for MAAS will have its disk space overwritten.
+    A node in the pool is under MAAS's sole control and should not be provisioned
+    using other methods.
+
+Users of the MAAS then allocate them for their own use ("Acquire") when they go
+into use. Any subsequently installed operating system will contain the user's
+SSH public key for remote access (the user's MAAS account first needs to import
+the key). The web UI also allows for manual allocation in the sense of reserving
+hardware to specific users for later use.
+
+When allocating from the API/CLI, you can specify requirements ("constraints")
+for a machine. Common constraints are: memory, CPU cores, connected networks,
+and what physical zone they should be in.
+
+An allocated MAAS node is not like a virtual instance in a cloud: you get
+complete control, including hardware drivers and root access. To upgrade a
+BIOS, for example, an administrator could allocate a node to themselves, and
+run a vendor-supplied upgrade utility.
+
+Once you are done with a node you have allocated you send it back to the pool
+for re-use.
+
+Note that [Juju][about-juju] is designed to work with MAAS. In this case, MAAS
+becomes a sort of backend (resource pool) for Juju, or a "cloud provider" in
+Juju terminology. However, everything that was stated earlier still applies.
+For instance, if Juju removes a machine then MAAS will, in turn, release that
+machine to the pool.
+
+<!-- LINKS -->
+
+[about-chef]: https://www.chef.io/chef
+[about-juju]: https://jujucharms.com/docs/stable/about-juju
+[controllers]: intro-concepts.md#controllers
+[ubuntu-advantage]: https://www.ubuntu.com/support
+[concepts-controllers]: intro-concepts.md#controllers
+[manage-ha]: manage-ha.md
+[dhcp]: installconfig-network-dhcp.md
+[power-types]: nodes-power-types.md
+[load-balancing]: manage-ha.md#load-balancing-(optional)
+[mirror]: installconfig-images-mirror.md
+[webui]: installconfig-webui.md
+[manage-cli]: manage-cli.md
+[api]: api.md
+
+<!-- IMAGES -->
+[img__webui]: ../media/intro__2.4_webui.png
+[img__arch-overview]: ../media/intro-arch-overview.png

--- a/en/metadata.yaml
+++ b/en/metadata.yaml
@@ -1,11 +1,12 @@
 navigation:
-  - title: Get started
-    location: index.md
-
+  - title: Introduction
     children:
 
-      - title: About MAAS
+      - title: Home
         location: index.md
+
+      - title: About MAAS
+        location: intro-what-is-maas.md
 
       - title: Explore MAAS
         location: intro-explore.md


### PR DESCRIPTION
Original design issue [here](https://github.com/ubuntudesign/vanilla-design/issues/219)

## Done

- Updated homepage with new design
- Moved original index.md to intro-what-is-maas.md
- Changed sidebar navigation to have an "Introduction" section

**Note: The demo does not show the version dropdown - this is a workaround to get the demo working with documentation-builder. The code in this PR will allow version switching**