### PR TITLE
Backport #1109 to 2.5

### DIFF
--- a/en/manage-cli-kernels.md
+++ b/en/manage-cli-kernels.md
@@ -22,31 +22,6 @@ To set kernel boot options that will be applied to all machines:
 maas $PROFILE maas set-config name=kernel_opts value='$KERNEL_OPTIONS'
 ```
 
-## Specify per-node kernel boot options
-
-To specify kernel boot options for an individual machine a tag needs to be
-created:
-
-```bash
-maas $PROFILE tags create name='$TAG_NAME' \
-	comment='$COMMENT' kernel_opts='$KERNEL_OPTIONS'
-```
-
-For example:
-
-```bash
-maas $PROFILE tags create name='nomodeset' \
-	comment='nomodeset kernel option' kernel_opts='nomodeset vga'
-```
-
-The tag must then be assigned to the machine in question. This can be done
-with the web UI or with the CLI. For the latter, see
-[CLI - Manual tag assignment][cli-manual-tag-assignment].
-
-If multiple tags attached to a node have the `kernel_opts` defined, the first
-one (ordered alphabetically) is used.
-
-
 ## Set a default minimum kernel for enlistment and commissioning
 
 To set a default minimum kernel for all new and commissioned machines:

--- a/en/nodes-kernel-options.md
+++ b/en/nodes-kernel-options.md
@@ -30,6 +30,29 @@ Per-node kernel boot options are set using the CLI. See
 
 Note that per-node boot options take precedence to global ones.
 
+### CLI
+
+To specify kernel boot options for an individual machine a tag needs to be
+created:
+
+```bash
+maas $PROFILE tags create name='$TAG_NAME' \
+	comment='$COMMENT' kernel_opts='$KERNEL_OPTIONS'
+```
+
+For example:
+
+```bash
+maas $PROFILE tags create name='nomodeset' \
+	comment='nomodeset kernel option' kernel_opts='nomodeset vga'
+```
+
+The tag must then be assigned to the machine in question. This can be done
+with the web UI or with the CLI. For the latter, see
+[CLI - Manual tag assignment][cli-manual-tag-assignment].
+
+If multiple tags attached to a node have the `kernel_opts` defined, the first
+one (ordered alphabetically) is used.
 
 <!-- LINKS -->
 


### PR DESCRIPTION
This pull request has been generated by the canonical-doc-utilities backport command.

It has successfully cherry-picked individual commits from a different branch of this repository, which should merge without issue. It is advisable to check the changes only occur where you expect them!

The original PR this was ported from can be viewed here:https://github.com/CanonicalLtd/maas-docs/pull/1109