### PR TITLE
Add scrollbar to long TOC menus

### DIFF
--- a/template.html
+++ b/template.html
@@ -261,7 +261,7 @@
         </footer>
       </main>
       {% if toc_items %}
-      <aside id="side-content" class="p-aside">
+      <aside id="side-content" class="p-aside p-sidebar">
         <nav class="p-aside__section">
           <h4 class="p-aside__header">Contents</h4>
           <nav class="p-aside__nav">


### PR DESCRIPTION
## Done
Added the same auto scrolling behavior to the right hand table of contents menu as the side navigation.

## QA
- Go to a smaller page like: /2.5/en/intro-requirements and see there is no scrollbar
- Go to a long page like /2.5/en/api and see the table of contents menu has a scrollbar

## Screenshot
![Screenshot_2019-06-17  MAAS documentation](https://user-images.githubusercontent.com/1413534/59612718-800a2500-9115-11e9-8c69-ff2ea5bcf8fe.png)

Fixes https://github.com/CanonicalLtd/maas-docs/issues/1165