### PR TITLE
Fix CVE-2019-10744

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,14 @@
 {
-    "scripts": {
-      "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite build/ .extra templates",
-      "watch": "watch -p './**/*.md' -c 'yarn run build-css'",
-      "build": "documentation-builder --template-path template.html --base-directory . --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.maas.io' --search-url 'https://www.ubuntu.com/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/"
-    },
-    "dependencies": {
-      "watch-cli": "^0.2.2"
+  "scripts": {
+    "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite build/ .extra templates",
+    "watch": "watch -p './**/*.md' -c 'yarn run build-css'",
+    "build": "documentation-builder --template-path template.html --base-directory . --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-domain 'docs.maas.io' --search-url 'https://www.ubuntu.com/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/"
+  },
+  "devDependencies": {
+    "watch-cli": "^0.2.2",
+    "lodash": "^4.17.13"
+  },
+  "devDependencyComments": {
+    "lodash": "We need >4.17.13 to fix vulnerability: https://github.com/lodash/lodash/pull/4336"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,6 +56,10 @@ lodash@^3.5.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
+lodash@^4.17.13:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+
 lodash@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.0.2.tgz#8f57560c83b59fc270bd3d561b690043430e2551"


### PR DESCRIPTION
Fixes https://github.com/canonicalltd/maas-docs/network/alert/yarn.lock/lodash/open

QA
--

`./run build`, and then look in `node_modules/lodash/package.json` and check the version is greater than or equal to `4.17.13`.