### PR TITLE
Redirect devel and 2.6 to new maas.io/docs

### DIFF
--- a/redirects.map
+++ b/redirects.map
@@ -1,8 +1,3 @@
-~^/(|en/?|2.6.0/?)?$ /2.6/en/;
-~^/en/(?<page>.+)$ /2.6/en/${page};
-~^/(?<version>[0-9-\._]+|devel)(/|/index)?$ /${version}/en/;
-~^/(?<version>[0-9-\._]+|devel)/(?<language>[a-zA-Z]+)(/index)?$ /${version}/${language}/;
-
 /devel/en/intel-rsd /devel/en/nodes-comp-hw;
 /2.1/en/installconfig-deploy-nodes /2.1/en/installconfig-nodes-deploy;
 /2.1/en/installconfig-gui /2.1/en/installconfig-webui;
@@ -17,3 +12,6 @@
 /2.2/en/installconfig-nodes-deploy /2.2/en/nodes-deploy;
 /2.2/en/installconfig-nodes-power-types /2.2/en/nodes-power-types;
 /2.2/en/intel-rsd /2.2/en/nodes-comp-hw;
+~^/(?<version>2.5|2.4|2.3|2.2|2.1|2.0|1.9)(/|/en|/index|/en/index)?$ /${version}/en/;
+~^(/devel/en|/2.6/en)(?<page>(/.*)?)$ https://maas.io/docs${page};
+~^(/|/devel|/2.6|/devel/en|/2.6/en)(?<page>(/.*)?)$ https://maas.io/docs${page};


### PR DESCRIPTION
Remove 2.6, devel and redirect those places to maas.io/docs

(this will be published to old-docs.maas.io when we go live with maas.io/docs)

QA
--

``` bash
./run build
docker build --build-arg REVISION_ID=none --tag maas-docs .
docker run -ti -p 8996:80 maas-docs
```

Now check redirects work:

- [x] http://127.0.0.1:8996/ -> https://maas.io/docs
- [x] http://127.0.0.1:8996/2.6 -> https://maas.io/docs
- [x] http://127.0.0.1:8996/2.6/en -> https://maas.io/docs
- [x] http://127.0.0.1:8996/devel/en/ -> https://maas.io/docs
- [x] http://127.0.0.1:8996/devel/en/somewhere -> https://maas.io/docs/somewhere
- [x] http://127.0.0.1:8996/2.5 -> http://127.0.0.1:8996/2.5/en/
- [x] http://127.0.0.1:8996/2.5/en/ loads
- [x] Other pages in nav load