### PR TITLE
Update site to use multistage build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -83,9 +83,7 @@ package.json
 node_modules
 yarn.lock
 
-# Git, travis, docker
-.git
-.gitignore
+# travis, docker
 .travis.yml
 docker-compose.yml
 .docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,36 @@
+# syntax=docker/dockerfile:experimental
+
+# Build stage: Build docs
+# ===
+FROM ubuntu:focal AS build-docs
+
+WORKDIR /srv
+ADD . .
+
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools git
+RUN pip3 install --requirement requirements.txt
+RUN /srv/build.sh
+
+# Build the production image
+# ===
 FROM ubuntu:focal
 
 # Set up environment
 ENV LANG C.UTF-8
 WORKDIR /srv
 
-# System dependencies
-RUN apt-get update && apt-get install --yes nginx net-tools
+# Install nginx
+RUN apt-get update && apt-get install --no-install-recommends --yes nginx
 
-# Set git commit ID
-ARG BUILD_ID
-RUN test -n "${BUILD_ID}"
-
-# Copy over files
-ADD build .
-ADD nginx.conf /etc/nginx/sites-enabled/default
+# Import code, build assets and mirror list
 ADD redirects.map /etc/nginx/redirects.map
+COPY --from=build-docs srv/build .
+
+ARG BUILD_ID
+ADD nginx.conf /etc/nginx/sites-enabled/default
 RUN sed -i "s/~BUILD_ID~/${BUILD_ID}/" /etc/nginx/sites-enabled/default
 RUN sed -i "s/8203/80/" /etc/nginx/sites-enabled/default
 
 STOPSIGNAL SIGTERM
 
 CMD ["nginx", "-g", "daemon off;"]
-

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+documentation-builder --template-path template.html --base-directory . --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-url 'https://maas.io/docs/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite .extra templates build/2.* build/1.* build/devel build/media",
     "watch": "watch -p './**/*.md' -c 'yarn run build-css'",
-    "build": "documentation-builder --template-path template.html --base-directory . --output-path build --output-media-path 'build/media' --media-url '/media' --tag-manager-code 'GTM-K92JCQ' --search-url 'https://maas.io/docs/search' --search-placeholder 'Search MAAS docs' --no-link-extensions --build-version-branches --site-root https://maas.io/"
+    "build": "./build.sh"
   },
   "devDependencies": {
     "watch-cli": "^0.2.2",


### PR DESCRIPTION
# Done

Update site to use multistage build
Standardize our build process

# QA

- `DOCKER_BUILDKIT=1 docker build --build-arg BUILD_ID=test --tag maas-docs-multi .`
- `docker run -ti -p "8006:80" --env SECRET_KEY=secret_key maas-docs-multi`
- http://0.0.0.0:8006/2.1/en/installconfig-images-mirror
- Make sure it works as usual