### PR TITLE
Backport #1112 to 2.5

### DIFF
--- a/en/manage-cli-kernels.md
+++ b/en/manage-cli-kernels.md
@@ -14,14 +14,6 @@ helpful:
 - [Kernel boot options][kernel-boot-options] for help on kernel boot options.
 
 
-## Set global kernel boot options
-
-To set kernel boot options that will be applied to all machines:
-
-```bash
-maas $PROFILE maas set-config name=kernel_opts value='$KERNEL_OPTIONS'
-```
-
 ## Set a default minimum kernel for enlistment and commissioning
 
 To set a default minimum kernel for all new and commissioned machines:

--- a/en/manage-cli-tags.md
+++ b/en/manage-cli-tags.md
@@ -1,9 +1,9 @@
-Title: CLI Tag Management
+Title: CLI tag management
 TODO:  Decide whether explicit examples are needed everywhere
        Foldouts cannot be used due to bug: https://git.io/vwbCz
 
 
-# CLI Tag Management
+# CLI tag management
 
 This is a list of tag management tasks to perform with the MAAS CLI. See
 [MAAS CLI][manage-cli] on how to get started and [Tags][tags] for an

--- a/en/nodes-kernel-options.md
+++ b/en/nodes-kernel-options.md
@@ -19,21 +19,22 @@ on the 'General' tab scroll down to the 'Global Kernel Parameters' section:
 Type in the desired (space separated) options and click 'Save'. The contents of
 the field will be used as-is. Do not use extra characters.
 
-See [MAAS CLI][cli-set-the-default-kernel-boot-options] for how to do this with
-the CLI.
+### CLI
 
+To set kernel boot options that will be applied to all machines with the CLI:
+
+```bash
+maas $PROFILE maas set-config name=kernel_opts value='$KERNEL_OPTIONS'
+```
 
 ## Per-node kernel boot options
 
-Per-node kernel boot options are set using the CLI. See
-[MAAS CLI][cli-specify-kernel-boot-options-for-a-machine] for instructions.
+Per-node kernel boot options are set using the CLI.
 
-Note that per-node boot options take precedence to global ones.
+!!! Note:
+    Per-node boot options take precedence to global ones.
 
-### CLI
-
-To specify kernel boot options for an individual machine a tag needs to be
-created:
+To specify kernel boot options for an individual machine, first create a tag:
 
 ```bash
 maas $PROFILE tags create name='$TAG_NAME' \
@@ -47,17 +48,23 @@ maas $PROFILE tags create name='nomodeset' \
 	comment='nomodeset kernel option' kernel_opts='nomodeset vga'
 ```
 
-The tag must then be assigned to the machine in question. This can be done
-with the web UI or with the CLI. For the latter, see
-[CLI - Manual tag assignment][cli-manual-tag-assignment].
+Next, assign the tag to the machine in question:
+
+```bash
+maas $PROFILE tag update-nodes $TAG_NAME add=$SYSTEM_ID
+```
 
 If multiple tags attached to a node have the `kernel_opts` defined, the first
 one (ordered alphabetically) is used.
+
+See the [CLI tag management][cli-tags] section for more information about using
+the CLI to manage tags.
 
 <!-- LINKS -->
 
 [upstream-kernel.org-kernel-parameters]: https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html
 [cli-set-the-default-kernel-boot-options]: manage-cli-kernels.md#set-global-kernel-boot-options
 [cli-specify-kernel-boot-options-for-a-machine]: manage-cli-kernels.md#specify-per-node-kernel-boot-options
+[cli-tags]: manage-cli-tags.md
 
 [img__2.2_global-kernel-options]: https://assets.ubuntu.com/v1/8b793b6d-nodes-kernel-options__2.2_global.png


### PR DESCRIPTION
This pull request has been generated by the canonical-doc-utilities backport command.

It has successfully cherry-picked individual commits from a different branch of this repository, which should merge without issue. It is advisable to check the changes only occur where you expect them!

The original PR this was ported from can be viewed here:https://github.com/CanonicalLtd/maas-docs/pull/1112