### PR TITLE
Add net-tools, preserve protocol and port in nginx redirects

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV LANG C.UTF-8
 WORKDIR /srv
 
 # System dependencies
-RUN apt-get update && apt-get install --yes nginx
+RUN apt-get update && apt-get install --yes nginx net-tools
 
 # Set git commit ID
 ARG COMMIT_ID

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,3 +1,9 @@
+map $http_x_forwarded_proto $url_prefix {
+     default $scheme://$http_host;
+     https https://$http_host;
+     http http://$http_host;
+}
+
 map $uri $target {
     include redirects.map;
 }
@@ -23,31 +29,34 @@ server {
     add_header X-Hostname $hostname always;
 
     # Apply redirects from file
-    if ($target) {
+    if ($target ~* '://') {
         rewrite ^ $target redirect;
+    }
+    if ($target) {
+        rewrite ^ $url_prefix$target redirect;
     }
 
     # Remove index or index.html from URIs
     if ($request_uri ~ ^.*/index$) {
-        rewrite ^(.*/)index$ $1 permanent;
+        rewrite ^(.*/)index$ $url_prefix$1 permanent;
     }
     if ($request_uri ~ ^.*/index.html$) {
-        rewrite ^(.*/)index.html$ $1 permanent;
+        rewrite ^(.*/)index.html$ $url_prefix$1 permanent;
     }
 
     # Remove .html from URIs
     if ($request_uri ~ ^.*\.html$) {
-        rewrite ^(.*)\.html$ $1 permanent;
+        rewrite ^(.*)\.html$ $url_prefix$1 permanent;
     }
 
     # Remove slashes form URIs if it's not a directory
     if (!-d $request_filename) {
-        rewrite ^/(.*)/$ /$1 permanent;
+        rewrite ^(.*)/$ $url_prefix$1 permanent;
     }
 
     # Add slashes from URIs if it's a directory
     if (-d $request_filename) {
-        rewrite ^/(.*[^/])$ /$1/ permanent;
+        rewrite ^(.*[^/])$ $url_prefix$1/ permanent;
     }
 
     try_files $uri $uri.html $uri/ =404;


### PR DESCRIPTION
Add net-tools to production image

So that we can use `netstat` to create a `livenessProbe` to check that a process is running on port 80.

Previously, nginx running behind a load balancer would not intelligently interpret your port or protocol, such that you could end up with the following erroneous redirect:

https://docs.maas.io:8090/ -> http://docs.maas.io/en/

These changes to the configuration make redirect work properly.

QA
--

``` bash
$ docker build --tag maas-docs --build-arg COMMIT_ID=`git rev-parse --short HEAD` .
$ docker run --name maas-docs -ti -p 8903:80 maas-docs
```

In a separate terminal:

``` bash
$ curl -I localhost:8903
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.14.0 (Ubuntu)
Date: Wed, 29 Aug 2018 13:41:14 GMT
Content-Type: text/html
Content-Length: 170
Connection: keep-alive
Location: http://localhost:8903/2.4/en/
X-Commit-ID: bf8d154
X-Hostname: 976b162bd036
```

^ See the port is preserved in the redirect ^

Leave the server running, and check you can test the container's health with netstat:

``` bash
$ docker exec -ti maas-docs netstat -lp | grep :80
tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN      1/nginx: master pro 
tcp6       0      0 [::]:80                 [::]:*                  LISTEN      1/nginx: master pro 
```