### PR TITLE
Update typo found in MAAS LXD Documentation

### DIFF
--- a/en/installconfig-lxd-install.md
+++ b/en/installconfig-lxd-install.md
@@ -83,7 +83,7 @@ When correctly configured, the above command outputs
 Launch the LXD container:
 
 ```bash
-lxc launch -p maas ubuntu:16.04 bionic-maas
+lxc launch -p maas ubuntu:18.04 bionic-maas
 ```
 
 Once the container is running, it can be accessed with:


### PR DESCRIPTION
Found a small typo in the docs while running through a refresher of the install maas on lxd guide. 
-sfeole